### PR TITLE
fix(core): nodes getting dragged infinitely on auto-pan with translateExtent

### DIFF
--- a/.changeset/wise-pumas-juggle.md
+++ b/.changeset/wise-pumas-juggle.md
@@ -1,0 +1,6 @@
+---
+'@reactflow/core': patch
+---
+
+Fix auto-pan moving nodes infinitely into the background when translateExtent is used. 
+Avoid updating node pos on auto-pan if the viewport is not transformed (no pan actually happened)

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -252,7 +252,7 @@ const createRFStore = () =>
         nodeInternals: new Map(nodeInternals),
       });
     },
-    panBy: (delta: XYPosition) => {
+    panBy: (delta: XYPosition, onBeforeTransform) => {
       const { transform, width, height, d3Zoom, d3Selection, translateExtent } = get();
 
       if (!d3Zoom || !d3Selection || (!delta.x && !delta.y)) {
@@ -267,6 +267,9 @@ const createRFStore = () =>
       ];
 
       const constrainedTransform = d3Zoom?.constrain()(nextTransform, extent, translateExtent);
+
+      onBeforeTransform?.(constrainedTransform);
+
       d3Zoom.transform(d3Selection, constrainedTransform);
     },
     cancelConnection: () =>

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -24,6 +24,7 @@ import type { Edge, EdgeProps, WrapEdgeProps } from './edges';
 import type { HandleType, ConnectingHandle } from './handles';
 import type { DefaultEdgeOptions } from '.';
 import type { ReactFlowInstance } from './instance';
+import { ZoomTransform } from 'd3';
 
 export type NodeTypes = { [key: string]: ComponentType<NodeProps> };
 export type NodeTypesWrapped = { [key: string]: MemoExoticComponent<ComponentType<WrapNodeProps>> };
@@ -252,7 +253,7 @@ export type ReactFlowActions = {
   cancelConnection: () => void;
   reset: () => void;
   triggerNodeChanges: (changes: NodeChange[]) => void;
-  panBy: (delta: XYPosition) => void;
+  panBy: (delta: XYPosition, onBeforeTransform?: (transform: ZoomTransform) => void) => void;
 };
 
 export type ReactFlowState = ReactFlowStore & ReactFlowActions;


### PR DESCRIPTION
# What's changed?

- Add `onBeforeTransform` arg to `panBy` action
   -  Maybe there's a more elegant solution for this?
- Avoid updating node pos for auto-pan triggers which do not transform the viewport, i.e. no pan actually happened

# Fixes

- nodes either stuttering when reaching translate extent or getting dragged infinitely into the background 