### PR TITLE
chore(utils): add renamed functions and deprecations closes #3528

### DIFF
--- a/.changeset/curly-points-travel.md
+++ b/.changeset/curly-points-travel.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': minor
+---
+
+chore(utils): add renamed functions and deprecations

--- a/packages/core/src/components/NodesSelection/index.tsx
+++ b/packages/core/src/components/NodesSelection/index.tsx
@@ -9,7 +9,7 @@ import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
-import { getRectOfNodes } from '../../utils/graph';
+import { getNodesBounds } from '../../utils/graph';
 import useDrag from '../../hooks/useDrag';
 import { arrowKeyDiffs } from '../Nodes/wrapNode';
 import useUpdateNodePositions from '../../hooks/useUpdateNodePositions';
@@ -24,7 +24,7 @@ export interface NodesSelectionProps {
 const selector = (s: ReactFlowState) => {
   const selectedNodes = s.getNodes().filter((n) => n.selected);
   return {
-    ...getRectOfNodes(selectedNodes, s.nodeOrigin),
+    ...getNodesBounds(selectedNodes, s.nodeOrigin),
     transformString: `translate(${s.transform[0]}px,${s.transform[1]}px) scale(${s.transform[2]})`,
     userSelectionActive: s.userSelectionActive,
   };

--- a/packages/core/src/hooks/useDrag/index.ts
+++ b/packages/core/src/hooks/useDrag/index.ts
@@ -17,7 +17,7 @@ import type {
   Box,
   CoordinateExtent,
 } from '../../types';
-import { getRectOfNodes } from '../../utils/graph';
+import { getNodesBounds } from '../../utils/graph';
 
 export type UseDragData = { dx: number; dy: number };
 
@@ -80,7 +80,7 @@ function useDrag({
         let nodesBox: Box = { x: 0, y: 0, x2: 0, y2: 0 };
 
         if (dragItems.current.length > 1 && nodeExtent) {
-          const rect = getRectOfNodes(dragItems.current as unknown as Node[], nodeOrigin);
+          const rect = getNodesBounds(dragItems.current as unknown as Node[], nodeOrigin);
           nodesBox = rectToBox(rect);
         }
 

--- a/packages/core/src/hooks/useViewportHelper.ts
+++ b/packages/core/src/hooks/useViewportHelper.ts
@@ -73,7 +73,7 @@ const useViewportHelper = (): ViewportHelperFunctions => {
           const { transform, snapToGrid, snapGrid } = store.getState();
 
           console.warn(
-            '[DEPRECATED] `project` is deprecated. Instead use `screenToFlowPosition`. There is no need to subtract the react flow bounds anymore!'
+            '[DEPRECATED] `project` is deprecated. Instead use `screenToFlowPosition`. There is no need to subtract the react flow bounds anymore! https://reactflow.dev/api-reference/types/react-flow-instance#screen-to-flow-position'
           );
 
           return pointToRendererPoint(position, transform, snapToGrid, snapGrid);

--- a/packages/core/src/hooks/useViewportHelper.ts
+++ b/packages/core/src/hooks/useViewportHelper.ts
@@ -3,7 +3,7 @@ import { zoomIdentity } from 'd3-zoom';
 import { shallow } from 'zustand/shallow';
 
 import { useStoreApi, useStore } from '../hooks/useStore';
-import { pointToRendererPoint, getTransformForBounds, getD3Transition } from '../utils/graph';
+import { pointToRendererPoint, getViewportForBounds, getD3Transition, rendererPointToPoint } from '../utils/graph';
 import { fitView } from '../store/utils';
 import type { ViewportHelperFunctions, ReactFlowState, XYPosition } from '../types';
 
@@ -63,14 +63,50 @@ const useViewportHelper = (): ViewportHelperFunctions => {
         },
         fitBounds: (bounds, options) => {
           const { width, height, minZoom, maxZoom } = store.getState();
-          const [x, y, zoom] = getTransformForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? 0.1);
+          const { x, y, zoom } = getViewportForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? 0.1);
           const transform = zoomIdentity.translate(x, y).scale(zoom);
 
           d3Zoom.transform(getD3Transition(d3Selection, options?.duration), transform);
         },
+        // @deprecated Use `screenToFlowPosition`.
         project: (position: XYPosition) => {
           const { transform, snapToGrid, snapGrid } = store.getState();
+
+          console.warn(
+            '[DEPRECATED] `project` is deprecated. Instead use `screenToFlowPosition`. There is no need to subtract the react flow bounds anymore!'
+          );
+
           return pointToRendererPoint(position, transform, snapToGrid, snapGrid);
+        },
+        screenToFlowPosition: (position: XYPosition) => {
+          const { transform, snapToGrid, snapGrid, domNode } = store.getState();
+
+          if (!domNode) {
+            return position;
+          }
+
+          const { x: domX, y: domY } = domNode.getBoundingClientRect();
+          const relativePosition = {
+            x: position.x - domX,
+            y: position.y - domY,
+          };
+
+          return pointToRendererPoint(relativePosition, transform, snapToGrid, snapGrid);
+        },
+        flowToScreenPosition: (position: XYPosition) => {
+          const { transform, domNode } = store.getState();
+
+          if (!domNode) {
+            return position;
+          }
+
+          const { x: domX, y: domY } = domNode.getBoundingClientRect();
+          const rendererPosition = rendererPointToPoint(position, transform);
+
+          return {
+            x: rendererPosition.x + domX,
+            y: rendererPosition.y + domY,
+          };
         },
         viewportInitialized: true,
       };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,9 @@ export {
   getConnectedEdges,
   updateEdge,
   getTransformForBounds,
+  getViewportForBounds,
   getRectOfNodes,
+  getNodesBounds,
   getNodePositionWithOrigin,
 } from './utils/graph';
 export { applyNodeChanges, applyEdgeChanges, handleParentExpand } from './utils/changes';

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -2,7 +2,7 @@ import { zoomIdentity } from 'd3-zoom';
 import type { StoreApi } from 'zustand';
 
 import { internalsSymbol, isNumeric } from '../utils';
-import { getD3Transition, getRectOfNodes, getViewportForBounds, getNodePositionWithOrigin } from '../utils/graph';
+import { getD3Transition, getNodesBounds, getViewportForBounds, getNodePositionWithOrigin } from '../utils/graph';
 import type {
   Edge,
   EdgeSelectionChange,
@@ -155,7 +155,7 @@ export function fitView(get: StoreApi<ReactFlowState>['getState'], options: Inte
     const nodesInitialized = nodes.every((n) => n.width && n.height);
 
     if (nodes.length > 0 && nodesInitialized) {
-      const bounds = getRectOfNodes(nodes, nodeOrigin);
+      const bounds = getNodesBounds(nodes, nodeOrigin);
 
       const { x, y, zoom } = getViewportForBounds(
         bounds,

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -2,7 +2,7 @@ import { zoomIdentity } from 'd3-zoom';
 import type { StoreApi } from 'zustand';
 
 import { internalsSymbol, isNumeric } from '../utils';
-import { getD3Transition, getRectOfNodes, getTransformForBounds, getNodePositionWithOrigin } from '../utils/graph';
+import { getD3Transition, getRectOfNodes, getViewportForBounds, getNodePositionWithOrigin } from '../utils/graph';
 import type {
   Edge,
   EdgeSelectionChange,
@@ -157,7 +157,7 @@ export function fitView(get: StoreApi<ReactFlowState>['getState'], options: Inte
     if (nodes.length > 0 && nodesInitialized) {
       const bounds = getRectOfNodes(nodes, nodeOrigin);
 
-      const [x, y, zoom] = getTransformForBounds(
+      const { x, y, zoom } = getViewportForBounds(
         bounds,
         width,
         height,

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -290,7 +290,7 @@ export const getTransformForBounds = (
   const { x, y, zoom } = getViewportForBounds(bounds, width, height, minZoom, maxZoom, padding);
 
   console.warn(
-    '[DEPRECATED] `getTransformForBounds` is deprecated. Instead use `getViewportForBounds`. Beware that the return value is type Viewport instead of Transform.'
+    '[DEPRECATED] `getTransformForBounds` is deprecated. Instead use `getViewportForBounds`. Beware that the return value is type Viewport (`{ x: number, y: number, zoom: number }`) instead of Transform (`[number, number, number]`).'
   );
 
   return [x, y, zoom];

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -218,7 +218,9 @@ export const getNodesBounds = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): 
 
 // @deprecated Use `getNodesBounds`.
 export const getRectOfNodes = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): Rect => {
-  console.warn('[DEPRECATED] `getRectOfNodes` is deprecated. Instead use `getNodesBounds`.');
+  console.warn(
+    '[DEPRECATED] `getRectOfNodes` is deprecated. Instead use `getNodesBounds` https://reactflow.dev/api-reference/utils/get-nodes-bounds.'
+  );
 
   return getNodesBounds(nodes, nodeOrigin);
 };
@@ -290,7 +292,7 @@ export const getTransformForBounds = (
   const { x, y, zoom } = getViewportForBounds(bounds, width, height, minZoom, maxZoom, padding);
 
   console.warn(
-    '[DEPRECATED] `getTransformForBounds` is deprecated. Instead use `getViewportForBounds`. Beware that the return value is type Viewport (`{ x: number, y: number, zoom: number }`) instead of Transform (`[number, number, number]`).'
+    '[DEPRECATED] `getTransformForBounds` is deprecated. Instead use `getViewportForBounds`. Beware that the return value is type Viewport (`{ x: number, y: number, zoom: number }`) instead of Transform (`[number, number, number]`). https://reactflow.dev/api-reference/utils/get-viewport-for-bounds'
   );
 
   return [x, y, zoom];

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -13,6 +13,7 @@ import {
   NodeInternals,
   NodeOrigin,
   UpdateEdgeOptions,
+  Viewport,
 } from '../types';
 import { errorMessages } from '../contants';
 
@@ -191,7 +192,7 @@ export const getNodePositionWithOrigin = (
   };
 };
 
-export const getRectOfNodes = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): Rect => {
+export const getNodesBounds = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): Rect => {
   if (nodes.length === 0) {
     return { x: 0, y: 0, width: 0, height: 0 };
   }
@@ -213,6 +214,13 @@ export const getRectOfNodes = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): 
   );
 
   return boxToRect(box);
+};
+
+// @deprecated Use `getNodesBounds`.
+export const getRectOfNodes = (nodes: Node[], nodeOrigin: NodeOrigin = [0, 0]): Rect => {
+  console.warn('[DEPRECATED] `getRectOfNodes` is deprecated. Instead use `getNodesBounds`.');
+
+  return getNodesBounds(nodes, nodeOrigin);
 };
 
 export const getNodesInside = (
@@ -270,6 +278,7 @@ export const getConnectedEdges = (nodes: Node[], edges: Edge[]): Edge[] => {
   return edges.filter((edge) => nodeIds.includes(edge.source) || nodeIds.includes(edge.target));
 };
 
+// @deprecated Use `getViewportForBounds`.
 export const getTransformForBounds = (
   bounds: Rect,
   width: number,
@@ -278,6 +287,23 @@ export const getTransformForBounds = (
   maxZoom: number,
   padding = 0.1
 ): Transform => {
+  const { x, y, zoom } = getViewportForBounds(bounds, width, height, minZoom, maxZoom, padding);
+
+  console.warn(
+    '[DEPRECATED] `getTransformForBounds` is deprecated. Instead use `getViewportForBounds`. Beware that the return value is type Viewport instead of Transform.'
+  );
+
+  return [x, y, zoom];
+};
+
+export const getViewportForBounds = (
+  bounds: Rect,
+  width: number,
+  height: number,
+  minZoom: number,
+  maxZoom: number,
+  padding = 0.1
+): Viewport => {
   const xZoom = width / (bounds.width * (1 + padding));
   const yZoom = height / (bounds.height * (1 + padding));
   const zoom = Math.min(xZoom, yZoom);
@@ -287,7 +313,7 @@ export const getTransformForBounds = (
   const x = width / 2 - boundsCenterX * clampedZoom;
   const y = height / 2 - boundsCenterY * clampedZoom;
 
-  return [x, y, clampedZoom];
+  return { x, y, zoom: clampedZoom };
 };
 
 export const getD3Transition = (selection: D3Selection<Element, unknown, null, undefined>, duration = 0) => {

--- a/packages/minimap/src/MiniMap.tsx
+++ b/packages/minimap/src/MiniMap.tsx
@@ -7,7 +7,7 @@ import { shallow } from 'zustand/shallow';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import type { D3ZoomEvent } from 'd3-zoom';
 import { select, pointer } from 'd3-selection';
-import { useStore, getRectOfNodes, Panel, getBoundsOfRects, useStoreApi, CoordinateExtent } from '@reactflow/core';
+import { useStore, getNodesBounds, Panel, getBoundsOfRects, useStoreApi, CoordinateExtent } from '@reactflow/core';
 import type { ReactFlowState, Rect } from '@reactflow/core';
 
 import type { MiniMapProps } from './types';
@@ -27,7 +27,7 @@ const selector = (s: ReactFlowState) => {
 
   return {
     viewBB,
-    boundingRect: nodes.length > 0 ? getBoundsOfRects(getRectOfNodes(nodes, s.nodeOrigin), viewBB) : viewBB,
+    boundingRect: nodes.length > 0 ? getBoundsOfRects(getNodesBounds(nodes, s.nodeOrigin), viewBB) : viewBB,
     rfId: s.rfId,
   };
 };

--- a/packages/node-toolbar/src/NodeToolbar.tsx
+++ b/packages/node-toolbar/src/NodeToolbar.tsx
@@ -3,7 +3,7 @@ import {
   Node,
   ReactFlowState,
   useStore,
-  getRectOfNodes,
+  getNodesBounds,
   Transform,
   Rect,
   Position,
@@ -112,7 +112,7 @@ function NodeToolbar({
     return null;
   }
 
-  const nodeRect: Rect = getRectOfNodes(nodes, nodeOrigin);
+  const nodeRect: Rect = getNodesBounds(nodes, nodeOrigin);
   const zIndex: number = Math.max(...nodes.map((node) => (node[internalsSymbol]?.z || 1) + 1));
 
   const wrapperStyle: CSSProperties = {


### PR DESCRIPTION
deprecations/renamings:

* `useReactFlow.project` => `useReactFlow.screenToFlowPosition` (changes: no need to subtract react flow bounds anymore)
* `getRectOfNodes` => `getNodesBounds` (changes: none)
* `getTransformForBounds` => `getViewportForBounds` (changes: returns `{ x: number, y: number, zoom: number }` instead of `[number, number, number]`)

--

new functions:

* added `useReactFlow.flowToScreenPosition` 