### PR TITLE
fix(react,svelte): allow panning by scroll when pan activation key is pressed

### DIFF
--- a/.changeset/empty-bobcats-taste.md
+++ b/.changeset/empty-bobcats-taste.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Allow panning by scroll when pan activation key is pressed. Fixes [#3516](https://github.com/xyflow/xyflow/issues/3516)

--- a/packages/react/src/container/FlowRenderer/index.tsx
+++ b/packages/react/src/container/FlowRenderer/index.tsx
@@ -50,7 +50,7 @@ const FlowRenderer = ({
   elementsSelectable,
   zoomOnScroll,
   zoomOnPinch,
-  panOnScroll,
+  panOnScroll: _panOnScroll,
   panOnScrollSpeed,
   panOnScrollMode,
   zoomOnDoubleClick,
@@ -72,6 +72,7 @@ const FlowRenderer = ({
   const panActivationKeyPressed = useKeyPress(panActivationKeyCode);
 
   const panOnDrag = panActivationKeyPressed || _panOnDrag;
+  const panOnScroll = panActivationKeyPressed || _panOnScroll;
   const isSelecting = selectionKeyPressed || (selectionOnDrag && panOnDrag !== true);
 
   useGlobalKeyHandler({ deleteKeyCode, multiSelectionKeyCode });

--- a/packages/svelte/src/lib/container/Zoom/Zoom.svelte
+++ b/packages/svelte/src/lib/container/Zoom/Zoom.svelte
@@ -33,6 +33,7 @@
 
   $: viewPort = initialViewport || { x: 0, y: 0, zoom: 1 };
   $: _panOnDrag = $panActivationKeyPressed || panOnDrag;
+  $: _panOnScroll = $panActivationKeyPressed || panOnScroll;
 </script>
 
 <div
@@ -50,7 +51,7 @@
     zoomOnScroll,
     zoomOnDoubleClick,
     zoomOnPinch,
-    panOnScroll,
+    panOnScroll: _panOnScroll,
     panOnDrag: _panOnDrag,
     panOnScrollSpeed: 0.5,
     panOnScrollMode: panOnScrollMode || PanOnScrollMode.Free,


### PR DESCRIPTION
# What's Changed? 

- Allow panning by scroll when `panActivationKeyCode` is pressed

# Notes

- Idk if this is even wanted or if the current behavior is intentional, either way here would be a proposal if a change is wanted 