### PR TITLE
Allow on:connect to be triggered on source and target handles

### DIFF
--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -106,14 +106,7 @@
   }
 
   function onTargetConnect(event: CustomEvent) {
-    // creating a dummy connection object so this doesn't break the current
-    // connection logic when the target is the starting point of the connection
-    const connection = {
-      source: '',
-      target: nodeId,
-      sourceHandle: '',
-      targetHandle: id as string
-    };
+    const connection = event.detail.connection;
     dispatch('connect', { connection });
   }
 

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -228,13 +228,11 @@ export function createStore({
           let handleDomNode = doc.querySelector(
             `.${get(store.lib)}-flow__handle[data-id="${edge.source}-${edge.sourceHandle}-source"]`
           );
-          console.log(handleDomNode);
           handleDomNode?.dispatchEvent(e);
 
           handleDomNode = doc.querySelector(
             `.${get(store.lib)}-flow__handle[data-id="${edge.target}-${edge.targetHandle}-target"]`
           );
-          console.log(handleDomNode);
           handleDomNode?.dispatchEvent(e);
         }
       }

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -220,6 +220,23 @@ export function createStore({
         store.edges.update((eds) =>
           eds.filter((edge) => !matchingEdges.some((mE) => mE.id === edge.id))
         );
+        // call disconnect on handles
+        for (const edge of matchingEdges) {
+          const doc = get(store.domNode) as HTMLElement;
+          const e = new CustomEvent('disconnect');
+
+          let handleDomNode = doc.querySelector(
+            `.${get(store.lib)}-flow__handle[data-id="${edge.source}-${edge.sourceHandle}-source"]`
+          );
+          console.log(handleDomNode);
+          handleDomNode?.dispatchEvent(e);
+
+          handleDomNode = doc.querySelector(
+            `.${get(store.lib)}-flow__handle[data-id="${edge.target}-${edge.targetHandle}-target"]`
+          );
+          console.log(handleDomNode);
+          handleDomNode?.dispatchEvent(e);
+        }
       }
     }
   });

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -210,7 +210,7 @@ function onPointerDown(
     if ((closestHandle || handleDomNode) && connection && isValid) {
       // calling custom event to trigger the onConnect callback
       // of the target Handle
-      const e = new CustomEvent('targetConnect');
+      const e = new CustomEvent('targetConnect', { detail: connection });
       handleDomNode?.dispatchEvent(e);
       onConnect?.(connection);
     }

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -182,12 +182,12 @@ function onPointerDown(
       connectionPosition:
         closestHandle && isValid
           ? rendererPointToPoint(
-              {
-                x: closestHandle.x,
-                y: closestHandle.y,
-              },
-              transform
-            )
+            {
+              x: closestHandle.x,
+              y: closestHandle.y,
+            },
+            transform
+          )
           : connectionPosition,
       connectionStatus: getConnectionStatus(!!closestHandle, isValid),
       connectionEndHandle: result.endHandle,
@@ -208,6 +208,10 @@ function onPointerDown(
 
   function onPointerUp(event: MouseEvent | TouchEvent) {
     if ((closestHandle || handleDomNode) && connection && isValid) {
+      // calling custom event to trigger the onConnect callback
+      // of the target Handle
+      const e = new CustomEvent('targetConnect');
+      handleDomNode?.dispatchEvent(e);
       onConnect?.(connection);
     }
 


### PR DESCRIPTION
In the current implementation of SvelteFlow, only the drag start handle's on:connect is called when connecting two nodes. This results in an issue as seen in the gif below where HTTP REQUEST has an on:connect that is only called when the connection is started from HTTP REQUEST.

![connectissue](https://github.com/xyflow/xyflow/assets/10972270/972a2a8e-fdf8-4a77-90f4-d6833ae99a94)

This implementation allows for both, the source and destination, on:connects to be called. Furthermore, it includes the ability to call on:disconnect on any handle affected by an edge that is deleted.

![workingconn](https://github.com/xyflow/xyflow/assets/10972270/dd8814fd-d581-41ee-96ab-a39a87544b07)
