### PR TITLE
fix(drag): set `dragging` to false on drag end

### DIFF
--- a/src/hooks/useDrag/index.ts
+++ b/src/hooks/useDrag/index.ts
@@ -118,6 +118,7 @@ function useDrag({
             }
 
             event.on('end', (event) => {
+              setDragging(false)
               if (dragItems.current) {
                 updateNodePositions(dragItems.current, false, false);
 


### PR DESCRIPTION
# What's changed?

* Set `dragging` to `false` on drag end event

# Fixes
* #2183