### PR TITLE
[Perf: Init Costs] Batch initial store updates together + more

### DIFF
--- a/packages/react/src/components/Edges/utils.ts
+++ b/packages/react/src/components/Edges/utils.ts
@@ -1,11 +1,9 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import type { StoreApi } from 'zustand';
-
-import type { Edge, ReactFlowState } from '../../types';
+import type { Edge, ReactFlowStoreApi } from '../../types';
 
 export function getMouseHandler(
   id: string,
-  getState: StoreApi<ReactFlowState>['getState'],
+  getState: ReactFlowStoreApi['getState'],
   handler?: (event: ReactMouseEvent<SVGGElement, MouseEvent>, edge: Edge) => void
 ) {
   return handler === undefined

--- a/packages/react/src/components/Nodes/utils.ts
+++ b/packages/react/src/components/Nodes/utils.ts
@@ -1,12 +1,10 @@
 import type { MouseEvent, RefObject } from 'react';
-import type { StoreApi } from 'zustand';
-
-import type { Node, ReactFlowState } from '../../types';
+import type { Node, ReactFlowStoreApi } from '../../types';
 import { errorMessages } from '@xyflow/system';
 
 export function getMouseHandler(
   id: string,
-  getState: StoreApi<ReactFlowState>['getState'],
+  getState: ReactFlowStoreApi['getState'],
   handler?: (event: MouseEvent, node: Node) => void
 ) {
   return handler === undefined
@@ -29,8 +27,8 @@ export function handleNodeClick({
 }: {
   id: string;
   store: {
-    getState: StoreApi<ReactFlowState>['getState'];
-    setState: StoreApi<ReactFlowState>['setState'];
+    getState: ReactFlowStoreApi['getState'];
+    setState: ReactFlowStoreApi['setState'];
   };
   unselect?: boolean;
   nodeRef?: RefObject<HTMLDivElement>;

--- a/packages/react/src/components/ReactFlowProvider/index.tsx
+++ b/packages/react/src/components/ReactFlowProvider/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from 'react';
+import { useRef, type ReactNode, useEffect } from 'react';
 import { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 
 import { Provider } from '../../contexts/RFStoreContext';
@@ -30,7 +30,46 @@ function ReactFlowProvider({
       height: initialHeight,
       fitView,
     });
+
+    // Start batching all subsequent updates when the store is created...
+    storeRef.current?.unsafe_startBatching();
   }
+
+  // ...and stop batching after the first render.
+  //
+  // This optimizes all independent store updates that various React Flow
+  // components perform from `useEffect` upon mounting – e.g.:
+  // - https://github.com/xyflow/xyflow/blob/8fe8f73ed3d7fc2a14b2ecbefffb1b988b2edaf8/packages/react/src/hooks/useGlobalKeyHandler.ts#L35
+  // - https://github.com/xyflow/xyflow/blob/8fe8f73ed3d7fc2a14b2ecbefffb1b988b2edaf8/packages/react/src/components/StoreUpdater/index.tsx#L167
+  // - and several more by batching them together and treating them as a single
+  //   store update.
+  //
+  // Without batching, each of these updates would update the state – and cause
+  // Zustand to notify every listeners and re-run every selector.
+  // - In React 17 and below, that will trigger a synchronous React rerender for
+  //   every selector that returns new data. (React 18 batches all synchronous
+  //   rerenders: https://github.com/reactwg/react-18/discussions/21 – so,
+  //   luckily, it’s not an issue with the latest versions.)
+  // - And no matter the version of React, that will re-evaluate every selector
+  //   several times in a row, which gets pricey. (Re-evaluating all selectors
+  //   just once costs ~20 ms with 6× CPU slowdown on an M2 Pro MacBook Pro).
+  //
+  // Implementation details:
+  // - To stop batching, we use `useEffect`, and we put that `useEffect` in the
+  //   topmost React component. React calls all `useEffect` definitions from
+  //   bottom to top (https://stackoverflow.com/a/75509568/1192426), so this
+  //   `useEffect` will be called after all other `useEffect` definitions in its
+  //   children.
+  // - We use `useRef` to track whether this is the first render. We can’t just
+  //   do `useEffect(() => { unsafe_stopBatching() }, [])` since React’s Strict
+  //   Mode will call it twice.
+  const firstRenderCompleted = useRef<boolean>(false);
+  useEffect(() => {
+    if (!firstRenderCompleted.current) {
+      storeRef.current?.unsafe_stopBatching();
+      firstRenderCompleted.current = true;
+    }
+  }, []);
 
   return <Provider value={storeRef.current}>{children}</Provider>;
 }

--- a/packages/react/src/components/ReactFlowProvider/index.tsx
+++ b/packages/react/src/components/ReactFlowProvider/index.tsx
@@ -1,10 +1,9 @@
 import { useRef, type ReactNode } from 'react';
-import { type StoreApi } from 'zustand';
 import { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 
 import { Provider } from '../../contexts/RFStoreContext';
 import { createRFStore } from '../../store';
-import type { ReactFlowState, Node, Edge } from '../../types';
+import type { Node, Edge, ReactFlowStoreApi } from '../../types';
 
 function ReactFlowProvider({
   children,
@@ -21,7 +20,7 @@ function ReactFlowProvider({
   initialHeight?: number;
   fitView?: boolean;
 }) {
-  const storeRef = useRef<UseBoundStoreWithEqualityFn<StoreApi<ReactFlowState>> | null>(null);
+  const storeRef = useRef<UseBoundStoreWithEqualityFn<ReactFlowStoreApi> | null>(null);
 
   if (!storeRef.current) {
     storeRef.current = createRFStore({

--- a/packages/react/src/components/StoreUpdater/index.tsx
+++ b/packages/react/src/components/StoreUpdater/index.tsx
@@ -3,13 +3,11 @@
  * We distinguish between values we can update directly with `useDirectStoreUpdater` (like `snapGrid`)
  * and values that have a dedicated setter function in the store (like `setNodes`).
  */
-import { useEffect } from 'react';
-import { StoreApi } from 'zustand';
+import { useEffect, useRef } from 'react';
 import { shallow } from 'zustand/shallow';
-import { devWarn, type CoordinateExtent } from '@xyflow/system';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
-import type { Node, Edge, ReactFlowState, ReactFlowProps, ReactFlowStore } from '../../types';
+import type { ReactFlowState, ReactFlowProps } from '../../types';
 
 type StoreUpdaterProps = Pick<
   ReactFlowProps,
@@ -76,80 +74,7 @@ const selector = (s: ReactFlowState) => ({
   reset: s.reset,
 });
 
-function useStoreUpdater<T>(value: T | undefined, setStoreAction: (param: T) => void) {
-  useEffect(() => {
-    if (typeof value !== 'undefined') {
-      setStoreAction(value);
-    }
-  }, [value]);
-}
-
-// updates with values in store that don't have a dedicated setter function
-function useDirectStoreUpdater(
-  key: keyof ReactFlowStore,
-  value: unknown,
-  setState: StoreApi<ReactFlowState>['setState']
-) {
-  useEffect(() => {
-    if (typeof value !== 'undefined') {
-      setState({ [key]: value });
-    }
-  }, [value]);
-}
-
-const StoreUpdater = ({
-  nodes,
-  edges,
-  defaultNodes,
-  defaultEdges,
-  onConnect,
-  onConnectStart,
-  onConnectEnd,
-  onClickConnectStart,
-  onClickConnectEnd,
-  nodesDraggable,
-  nodesConnectable,
-  nodesFocusable,
-  edgesFocusable,
-  edgesUpdatable,
-  elevateNodesOnSelect,
-  minZoom,
-  maxZoom,
-  nodeExtent,
-  onNodesChange,
-  onEdgesChange,
-  elementsSelectable,
-  connectionMode,
-  snapGrid,
-  snapToGrid,
-  translateExtent,
-  connectOnClick,
-  defaultEdgeOptions,
-  fitView,
-  fitViewOptions,
-  onNodesDelete,
-  onEdgesDelete,
-  onDelete,
-  onNodeDrag,
-  onNodeDragStart,
-  onNodeDragStop,
-  onSelectionDrag,
-  onSelectionDragStart,
-  onSelectionDragStop,
-  onMoveStart,
-  onMove,
-  onMoveEnd,
-  noPanClassName,
-  nodeOrigin,
-  rfId,
-  autoPanOnConnect,
-  autoPanOnNodeDrag,
-  onError,
-  connectionRadius,
-  isValidConnection,
-  selectNodesOnDrag,
-  nodeDragThreshold,
-}: StoreUpdaterProps) => {
+const StoreUpdater = (props: StoreUpdaterProps) => {
   const {
     setNodes,
     setEdges,
@@ -163,64 +88,99 @@ const StoreUpdater = ({
   const store = useStoreApi();
 
   useEffect(() => {
-    const edgesWithDefaults = defaultEdges?.map((e) => ({ ...e, ...defaultEdgeOptions }));
-    setDefaultNodesAndEdges(defaultNodes, edgesWithDefaults);
+    const edgesWithDefaults = props.defaultEdges?.map((e) => ({ ...e, ...props.defaultEdgeOptions }));
+    setDefaultNodesAndEdges(props.defaultNodes, edgesWithDefaults);
 
     return () => {
       reset();
     };
   }, []);
 
-  useDirectStoreUpdater('defaultEdgeOptions', defaultEdgeOptions, store.setState);
-  useDirectStoreUpdater('connectionMode', connectionMode, store.setState);
-  useDirectStoreUpdater('onConnect', onConnect, store.setState);
-  useDirectStoreUpdater('onConnectStart', onConnectStart, store.setState);
-  useDirectStoreUpdater('onConnectEnd', onConnectEnd, store.setState);
-  useDirectStoreUpdater('onClickConnectStart', onClickConnectStart, store.setState);
-  useDirectStoreUpdater('onClickConnectEnd', onClickConnectEnd, store.setState);
-  useDirectStoreUpdater('nodesDraggable', nodesDraggable, store.setState);
-  useDirectStoreUpdater('nodesConnectable', nodesConnectable, store.setState);
-  useDirectStoreUpdater('nodesFocusable', nodesFocusable, store.setState);
-  useDirectStoreUpdater('edgesFocusable', edgesFocusable, store.setState);
-  useDirectStoreUpdater('edgesUpdatable', edgesUpdatable, store.setState);
-  useDirectStoreUpdater('elementsSelectable', elementsSelectable, store.setState);
-  useDirectStoreUpdater('elevateNodesOnSelect', elevateNodesOnSelect, store.setState);
-  useDirectStoreUpdater('snapToGrid', snapToGrid, store.setState);
-  useDirectStoreUpdater('snapGrid', snapGrid, store.setState);
-  useDirectStoreUpdater('onNodesChange', onNodesChange, store.setState);
-  useDirectStoreUpdater('onEdgesChange', onEdgesChange, store.setState);
-  useDirectStoreUpdater('connectOnClick', connectOnClick, store.setState);
-  useDirectStoreUpdater('fitViewOnInit', fitView, store.setState);
-  useDirectStoreUpdater('fitViewOnInitOptions', fitViewOptions, store.setState);
-  useDirectStoreUpdater('onNodesDelete', onNodesDelete, store.setState);
-  useDirectStoreUpdater('onEdgesDelete', onEdgesDelete, store.setState);
-  useDirectStoreUpdater('onDelete', onDelete, store.setState);
-  useDirectStoreUpdater('onNodeDrag', onNodeDrag, store.setState);
-  useDirectStoreUpdater('onNodeDragStart', onNodeDragStart, store.setState);
-  useDirectStoreUpdater('onNodeDragStop', onNodeDragStop, store.setState);
-  useDirectStoreUpdater('onSelectionDrag', onSelectionDrag, store.setState);
-  useDirectStoreUpdater('onSelectionDragStart', onSelectionDragStart, store.setState);
-  useDirectStoreUpdater('onSelectionDragStop', onSelectionDragStop, store.setState);
-  useDirectStoreUpdater('onMove', onMove, store.setState);
-  useDirectStoreUpdater('onMoveStart', onMoveStart, store.setState);
-  useDirectStoreUpdater('onMoveEnd', onMoveEnd, store.setState);
-  useDirectStoreUpdater('noPanClassName', noPanClassName, store.setState);
-  useDirectStoreUpdater('nodeOrigin', nodeOrigin, store.setState);
-  useDirectStoreUpdater('rfId', rfId, store.setState);
-  useDirectStoreUpdater('autoPanOnConnect', autoPanOnConnect, store.setState);
-  useDirectStoreUpdater('autoPanOnNodeDrag', autoPanOnNodeDrag, store.setState);
-  useDirectStoreUpdater('onError', onError || devWarn, store.setState);
-  useDirectStoreUpdater('connectionRadius', connectionRadius, store.setState);
-  useDirectStoreUpdater('isValidConnection', isValidConnection, store.setState);
-  useDirectStoreUpdater('selectNodesOnDrag', selectNodesOnDrag, store.setState);
-  useDirectStoreUpdater('nodeDragThreshold', nodeDragThreshold, store.setState);
+  const fieldsToTrack: (keyof StoreUpdaterProps)[] = [
+    'nodes',
+    'edges',
+    'defaultNodes',
+    'defaultEdges',
+    'onConnect',
+    'onConnectStart',
+    'onConnectEnd',
+    'onClickConnectStart',
+    'onClickConnectEnd',
+    'nodesDraggable',
+    'nodesConnectable',
+    'nodesFocusable',
+    'edgesFocusable',
+    'edgesUpdatable',
+    'elevateNodesOnSelect',
+    'minZoom',
+    'maxZoom',
+    'nodeExtent',
+    'onNodesChange',
+    'onEdgesChange',
+    'elementsSelectable',
+    'connectionMode',
+    'snapGrid',
+    'snapToGrid',
+    'translateExtent',
+    'connectOnClick',
+    'defaultEdgeOptions',
+    'fitView',
+    'fitViewOptions',
+    'onNodesDelete',
+    'onEdgesDelete',
+    'onDelete',
+    'onNodeDrag',
+    'onNodeDragStart',
+    'onNodeDragStop',
+    'onSelectionDrag',
+    'onSelectionDragStart',
+    'onSelectionDragStop',
+    'onMoveStart',
+    'onMove',
+    'onMoveEnd',
+    'noPanClassName',
+    'nodeOrigin',
+    'rfId',
+    'autoPanOnConnect',
+    'autoPanOnNodeDrag',
+    'onError',
+    'connectionRadius',
+    'isValidConnection',
+    'selectNodesOnDrag',
+    'nodeDragThreshold',
+  ];
+  const previousFields = useRef<Partial<StoreUpdaterProps>>({});
 
-  useStoreUpdater<Node[]>(nodes, setNodes);
-  useStoreUpdater<Edge[]>(edges, setEdges);
-  useStoreUpdater<number>(minZoom, setMinZoom);
-  useStoreUpdater<number>(maxZoom, setMaxZoom);
-  useStoreUpdater<CoordinateExtent>(translateExtent, setTranslateExtent);
-  useStoreUpdater<CoordinateExtent>(nodeExtent, setNodeExtent);
+  useEffect(
+    () => {
+      store.batchUpdates(() => {
+        for (const fieldName of fieldsToTrack) {
+          const fieldValue = props[fieldName];
+          const previousFieldValue = previousFields.current[fieldName];
+
+          if (fieldValue === previousFieldValue) continue;
+          if (typeof props[fieldName] === 'undefined') continue;
+
+          // Custom handling for some fields
+          if (fieldName === 'nodes') setNodes(fieldValue as any);
+          else if (fieldName === 'edges') setEdges(fieldValue as any);
+          else if (fieldName === 'minZoom') setMinZoom(fieldValue as any);
+          else if (fieldName === 'maxZoom') setMaxZoom(fieldValue as any);
+          else if (fieldName === 'translateExtent') setTranslateExtent(fieldValue as any);
+          else if (fieldName === 'nodeExtent') setNodeExtent(fieldValue as any);
+          // Renamed fields
+          else if (fieldName === 'fitView') store.setState({ fitViewOnInit: fieldValue as any });
+          else if (fieldName === 'fitViewOptions') store.setState({ fitViewOnInitOptions: fieldValue as any });
+          // General case
+          else store.setState({ [fieldName]: fieldValue });
+        }
+      });
+
+      previousFields.current = props;
+    },
+    // Only re-run the effect if one of the fields we track changes
+    fieldsToTrack.map((fieldName) => props[fieldName])
+  );
 
   return null;
 };

--- a/packages/react/src/container/NodeRenderer/index.tsx
+++ b/packages/react/src/container/NodeRenderer/index.tsx
@@ -103,7 +103,6 @@ const NodeRenderer = (props: NodeRendererProps) => {
           height: node.computed?.height ?? node.height ?? 0,
           origin: node.origin || props.nodeOrigin,
         });
-        const initialized = (!!node.computed?.width && !!node.computed?.height) || (!!node.width && !!node.height);
 
         return (
           <NodeComponent
@@ -140,7 +139,8 @@ const NodeRenderer = (props: NodeRendererProps) => {
             isParent={!!node[internalsSymbol]?.isParent}
             noDragClassName={props.noDragClassName}
             noPanClassName={props.noPanClassName}
-            initialized={initialized}
+            // Hard-code to false; this will be overridden with styles in updateNodeDimensions() in Zustand
+            initialized={false}
             rfId={props.rfId}
             disableKeyboardA11y={props.disableKeyboardA11y}
             ariaLabel={node.ariaLabel}

--- a/packages/react/src/container/ZoomPane/index.tsx
+++ b/packages/react/src/container/ZoomPane/index.tsx
@@ -68,10 +68,30 @@ const ZoomPane = ({
           onViewportChange?.({ x: transform[0], y: transform[1], zoom: transform[2] });
 
           if (!isControlledViewport) {
-            store.setState({ transform });
+            store.setState((state) => {
+              if (
+                transform[0] === state.transform[0] &&
+                transform[1] === state.transform[1] &&
+                transform[2] === state.transform[2]
+              ) {
+                // Nothing has changed, no need to trigger a state update
+                return state;
+              }
+
+              return { transform };
+            });
           }
         },
-        onDraggingChange: (paneDragging: boolean) => store.setState({ paneDragging }),
+        onDraggingChange: (paneDragging: boolean) => {
+          return store.setState((state) => {
+            if (paneDragging === state.paneDragging) {
+              // Nothing has changed, no need to trigger a state update
+              return state;
+            }
+
+            return { paneDragging };
+          });
+        },
         onPanZoomStart: (event, vp) => {
           const { onViewportChangeStart, onMoveStart } = store.getState();
           onMoveStart?.(event, vp);

--- a/packages/react/src/hooks/useResizeHandler.ts
+++ b/packages/react/src/hooks/useResizeHandler.ts
@@ -17,7 +17,14 @@ function useResizeHandler(domNode: MutableRefObject<HTMLDivElement | null>): voi
         store.getState().onError?.('004', errorMessages['error004']());
       }
 
-      store.setState({ width: size.width || 500, height: size.height || 500 });
+      store.setState((state) => {
+        if (size.width === state.width && size.height === state.height) {
+          // Nothing has changed, no need to trigger a state update
+          return state;
+        }
+
+        return { width: size.width || 500, height: size.height || 500 };
+      });
     };
 
     if (domNode.current) {

--- a/packages/react/src/hooks/useStore.ts
+++ b/packages/react/src/hooks/useStore.ts
@@ -36,6 +36,7 @@ const useStoreApi = () => {
       setState: store.setState,
       subscribe: store.subscribe,
       destroy: store.destroy,
+      batchUpdates: store.batchUpdates,
     }),
     [store]
   );

--- a/packages/react/src/store/batchMiddleware.ts
+++ b/packages/react/src/store/batchMiddleware.ts
@@ -1,0 +1,86 @@
+import type { StateCreator, StoreMutatorIdentifier, Mutate, StoreApi } from 'zustand';
+
+// Types are adopted from https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#middleware-that-changes-the-store-type
+export type Write<T extends object, U extends object> = Omit<T, keyof U> & U;
+type Cast<T, U> = T extends U ? T : U;
+
+export type BatchUpdatesFn = (fn: () => void) => void;
+
+type BatchMiddleware = <
+  T,
+  Mps extends [StoreMutatorIdentifier, unknown][] = [],
+  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+>(
+  f: StateCreator<T, [...Mps, ['batchUpdates', BatchUpdatesFn]], Mcs>
+) => StateCreator<T, Mps, [['batchUpdates', BatchUpdatesFn], ...Mcs]>;
+
+declare module 'zustand' {
+  interface StoreMutators<S, A> {
+    batchUpdates: Write<Cast<S, object>, { batchUpdates: BatchUpdatesFn }>;
+  }
+}
+
+type BatchMiddlewareImpl = <T>(stateCreator: StateCreator<T, [], []>) => StateCreator<T, [], []>;
+
+const batchMiddleware: BatchMiddlewareImpl = (stateCreator) => (originalSet, originalGet, _store) => {
+  type StoreType = ReturnType<typeof stateCreator>;
+
+  const store = _store as Mutate<StoreApi<StoreType>, [['batchUpdates', BatchUpdatesFn]]>;
+
+  // End of TS boilerplate, start of actual middleware implementation:
+  let batchingState: { isBatching: true; intermediateStoreState: StoreType } | { isBatching: false } = {
+    isBatching: false,
+  };
+
+  const batchingGet: typeof originalGet = () => {
+    if (!batchingState.isBatching) return originalGet();
+
+    return batchingState.intermediateStoreState;
+  };
+
+  const batchingSet: typeof originalSet = (partial, replace) => {
+    if (!batchingState.isBatching) return originalSet(partial);
+
+    if (replace) {
+      // `replace` is true when the user explicitly passes it into `set()`: https://docs.pmnd.rs/zustand/guides/immutable-state-and-merging#replace-flag
+      // If we ever need to support this, we can do the following:
+      // - check if a user is calling `set()` with replace=true; and if yes,
+      //   - replace `intermediateStoreState` with the new state
+      //   - set a flag that will tell `unsafe_stopBatching()` to call `store.setState()` with replace=true
+      //   - keep batching subsequent updates as usual
+      throw new Error('Replacing the whole state inside `store.batchUpdates()` is not implemented');
+    }
+
+    if (partial instanceof Function) {
+      // `partial instanceof Function` is true when the user passes a function instead of a partial state object into `set()`:
+      //   storeApi.setState(state => ({ foo: state.nodes.length > 0 ? 'bar' : 'baz' }))
+      batchingState.intermediateStoreState = {
+        ...batchingState.intermediateStoreState,
+        ...partial(batchingState.intermediateStoreState),
+      };
+    }
+
+    batchingState.intermediateStoreState = { ...batchingState.intermediateStoreState, ...partial };
+  };
+
+  // Replace the original `getState()` and `setState()` as they may be called
+  // in-between batching – and should
+  // 1) provide correct (not stale) state values when called,
+  // 2) batch updates instead of applying them immediately.
+  store.getState = batchingGet;
+  store.setState = batchingSet;
+
+  store.batchUpdates = (fn) => {
+    batchingState = { isBatching: true, intermediateStoreState: originalGet() };
+
+    fn();
+
+    originalSet(batchingState.intermediateStoreState);
+    batchingState = { isBatching: false };
+  };
+
+  return stateCreator(batchingSet, batchingGet, _store);
+  // End of actual middleware implementation
+};
+
+export default batchMiddleware as unknown as BatchMiddleware;

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -23,6 +23,7 @@ import type {
   UnselectNodesAndEdgesParams,
   FitViewOptions,
 } from '../types';
+import batchMiddleware from './batchMiddleware';
 
 const createRFStore = ({
   nodes,
@@ -37,8 +38,8 @@ const createRFStore = ({
   height?: number;
   fitView?: boolean;
 }) =>
-  createWithEqualityFn<ReactFlowState>(
-    (set, get) => ({
+  createWithEqualityFn<ReactFlowState>()(
+    batchMiddleware((set, get) => ({
       ...getInitialState({ nodes, edges, width, height, fitView }),
       setNodes: (nodes: Node[]) => {
         const { nodeLookup, nodeOrigin, elevateNodesOnSelect } = get();
@@ -333,7 +334,7 @@ const createRFStore = ({
         // leads to an emtpy nodes array at the beginning.
         // set({ ...getInitialState() });
       },
-    }),
+    })),
     Object.is
   );
 

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -135,6 +135,16 @@ const createRFStore = ({
         // attribute which they get from this handler.
         set({ nodes: nextNodes, fitViewDone: nextFitViewDone });
 
+        // Here, we are making all nodes visible once we have the dimensions.
+        if (!document.querySelector('#initialized-styles')) {
+          const style = document.createElement('style');
+          style.id = 'initialized-styles';
+          document.head.appendChild(style);
+
+          const css = `.react-flow__node { visibility: visible !important; }`;
+          style.appendChild(document.createTextNode(css));
+        }
+
         if (changes?.length > 0) {
           onNodesChange?.(changes);
         }

--- a/packages/react/src/store/utils.ts
+++ b/packages/react/src/store/utils.ts
@@ -1,5 +1,4 @@
-import type { StoreApi } from 'zustand';
-import type { Edge, EdgeSelectionChange, Node, NodeSelectionChange, ReactFlowState } from '../types';
+import type { Edge, EdgeSelectionChange, Node, NodeSelectionChange, ReactFlowStoreApi } from '../types';
 
 export function handleControlledSelectionChange<NodeOrEdge extends Node | Edge>(
   changes: NodeSelectionChange[] | EdgeSelectionChange[],
@@ -19,8 +18,8 @@ export function handleControlledSelectionChange<NodeOrEdge extends Node | Edge>(
 type UpdateNodesAndEdgesParams = {
   changedNodes: NodeSelectionChange[] | null;
   changedEdges: EdgeSelectionChange[] | null;
-  get: StoreApi<ReactFlowState>['getState'];
-  set: StoreApi<ReactFlowState>['setState'];
+  get: ReactFlowStoreApi['getState'];
+  set: ReactFlowStoreApi['setState'];
 };
 
 export function updateNodesAndEdgesSelections({ changedNodes, changedEdges, get, set }: UpdateNodesAndEdgesParams) {

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -41,6 +41,9 @@ import type {
   OnDelete,
 } from '.';
 
+import type { StoreApi } from 'zustand';
+import type { BatchUpdatesFn, Write } from '../store/batchMiddleware';
+
 export type ReactFlowStore = {
   rfId: string;
   width: number;
@@ -162,3 +165,5 @@ export type ReactFlowActions = {
 };
 
 export type ReactFlowState = ReactFlowStore & ReactFlowActions;
+
+export type ReactFlowStoreApi = Write<StoreApi<ReactFlowState>, { batchUpdates: BatchUpdatesFn }>;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -42,7 +42,7 @@ import type {
 } from '.';
 
 import type { StoreApi } from 'zustand';
-import type { BatchUpdatesFn, Write } from '../store/batchMiddleware';
+import type { BatchUpdatesFn, StartStopBatchingFn, Write } from '../store/batchMiddleware';
 
 export type ReactFlowStore = {
   rfId: string;
@@ -166,4 +166,7 @@ export type ReactFlowActions = {
 
 export type ReactFlowState = ReactFlowStore & ReactFlowActions;
 
-export type ReactFlowStoreApi = Write<StoreApi<ReactFlowState>, { batchUpdates: BatchUpdatesFn }>;
+export type ReactFlowStoreApi = Write<
+  StoreApi<ReactFlowState>,
+  { batchUpdates: BatchUpdatesFn; unsafe_startBatching: StartStopBatchingFn; unsafe_stopBatching: StartStopBatchingFn }
+>;


### PR DESCRIPTION
This PR does two things:

**1\) Batching.** The PR introduces a new Zustand middleware and three new store API:

- `storeApi.batchUpdates()`
- `storeApi.unsafe_startBatching()`
- `storeApi.unsafe_stopBatching()`

It then applies these APIs to batch initial store updates (1e31fbdebb7c12f345d0f9f83b1cac4aa54ba2e7 and 3066b646b711b537da000db689e8993845d4d5d1), plus prevents a few additional store updates (4deee6ffe36e8f3ed7876ec468d223874cccfa7f). This improves initial rendering costs by ~10%, compared to `next`.

10% ain’t much, but:

**2\) CSS-based updates (POC).** This PR also gets rid of an extra `NodeComponent` update, replacing it with a single update of styles (ee555b9ed0064a7a9597ec172c8d26042338895d). This saves another ~10% of rendering costs.

This change is a Proof of Concept since I had time to prototype it but not to finalize it.

### Background

If you record a Chrome DevTools trace of how the Stress example loads, you’ll see this:

![CleanShot 2023-11-28 at 01 00 36@2x](https://github.com/xyflow/xyflow/assets/2953267/94e3cbd9-9a53-44d0-9b27-3a8ed6d133a1)

There’s a lot of stuff happening here, so let’s highlight the most important pieces:

![CleanShot 2023-11-28 at 01 00 50@2x](https://github.com/xyflow/xyflow/assets/2953267/9448f45b-0d78-4652-8900-838d7dea0469)

> _How do I know how it’s exactly these things happening there?_ I went over the recording and looked for some key names (“Evaluate Script” is bundle initialization, `renderRootSync` is a React render, `flushPassiveEffects` is `useEffect`s running). Then, I recorded a trace in React Profiler and matched the rough durations of each render with what I’m seeing in DevTools

Let’s walk over each of these one by one:

1. _Bundle init._ This is when your bundle `<script>` loads – and starts executing all modules defined in it, in the order of imports. This is fairly cheap, plus it’s app-dependent, so it’s not worth optimizing it. 
2. _First render._ This is when React has to render all components in the tree. Since this is the first render, we can’t optimize much there – _every_ component has to render.
3. _First render’s `useEffect`s_. This is when all `useEffect`s defined in all React Flow components execute. This is fairly expensive, so this PR addresses this. We’ll talk about this below, in the “Batching” section.
4. _Second render._ This render is a cheaper one, so this PR skips over it.
5. _Third render._ This render is also expensive; this PR addresses it as well. We’ll also talk about this below, in the “CSS-Based Updates” section.
6. _Subsequent renders._ These renders are fairly cheap and happen _after_ the grid is rendered, so this PR skips over them.

### Batching

If you zoom into the area that runs first render’s `useEffect`s [remember, it’s the area below React’s internal `flushPassiveEffects` method], you’ll notice an interesting detail: a lot (most?) of the time in that area is spent calling Zustand’s `setState`:

![CleanShot 2023-11-28 at 01 15 44@2x](https://github.com/xyflow/xyflow/assets/2953267/b7026064-b15e-4295-9b0a-48487b55b722)

Debugging this (eg by adding [the logger middleware](https://github.com/pmndrs/zustand?tab=readme-ov-file#middleware) and trying to log where these `setState`s are coming from) will reveal a curious finding:

- React Flow has a lot of separate components with separate `useEffect`s that call `setState`.

  (Examples: [`StoreUpdater`](https://github.com/xyflow/xyflow/blob/8fe8f73ed3d7fc2a14b2ecbefffb1b988b2edaf8/packages/react/src/components/StoreUpdater/index.tsx#L165-L223) (a few dozen `useEffect`s!), [`ZoomPane`](https://github.com/xyflow/xyflow/blob/8fe8f73ed3d7fc2a14b2ecbefffb1b988b2edaf8/packages/react/src/container/ZoomPane/index.tsx#L94-L98), half a dozen of others)

- When all these components mount, their `useEffect`s run for the first time
- This triggers a lot of independent consecutive `useEffect` calls, each updating the store field by field

Normally, a lot of `useEffect`s aren’t an issue – as long as they’re cheap. However, in our case, calling `setState` isn’t cheap. Every `setState` call costs ~3 ms on my M2 Pro MacBook Pro (20% of the frame budget!) – with no CPU throttling. This is because:
- The Stress example has _several thousands_ of `useStore` selectors! Whenever the store updates, Zustand has to re-run _every_ selector, which (with several thousands of them) gets expensive
- Additionally, some of the selectors use shallow comparison, which means they have to do a loop over their return value every time. This increases the selector costs even further

**Optimizing.** Optimizing this is tricky. You can try to reduce the number of selectors. You can try to find the most expensive selectors and optimize them. Or – you can reduce the number of `setState` calls.

This PR does the latter. It implements a middleware that allows to batch multiple `set()` and `setState()` calls into one. And it enables batching for two critical parts of the app:

- `StoreUpdater`: this component, today, has a separate `useEffect` for every prop that changes. If a user changes three props, today, we’ll run three `useEffect`s and call `setState` three times. When the app initializes, `StoreUpdater` runs ~50 `useEffect`s and calls `setState` 50 times. Thus gets expensive.

   This PR replaces all these `useEffect`s with one – and then batches all updates that happen inside it. 1e31fbdebb7c12f345d0f9f83b1cac4aa54ba2e7

- App init: when the app initializes, apart from `StoreUpdater`, half-a-dozen of other components also call `setState()` inside their `useEffect()`s. To batch these updates, we also enable batching when the app renders – and disable it when the app finishes initializing. 3066b646b711b537da000db689e8993845d4d5d1

> _“Wait, what the heck is batching?”_ “Batching” means “take several independent operations and apply them at once, as a single operation”. In our case, we take several independent `setState` calls and apply them as one `setState()`.
> 
> Batching is similar to [React 18 render batching](https://github.com/reactwg/react-18/discussions/21) or SQL transactions.

#### Batching API design

Batching is implemented through a middleware that extends the store with three new methods:

```js
// METHOD 1: batchUpdates – batches all `setState()` calls that happen inside it
storeApi.batchUpdates(() => {
  store.setState({ a: 5 }); // → no store subscribers are called
  store.setState({ a: 6 }); // → still, no store subscribers are called
  store.getState() // → returns { a: 6 } as expected –
    // this state isn‘t committed to the store yet, but we keep track of it
  
  store.setNodes(...) // → this is also batched, no store subscribers are called
  someMethodThatUpdatesTheStoreInside() // → this also workds
});
// → Finally, the state is committed to the store, and all `useSelector()`s re-run

// METHODS 2 and 3: `unsafe_startBatching()` and `unsafe_stopBatching()` –
// work like `batchUpdates()` but can be called from separate parts of the code
storeApi.unsafe_startBatching();
setTimeout(() => storeApi.unsafe_stopBatching(), 10);
// → all `setState()` calls within the next 10 ms are going to be batched
```

The batching API and implementation are inspired by [React’s own `unstable_batchUpdates()` (aka Redux’s `batch()`)](https://react-redux.js.org/api/batch). 

### CSS-Based Updates

If you profile the third render using React Profiler, you‘ll notice that 1) it’s expensive; 2) a relatively big chunk of its cost is spent re-rendering all `NodeWrapper` elements, 3) all `NodeWrapper`s rerender because their `initialized` prop changes.

![CleanShot 2023-11-28 at 01 59 51@2x](https://github.com/xyflow/xyflow/assets/2953267/22c73c92-639f-4ad4-af7a-872a772a9650)

The `initialized` prop controls node visibility: when it flips to `true`, nodes go from `visibility: hidden` to `visibility: visible`. And it flips to `true` for all nodes at once – when the nodes get their dimensions measured for the first time.

Question: why don’t we set `visibility: visible` using CSS instead – and save the 100 ms we spend on rerendering all nodes?

This is what commit ee555b9ed0064a7a9597ec172c8d26042338895d does.

This commit is a Proof of Concept – it works, but the implementation is far from optimal, plus it doesn’t account for edge cases (can there be cases when not all nodes will become visible at once?). But it works, it‘s really simple, and it saves 10% of rendering costs.

### Performance Wins

In total, changes in this PR seem to cut around 20% of render-blocking costs (~1170 ms → 990 ms):

**Before ([trace link](https://trace.cafe/t/WITRynbK34))**

![CleanShot 2023-11-28 at 00 57 09@2x](https://github.com/xyflow/xyflow/assets/2953267/166ab2e6-88d6-4b21-a07c-bc5c957f5faa)

**After ([trace link](https://trace.cafe/t/YJ1T4Eoljw))**

![Screenshot 2023-11-28 at 00 53 09](https://github.com/xyflow/xyflow/assets/2953267/c07be709-3d41-4cc2-9d41-fd152a60b60b)

These savings will be offset a little by https://github.com/xyflow/xyflow/pull/3668#issuecomment-1826986591, but I still expect a net improvement.