### PR TITLE
fix(core): use valid handles in proximity to determine closest handle

### DIFF
--- a/.changeset/funny-penguins-tickle.md
+++ b/.changeset/funny-penguins-tickle.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+Use all valid handles in proximity to determine the closest handle that can be snapped to. Fixes invalid handles connection radius blocking snap to valid handles inside the same radius.

--- a/packages/core/src/components/Handle/handler.ts
+++ b/packages/core/src/components/Handle/handler.ts
@@ -108,31 +108,34 @@ export function handlePointerDown({
     const { transform } = getState();
 
     connectionPosition = getEventPosition(event, containerBounds);
-    closestHandle = getClosestHandle(
+
+    const { handle, validHandleResult } = getClosestHandle(
       pointToRendererPoint(connectionPosition, transform, false, [1, 1]),
       connectionRadius,
-      handleLookup
+      handleLookup,
+      (handle) =>
+        isValidHandle(
+          event,
+          handle,
+          connectionMode,
+          nodeId,
+          handleId,
+          isTarget ? 'target' : 'source',
+          isValidConnection,
+          doc
+        )
     );
+
+    closestHandle = handle;
 
     if (!autoPanStarted) {
       autoPan();
       autoPanStarted = true;
     }
 
-    const result = isValidHandle(
-      event,
-      closestHandle,
-      connectionMode,
-      nodeId,
-      handleId,
-      isTarget ? 'target' : 'source',
-      isValidConnection,
-      doc
-    );
-
-    handleDomNode = result.handleDomNode;
-    connection = result.connection;
-    isValid = result.isValid;
+    handleDomNode = validHandleResult.handleDomNode;
+    connection = validHandleResult.connection;
+    isValid = validHandleResult.isValid;
 
     setState({
       connectionPosition:
@@ -146,7 +149,7 @@ export function handlePointerDown({
             )
           : connectionPosition,
       connectionStatus: getConnectionStatus(!!closestHandle, isValid),
-      connectionEndHandle: result.endHandle,
+      connectionEndHandle: validHandleResult.endHandle,
     });
 
     if (!closestHandle && !isValid && !handleDomNode) {

--- a/packages/core/src/components/Handle/utils.ts
+++ b/packages/core/src/components/Handle/utils.ts
@@ -39,32 +39,42 @@ export function getHandles(
 export function getClosestHandle(
   pos: XYPosition,
   connectionRadius: number,
-  handles: ConnectionHandle[]
-): ConnectionHandle | null {
-  let closestHandles: ConnectionHandle[] = [];
+  handles: ConnectionHandle[],
+  validator: (handle: ConnectionHandle) => Result
+) {
+  let closestHandles: { handle: ConnectionHandle; validHandleResult: Result }[] = [];
   let minDistance = Infinity;
 
   handles.forEach((handle) => {
-    const distance = Math.sqrt(Math.pow(handle.x - pos.x, 2) + Math.pow(handle.y - pos.y, 2));
+    const distance = Math.sqrt((handle.x - pos.x) ** 2 + (handle.y - pos.y) ** 2);
+
     if (distance <= connectionRadius) {
-      if (distance < minDistance) {
-        closestHandles = [handle];
-      } else if (distance === minDistance) {
-        // when multiple handles are on the same distance we collect all of them
-        closestHandles.push(handle);
+      const validHandleResult = validator(handle);
+
+      if (distance <= minDistance && validHandleResult.isValid) {
+        if (distance < minDistance) {
+          closestHandles = [{ handle, validHandleResult }];
+        } else if (distance === minDistance) {
+          // when multiple handles are on the same distance we collect all of them
+          closestHandles.push({
+            handle,
+            validHandleResult,
+          });
+        }
+
+        minDistance = distance;
       }
-      minDistance = distance;
     }
   });
 
   if (!closestHandles.length) {
-    return null;
+    return { handle: null, validHandleResult: defaultResult() };
   }
 
   return closestHandles.length === 1
     ? closestHandles[0]
-    : // if multiple handles are layouted on top of each other we take the one with type = target because it's more likely that the user wants to connect to this one
-      closestHandles.find((handle) => handle.type === 'target') || closestHandles[0];
+    : // if multiple handles are layout on top of each other we take the one with type = target because it's more likely that the user wants to connect to this one
+      closestHandles.find(({ handle }) => handle.type === 'target') || closestHandles[0];
 }
 
 type Result = {
@@ -75,6 +85,13 @@ type Result = {
 };
 
 const nullConnection: Connection = { source: null, target: null, sourceHandle: null, targetHandle: null };
+
+const defaultResult = (): Result => ({
+  handleDomNode: null,
+  isValid: false,
+  connection: nullConnection,
+  endHandle: null,
+});
 
 // checks if  and returns connection in fom of an object { source: 123, target: 312 }
 export function isValidHandle(
@@ -97,12 +114,7 @@ export function isValidHandle(
   // because it could be that the center of another handle is closer to the mouse pointer than the handle below the cursor
   const handleToCheck = handleBelow?.classList.contains('react-flow__handle') ? handleBelow : handleDomNode;
 
-  const result: Result = {
-    handleDomNode: handleToCheck,
-    isValid: false,
-    connection: nullConnection,
-    endHandle: null,
-  };
+  const result = defaultResult();
 
   if (handleToCheck) {
     const handleType = getHandleType(undefined, handleToCheck);

--- a/packages/core/src/components/Handle/utils.ts
+++ b/packages/core/src/components/Handle/utils.ts
@@ -114,7 +114,10 @@ export function isValidHandle(
   // because it could be that the center of another handle is closer to the mouse pointer than the handle below the cursor
   const handleToCheck = handleBelow?.classList.contains('react-flow__handle') ? handleBelow : handleDomNode;
 
-  const result = defaultResult();
+  const result = {
+    ...defaultResult(),
+    handleDomNode: handleToCheck,
+  };
 
   if (handleToCheck) {
     const handleType = getHandleType(undefined, handleToCheck);


### PR DESCRIPTION
# 🏎️ What's changed?

- Call `isValidHandle` for all handles inside the connection radius
- Use the closest handle that is valid as snap target

# 🐛 Fixes

- [x] Connection radius not working when a handle that is *not* valid is close-by and therefore blocking the snap to another handle that might be valid instead