### PR TITLE
[Perf: Selection] Set `nodeDragThreshold` to 1

### DIFF
--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -61,7 +61,7 @@ const getInitialState = ({
     paneDragging: false,
     noPanClassName: 'nopan',
     nodeOrigin: [0, 0],
-    nodeDragThreshold: 0,
+    nodeDragThreshold: 1,
 
     snapGrid: [15, 15],
     snapToGrid: false,


### PR DESCRIPTION
This PR sets `nodeDragThreshold` to 1. This removes an expensive state and React update that would otherwise happen on `mouseup`.

### More details

Currently, whenever you select a node, XYFlow triggers two state updates:

![CleanShot 2023-11-25 at 01 17 54@2x](https://github.com/xyflow/xyflow/assets/2953267/b71c5555-81c7-42bd-8db9-0d1278330f2e)

This PR simply removes the second one.

### Performance wins

With this PR, node selection gets 1.6× cheaper.

(To verify, try changing selection while running a recording in Chrome DevTools → Performance – and compare the total JS costs between `next` and this branch.)

### Potential future improvements

If you look at this interaction really closely, you’ll notice we do a store update with `dragging: false` despite never setting `dragging: true`. Generally, this should be a no-op update (the node goes from not dragging to not dragging), but in the current codebase, it’s not: the update still triggers a React rerender.

This is an undesirable side effect of how [`applyChanges`](https://github.com/xyflow/xyflow/blob/74c82272aae7b1b29e97c142b9a0a1748920e417/packages/react/src/utils/changes.ts#L51) is implemented. `applyChanges` clones a node object if there’s _any_ change in the queue that applies to it – even if that change doesn’t functionally change anything. 

To solve this, we could introduce additional checks – or we can simply use `immer`, which, by design, avoids recreating objects when it can:

```js
const object = { foo: 'foo' }

// Immer creates a new object when you update any of the fields
const updatedObject1 = immer.produce(object, (draft) => { draft.foo = 'bar' })
console.log(object === updatedObject1) // → false

// ...but returns the same object if none of the fields actually change
const updatedObject2 = immer.produce(object, (draft) => { draft.foo = 'foo' })
console.log(object === updatedObject2) // → true

```

_Note:_ Immer has a performance overhead (which is small – it doesn’t do any deep checking, it just uses proxies) – but which is still worth measuring (as `applyChanges` executes hundreds of times per frame in big grids).