### PR TITLE
feat(core): add nodes option to fitView

### DIFF
--- a/.changeset/witty-actors-clap.md
+++ b/.changeset/witty-actors-clap.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+Add `nodes` to fit view options to allow fitting view only around specified set of nodes

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -141,11 +141,16 @@ export function fitView(get: StoreApi<ReactFlowState>['getState'], options: Inte
 
   if ((options.initial && !fitViewOnInitDone && fitViewOnInit) || !options.initial) {
     if (d3Zoom && d3Selection) {
-      let nodes: Node[] = getNodes().filter((n) => (options.includeHiddenNodes ? n.width && n.height : !n.hidden));
+      const nodes = getNodes().filter((n) => {
+        const isVisible = (options.includeHiddenNodes ? n.width && n.height : !n.hidden);
+        let shouldInclude = true;
 
-      if (options.nodes?.length) {
-        nodes = nodes.filter((n) => options.nodes?.includes(n.id))
-      }
+        if (options.nodes?.length) {
+          shouldInclude = options.nodes.includes(n.id);
+        }
+
+        return isVisible && shouldInclude;
+      });
 
       const nodesInitialized = nodes.every((n) => n.width && n.height);
 

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -141,7 +141,11 @@ export function fitView(get: StoreApi<ReactFlowState>['getState'], options: Inte
 
   if ((options.initial && !fitViewOnInitDone && fitViewOnInit) || !options.initial) {
     if (d3Zoom && d3Selection) {
-      const nodes = getNodes().filter((n) => (options.includeHiddenNodes ? n.width && n.height : !n.hidden));
+      let nodes: Node[] = getNodes().filter((n) => (options.includeHiddenNodes ? n.width && n.height : !n.hidden));
+
+      if (options.nodes?.length) {
+        nodes = nodes.filter((n) => options.nodes?.includes(n.id))
+      }
 
       const nodesInitialized = nodes.every((n) => n.width && n.height);
 

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -76,6 +76,7 @@ export type FitViewOptions = {
   minZoom?: number;
   maxZoom?: number;
   duration?: number;
+  nodes?: string[];
 };
 
 export type OnConnectStartParams = {


### PR DESCRIPTION
# What's changed?

- Add `nodes` option to `fitView`
- Allows `fitView` to only fit around a certain set of specified nodeIds