### PR TITLE
refactor(svelte): rename width/height to measuredWidth/measuredHeight

### DIFF
--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -44,7 +44,12 @@ const createRFStore = ({
         const { nodeLookup, nodeOrigin, elevateNodesOnSelect } = get();
         // Whenver new nodes are set, we need to calculate the absolute positions of the nodes
         // and update the nodeLookup.
-        const nextNodes = updateNodes(nodes, nodeLookup, { nodeOrigin, elevateNodesOnSelect });
+        const nextNodes = updateNodes(nodes, nodeLookup, {
+          nodeOrigin,
+          elevateNodesOnSelect,
+          widthAttr: 'width',
+          heightAttr: 'height',
+        });
 
         set({ nodes: nextNodes });
       },
@@ -72,6 +77,8 @@ const createRFStore = ({
           nextState.nodes = updateNodes(nodes, new Map(), {
             nodeOrigin: get().nodeOrigin,
             elevateNodesOnSelect: get().elevateNodesOnSelect,
+            widthAttr: 'width',
+            heightAttr: 'height',
           });
         }
         if (hasDefaultEdges) {
@@ -103,6 +110,8 @@ const createRFStore = ({
           nodeLookup,
           domNode,
           nodeOrigin,
+          'width',
+          'height',
           (id: string, dimensions: Dimensions) => {
             changes.push({
               id: id,
@@ -166,6 +175,8 @@ const createRFStore = ({
             const nextNodes = updateNodes(updatedNodes, nodeLookup, {
               nodeOrigin,
               elevateNodesOnSelect,
+              widthAttr: 'width',
+              heightAttr: 'height',
             });
             set({ nodes: nextNodes });
           }

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -23,7 +23,12 @@ const getInitialState = ({
   fitView?: boolean;
 } = {}): ReactFlowStore => {
   const nodeLookup = new Map<string, Node>();
-  const nextNodes = updateNodes(nodes, nodeLookup, { nodeOrigin: [0, 0], elevateNodesOnSelect: false });
+  const nextNodes = updateNodes(nodes, nodeLookup, {
+    nodeOrigin: [0, 0],
+    elevateNodesOnSelect: false,
+    widthAttr: 'width',
+    heightAttr: 'height',
+  });
 
   let transform: Transform = [0, 0, 1];
 

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -1,9 +1,9 @@
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
 import type { NodeBase } from '@xyflow/system';
 
-export type Node<NodeData = any, NodeType extends string | undefined = string | undefined> = NodeBase<
-  NodeData,
-  NodeType
+export type Node<NodeData = any, NodeType extends string | undefined = string | undefined> = Omit<
+  NodeBase<NodeData, NodeType>,
+  'measuredWidth' | 'measuredHeight'
 > & {
   style?: CSSProperties;
   className?: string;

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -14,21 +14,25 @@
 
   interface $$Props extends NodeWrapperProps {}
 
-  export let node: NodeWrapperProps['node'];
   export let id: NodeWrapperProps['id'];
+  export let node: NodeWrapperProps['node'];
   export let data: NodeWrapperProps['data'] = {};
   export let selected: NodeWrapperProps['selected'] = false;
   export let draggable: NodeWrapperProps['draggable'] = undefined;
   export let selectable: NodeWrapperProps['selectable'] = undefined;
   export let connectable: NodeWrapperProps['connectable'] = true;
   export let hidden: NodeWrapperProps['hidden'] = false;
+  export let width: NodeWrapperProps['width'] = undefined;
+  export let height: NodeWrapperProps['height'] = undefined;
   export let dragging: boolean = false;
   export let resizeObserver: NodeWrapperProps['resizeObserver'] = null;
   export let style: NodeWrapperProps['style'] = undefined;
   export let type: NodeWrapperProps['type'] = 'default';
   export let isParent: NodeWrapperProps['isParent'] = false;
-  export let positionAbsolute: NodeWrapperProps['positionAbsolute'] = undefined;
-  export let positionOrigin: NodeWrapperProps['positionOrigin'] = undefined;
+  export let positionX: NodeWrapperProps['positionX'];
+  export let positionY: NodeWrapperProps['positionY'];
+  export let positionOriginX: NodeWrapperProps['positionOriginX'];
+  export let positionOriginY: NodeWrapperProps['positionOriginY'];
   export let sourcePosition: NodeWrapperProps['sourcePosition'] = undefined;
   export let targetPosition: NodeWrapperProps['targetPosition'] = undefined;
   export let zIndex: NodeWrapperProps['zIndex'];
@@ -164,11 +168,9 @@
     class:nopan={draggable}
     class:parent={isParent}
     style:z-index={zIndex}
-    style:transform="translate({positionOrigin?.x ?? 0}px, {positionOrigin?.y ?? 0}px)"
+    style:transform="translate({positionOriginX ?? 0}px, {positionOriginY ?? 0}px)"
     style:visibility={initialized ? 'visible' : 'hidden'}
-    style="{style} {node.size?.width ? `;width=${node.size?.width}px` : ''} {node.size?.height
-      ? `;height=${node.size?.height}px;`
-      : ''}"
+    style="{style} {width ? `;width=${width}px` : ''} {height ? `;height=${height}px;` : ''}"
     on:click={onSelectNodeHandler}
     on:mouseenter={(event) => dispatch('nodemouseenter', { node, event })}
     on:mouseleave={(event) => dispatch('nodemouseleave', { node, event })}
@@ -187,8 +189,8 @@
       {dragging}
       {dragHandle}
       isConnectable={connectable}
-      xPos={positionAbsolute?.x ?? 0}
-      yPos={positionAbsolute?.y ?? 0}
+      xPos={positionX}
+      yPos={positionY}
       on:connectstart
       on:connect
       on:connectend

--- a/packages/svelte/src/lib/components/NodeWrapper/types.ts
+++ b/packages/svelte/src/lib/components/NodeWrapper/types.ts
@@ -1,4 +1,3 @@
-import type { XYPosition } from '@xyflow/system';
 import type { Node } from '$lib/types';
 
 export type NodeWrapperProps = Pick<
@@ -9,7 +8,6 @@ export type NodeWrapperProps = Pick<
   | 'data'
   | 'draggable'
   | 'dragging'
-  | 'positionAbsolute'
   | 'selected'
   | 'selectable'
   | 'style'
@@ -21,11 +19,16 @@ export type NodeWrapperProps = Pick<
   | 'dragHandle'
   | 'hidden'
 > & {
-  positionOrigin?: XYPosition;
+  positionX: number;
+  positionY: number;
+  positionOriginX: number;
+  positionOriginY: number;
   'on:nodeclick'?: (event: MouseEvent) => void;
   resizeObserver?: ResizeObserver | null;
   isParent?: boolean;
   zIndex: number;
   node: Node;
   initialized: boolean;
+  width?: number;
+  height?: number;
 };

--- a/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
+++ b/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
@@ -42,8 +42,8 @@
     {@const posOrigin = getPositionWithOrigin({
       x: node.positionAbsolute?.x ?? 0,
       y: node.positionAbsolute?.y ?? 0,
-      width: (node.size?.width || node.width) ?? 0,
-      height: (node.size?.height || node.height) ?? 0,
+      width: (node?.width || node.measuredWidth) ?? 0,
+      height: (node?.height || node.measuredHeight) ?? 0,
       origin: node.origin
     })}
     <NodeWrapper
@@ -61,8 +61,10 @@
         node.connectable ||
         ($nodesConnectable && typeof node.connectable === 'undefined')
       )}
-      positionAbsolute={node.positionAbsolute}
-      positionOrigin={posOrigin}
+      positionX={node.positionAbsolute?.x ?? 0}
+      positionY={node.positionAbsolute?.y ?? 0}
+      positionOriginX={posOrigin.x}
+      positionOriginY={posOrigin.y}
       isParent={!!node[internalsSymbol]?.isParent}
       style={node.style}
       class={node.class}
@@ -72,7 +74,10 @@
       dragging={node.dragging}
       zIndex={node[internalsSymbol]?.z ?? 0}
       dragHandle={node.dragHandle}
-      initialized={(!!node.width && !!node.height) || (!!node.size?.width && !!node.size?.height)}
+      width={node.width}
+      height={node.height}
+      initialized={(!!node.measuredWidth && !!node.measuredHeight) ||
+        (!!node.width && !!node.height)}
       {resizeObserver}
       on:nodeclick
       on:nodemouseenter

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -114,13 +114,13 @@
       {#if ariaLabel}<title id={labelledBy}>{ariaLabel}</title>{/if}
 
       {#each $nodes as node (node.id)}
-        {#if node.width && node.height}
+        {#if node.measuredWidth && node.measuredHeight}
           {@const pos = getNodePositionWithOrigin(node).positionAbsolute}
           <MinimapNode
             x={pos.x}
             y={pos.y}
-            width={node.width}
-            height={node.height}
+            width={node.measuredWidth}
+            height={node.measuredHeight}
             selected={node.selected}
             color={nodeColorFunc(node)}
             borderRadius={nodeBorderRadius}

--- a/packages/svelte/src/lib/store/derived-connection-props.ts
+++ b/packages/svelte/src/lib/store/derived-connection-props.ts
@@ -80,8 +80,10 @@ export function getDerivedConnectionProps(
         : handleBounds[0];
       const fromHandleX = fromHandle
         ? fromHandle.x + fromHandle.width / 2
-        : (fromNode?.width ?? 0) / 2;
-      const fromHandleY = fromHandle ? fromHandle.y + fromHandle.height / 2 : fromNode?.height ?? 0;
+        : (fromNode?.measuredWidth ?? 0) / 2;
+      const fromHandleY = fromHandle
+        ? fromHandle.y + fromHandle.height / 2
+        : fromNode?.measuredHeight ?? 0;
       const fromX = (fromNode?.positionAbsolute?.x ?? 0) + fromHandleX;
       const fromY = (fromNode?.positionAbsolute?.y ?? 0) + fromHandleY;
       const fromPosition = fromHandle?.position;

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -87,12 +87,14 @@ export function createStore({
   };
 
   function updateNodeDimensions(updates: Map<string, NodeDimensionUpdate>) {
-    const nextNodes = updateNodeDimensionsSystem(
+    const nextNodes = updateNodeDimensionsSystem<Node>(
       updates,
       get(store.nodes),
       get(store.nodeLookup),
       get(store.domNode),
-      get(store.nodeOrigin)
+      get(store.nodeOrigin),
+      'measuredWidth',
+      'measuredHeight'
     );
 
     if (!nextNodes) {

--- a/packages/svelte/src/lib/store/initial-store.ts
+++ b/packages/svelte/src/lib/store/initial-store.ts
@@ -70,7 +70,9 @@ export const getInitialStore = ({
   const nodeLookup = new Map<string, Node>();
   const nextNodes = updateNodes(nodes, nodeLookup, {
     nodeOrigin: [0, 0],
-    elevateNodesOnSelect: false
+    elevateNodesOnSelect: false,
+    widthAttr: 'measuredWidth',
+    heightAttr: 'measuredHeight'
   });
 
   let viewport: Viewport = { x: 0, y: 0, zoom: 1 };
@@ -78,8 +80,8 @@ export const getInitialStore = ({
   if (fitView && width && height) {
     const nodesWithDimensions = nextNodes.map((node) => ({
       ...node,
-      width: node.size?.width,
-      height: node.size?.height
+      width: node?.width,
+      height: node?.height
     }));
     const bounds = getNodesBounds(nodesWithDimensions, [0, 0]);
     viewport = getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);

--- a/packages/svelte/src/lib/store/utils.ts
+++ b/packages/svelte/src/lib/store/utils.ts
@@ -135,7 +135,9 @@ export const createNodesStore = (
   const _set = (nds: Node[]): Node[] => {
     const nextNodes = updateNodes(nds, nodeLookup, {
       elevateNodesOnSelect,
-      defaults
+      defaults,
+      widthAttr: 'measuredWidth',
+      heightAttr: 'measuredHeight'
     });
 
     value = nextNodes;

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -6,12 +6,14 @@ import type { NodeBase, NodeProps } from '@xyflow/system';
 // @todo: currently the helper function only like Node from '@reactflow/core'
 // we need a base node type or helpes that accept Node like types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Node<
-  NodeData = any,
-  NodeType extends string | undefined = string | undefined
-> = NodeBase<NodeData, NodeType> & {
+export type Node<NodeData = any, NodeType extends string | undefined = string | undefined> = Omit<
+  NodeBase<NodeData, NodeType>,
+  'size'
+> & {
   class?: string;
   style?: string;
+  measuredWidth?: number;
+  measuredHeight?: number;
 };
 
 export type NodeTypes = Record<string, ComponentType<SvelteComponent<NodeProps>>>;

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -19,8 +19,10 @@ export type NodeBase<T = any, U extends string | undefined = string | undefined>
   connectable?: boolean;
   deletable?: boolean;
   dragHandle?: string;
-  width?: number | null;
-  height?: number | null;
+  width?: number;
+  height?: number;
+  measuredWidth?: number;
+  measuredHeight?: number;
   parentNode?: string;
   zIndex?: number;
   extent?: 'parent' | CoordinateExtent;
@@ -31,8 +33,8 @@ export type NodeBase<T = any, U extends string | undefined = string | undefined>
   origin?: NodeOrigin;
   handles?: NodeHandle[];
   size?: {
-    width?: number;
-    height?: number;
+    width: number;
+    height: number;
   };
 
   // only used internally
@@ -81,8 +83,10 @@ export type NodeDragItem = {
   positionAbsolute: XYPosition;
   // distance from the mouse cursor to the node when start dragging
   distance: XYPosition;
-  width?: number | null;
-  height?: number | null;
+  width?: number;
+  height?: number;
+  measuredWidth?: number;
+  measuredHeight?: number;
   extent?: 'parent' | CoordinateExtent;
   parentNode?: string;
   dragging?: boolean;

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -88,8 +88,8 @@ function toHandleBounds(handles?: NodeHandle[]) {
 
 function getHandleDataByNode(node?: NodeBase): [Rect, NodeHandleBounds | null, boolean] {
   const handleBounds = node?.[internalsSymbol]?.handleBounds || toHandleBounds(node?.handles) || null;
-  const nodeWidth = node?.width || node?.size?.width;
-  const nodeHeight = node?.height || node?.size?.height;
+  const nodeWidth = node?.measuredWidth || node?.width || node?.size?.width;
+  const nodeHeight = node?.measuredHeight || node?.height || node?.size?.height;
 
   const isValid =
     handleBounds &&

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -64,8 +64,8 @@ export const nodeToRect = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Rec
 
   return {
     ...positionAbsolute,
-    width: node.width || 0,
-    height: node.height || 0,
+    width: node.measuredWidth || node.width || 0,
+    height: node.measuredHeight || node.height || 0,
   };
 };
 
@@ -74,8 +74,8 @@ export const nodeToBox = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Box 
 
   return {
     ...positionAbsolute,
-    x2: positionAbsolute.x + (node.width || 0),
-    y2: positionAbsolute.y + (node.height || 0),
+    x2: positionAbsolute.x + (node.measuredWidth || node.width || 0),
+    y2: positionAbsolute.y + (node.measuredHeight || node.height || 0),
   };
 };
 

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -60,6 +60,8 @@ type UpdateNodesOptions<NodeType extends NodeBase> = {
   nodeOrigin?: NodeOrigin;
   elevateNodesOnSelect?: boolean;
   defaults?: Partial<NodeType>;
+  widthAttr: 'width' | 'measuredWidth';
+  heightAttr: 'height' | 'measuredHeight';
 };
 
 export function updateNodes<NodeType extends NodeBase>(
@@ -69,6 +71,8 @@ export function updateNodes<NodeType extends NodeBase>(
     nodeOrigin: [0, 0] as NodeOrigin,
     elevateNodesOnSelect: true,
     defaults: {},
+    widthAttr: 'width',
+    heightAttr: 'height',
   }
 ): NodeType[] {
   const parentNodes: ParentNodes = {};
@@ -80,8 +84,8 @@ export function updateNodes<NodeType extends NodeBase>(
       ...options.defaults,
       ...n,
       positionAbsolute: n.position,
-      width: n.width || currentStoreNode?.width,
-      height: n.height || currentStoreNode?.height,
+      [options.widthAttr]: n[options.widthAttr] || currentStoreNode?.[options.widthAttr],
+      [options.heightAttr]: n[options.heightAttr] || currentStoreNode?.[options.heightAttr],
     };
     const z = (isNumeric(n.zIndex) ? n.zIndex : 0) + (n.selected ? selectedNodeZ : 0);
     const currInternals = n?.[internalsSymbol] || currentStoreNode?.[internalsSymbol];
@@ -135,14 +139,16 @@ function calculateXYZPosition<NodeType extends NodeBase>(
   );
 }
 
-export function updateNodeDimensions(
+export function updateNodeDimensions<NodeType extends NodeBase>(
   updates: Map<string, NodeDimensionUpdate>,
-  nodes: NodeBase[],
-  nodeLookup: Map<string, NodeBase>,
+  nodes: NodeType[],
+  nodeLookup: Map<string, NodeType>,
   domNode: HTMLElement | null,
   nodeOrigin?: NodeOrigin,
+  widthAttr: 'width' | 'measuredWidth' = 'width',
+  heightAttr: 'height' | 'measuredHeight' = 'height',
   onUpdate?: (id: string, dimensions: Dimensions) => void
-): NodeBase[] | null {
+): NodeType[] | null {
   const viewportNode = domNode?.querySelector('.xyflow__viewport');
 
   if (!viewportNode) {
@@ -160,7 +166,7 @@ export function updateNodeDimensions(
       const doUpdate = !!(
         dimensions.width &&
         dimensions.height &&
-        (node.width !== dimensions.width || node.height !== dimensions.height || update.forceUpdate)
+        (node[widthAttr] !== dimensions.width || node[heightAttr] !== dimensions.height || update.forceUpdate)
       );
 
       if (doUpdate) {
@@ -168,7 +174,8 @@ export function updateNodeDimensions(
 
         const newNode = {
           ...node,
-          ...dimensions,
+          [widthAttr]: dimensions.width,
+          [heightAttr]: dimensions.height,
           [internalsSymbol]: {
             ...node[internalsSymbol],
             handleBounds: {

--- a/packages/system/src/xydrag/utils.ts
+++ b/packages/system/src/xydrag/utils.ts
@@ -48,24 +48,24 @@ export function getDragItems<NodeType extends NodeBase>(
         (!n.parentNode || !isParentSelected(n, nodes)) &&
         (n.draggable || (nodesDraggable && typeof n.draggable === 'undefined'))
     )
-    .map((n) => ({
-      id: n.id,
-      position: n.position || { x: 0, y: 0 },
-      positionAbsolute: n.positionAbsolute || { x: 0, y: 0 },
+    .map((node) => ({
+      id: node.id,
+      position: node.position || { x: 0, y: 0 },
+      positionAbsolute: node.positionAbsolute || { x: 0, y: 0 },
       distance: {
-        x: mousePos.x - (n.positionAbsolute?.x ?? 0),
-        y: mousePos.y - (n.positionAbsolute?.y ?? 0),
+        x: mousePos.x - (node.positionAbsolute?.x ?? 0),
+        y: mousePos.y - (node.positionAbsolute?.y ?? 0),
       },
       delta: {
         x: 0,
         y: 0,
       },
-      extent: n.extent,
-      parentNode: n.parentNode,
-      width: n.width,
-      height: n.height,
-      origin: n.origin,
-      expandParent: n.expandParent,
+      extent: node.extent,
+      parentNode: node.parentNode,
+      width: node.measuredWidth || node.width,
+      height: node.measuredWidth || node.height,
+      origin: node.origin,
+      expandParent: node.expandParent,
     }));
 }
 


### PR DESCRIPTION
There is a lot of confusion about node.width and node.height. We measure the nodes and set width and height - then you can use those dimensions for layouting for examples but you can't use them to define the actual node size. In Svelte Flow we will change this, so that you can specify/force certain node dimensions by passing width/height. If you want to get the measured values, you can use node.measuredWidth/node.measuredHeight.  

Maybe we should do this change for ReactFlow 12, too? It's a huge breaking change because everyone who is doing layouting uses node.width/node.height but the API would be way easier to understand.