### PR TITLE
refactor(system,styles)!: use translate to align handles to center of its side

### DIFF
--- a/.changeset/thin-dryers-worry.md
+++ b/.changeset/thin-dryers-worry.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': major
+---
+
+Use css `translate` to align handles to the center of their side instead of using hard-coded 4px to each direction, otherwise handles with different sizes aren't correctly aligned by the default handle styles

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -183,26 +183,26 @@
   &-bottom {
     top: auto;
     left: 50%;
-    bottom: -4px;
-    transform: translate(-50%, 0);
+    bottom: 0;
+    transform: translate(-50%, 50%);
   }
 
   &-top {
+    top: 0;
     left: 50%;
-    top: -4px;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -50%);
   }
 
   &-left {
     top: 50%;
-    left: -4px;
-    transform: translate(0, -50%);
+    left: 0;
+    transform: translate(-50%, -50%);
   }
 
   &-right {
-    right: -4px;
     top: 50%;
-    transform: translate(0, -50%);
+    right: 0;
+    transform: translate(50%, -50%);
   }
 }
 


### PR DESCRIPTION
# What's Changed?

- Remove `4px` offsets for handles and replace them with `translate` and `50%`
   - Aligns all handles, regardless of size, properly to the center of the side their own

# Notes

- This would probably count as another breaking change, as existing users styles might be affected by this change