### PR TITLE
fix the undraggable bug in example in touch device

### DIFF
--- a/examples/react/src/examples/EasyConnect/CustomNode.tsx
+++ b/examples/react/src/examples/EasyConnect/CustomNode.tsx
@@ -4,7 +4,7 @@ const connectionNodeIdSelector = (state: ReactFlowState) => state.connectionStar
 
 export default function CustomNode({ id }: NodeProps) {
   const connectionNodeId = useStore(connectionNodeIdSelector);
-  const isConnecting = !!connectionNodeId;
+  //const isConnecting = !!connectionNodeId;
   const isTarget = connectionNodeId && connectionNodeId !== id;
 
   const targetHandleStyle = { zIndex: isTarget ? 3 : 1 };
@@ -19,7 +19,7 @@ export default function CustomNode({ id }: NodeProps) {
           backgroundColor: isTarget ? '#ffcce3' : '#ccd9f6',
         }}
       >
-        {!isConnecting && (
+        {!isTarget && (
           <Handle className="customHandle" style={{ zIndex: 2 }} position={Position.Right} type="source" />
         )}
 


### PR DESCRIPTION
This is the bug

![RPReplay_Final1698909600](https://github.com/xyflow/xyflow/assets/128367207/75d3302f-ccdf-4682-9185-39a4b0d58f42)


This example(easy drag) has a small bug in touch device. I found it in iPad.

And It can be solved by an amazing way haha. I don’t know why but it works and it still works by mouse device.

![RPReplay_Final1698908890](https://github.com/xyflow/xyflow/assets/128367207/e0ccdfc3-1647-4047-bf29-2566625a4159)