### PR TITLE
feat(core): allow array of ids as updateNodeInternals arg

### DIFF
--- a/.changeset/mighty-seas-hang.md
+++ b/.changeset/mighty-seas-hang.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': minor
+---
+
+Add `edgesUpdatable` prop to store state. Allows enabling/disabling edge updating globally.

--- a/packages/core/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/core/src/hooks/useUpdateNodeInternals.ts
@@ -6,12 +6,16 @@ import type { UpdateNodeInternals } from '../types';
 function useUpdateNodeInternals(): UpdateNodeInternals {
   const store = useStoreApi();
 
-  return useCallback<UpdateNodeInternals>((id: string) => {
+  return useCallback<UpdateNodeInternals>((id: string | string[]) => {
     const { domNode, updateNodeDimensions } = store.getState();
     const nodeElement = domNode?.querySelector(`.react-flow__node[data-id="${id}"]`) as HTMLDivElement;
 
     if (nodeElement) {
-      requestAnimationFrame(() => updateNodeDimensions([{ id, nodeElement, forceUpdate: true }]));
+      const updateIds = Array.isArray(id) ? id : [id];
+
+      updateIds.forEach((id) => {
+        requestAnimationFrame(() => updateNodeDimensions([{ id, nodeElement, forceUpdate: true }]));
+      });
     }
   }, []);
 }

--- a/packages/core/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/core/src/hooks/useUpdateNodeInternals.ts
@@ -13,9 +13,11 @@ function useUpdateNodeInternals(): UpdateNodeInternals {
     if (nodeElement) {
       const updateIds = Array.isArray(id) ? id : [id];
 
-      updateIds.forEach((id) => {
-        requestAnimationFrame(() => updateNodeDimensions([{ id, nodeElement, forceUpdate: true }]));
-      });
+      requestAnimationFrame(() => {
+        updateIds.forEach((id) => {
+          updateNodeDimensions([{ id, nodeElement, forceUpdate: true }]);
+        });
+      })
     }
   }, []);
 }

--- a/packages/core/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/core/src/hooks/useUpdateNodeInternals.ts
@@ -8,17 +8,18 @@ function useUpdateNodeInternals(): UpdateNodeInternals {
 
   return useCallback<UpdateNodeInternals>((id: string | string[]) => {
     const { domNode, updateNodeDimensions } = store.getState();
-    const nodeElement = domNode?.querySelector(`.react-flow__node[data-id="${id}"]`) as HTMLDivElement;
 
-    if (nodeElement) {
-      const updateIds = Array.isArray(id) ? id : [id];
+    const updateIds = Array.isArray(id) ? id : [id];
 
-      requestAnimationFrame(() => {
-        updateIds.forEach((id) => {
-          updateNodeDimensions([{ id, nodeElement, forceUpdate: true }]);
-        });
-      })
-    }
+    requestAnimationFrame(() => {
+      updateIds.forEach((updateId) => {
+        const nodeElement = domNode?.querySelector(`.react-flow__node[data-id="${updateId}"]`) as HTMLDivElement;
+
+        if (nodeElement) {
+          updateNodeDimensions([{ id: updateId, nodeElement, forceUpdate: true }]);
+        }
+      });
+    });
   }, []);
 }
 


### PR DESCRIPTION
# What's changed?

- In addition to a single id, also allow for an array of ids to be passed to `updateNodeInternals`