### PR TITLE
refactor(nodes): use initialWidth/initialHeight instead of width/height

### DIFF
--- a/examples/astro-xyflow/src/components/ReactFlowExample/index.tsx
+++ b/examples/astro-xyflow/src/components/ReactFlowExample/index.tsx
@@ -17,8 +17,8 @@ import CustomNode from './CustomNode';
 import '@xyflow/react/dist/style.css';
 
 const nodeSize = {
-  width: 100,
-  height: 40,
+  initialWidth: 100,
+  initialHeight: 40,
 };
 
 const initialNodes: Node[] = [
@@ -32,8 +32,8 @@ const initialNodes: Node[] = [
       {
         type: 'source',
         position: Position.Bottom,
-        x: nodeSize.width * 0.5,
-        y: nodeSize.height,
+        x: nodeSize.initialWidth * 0.5,
+        y: nodeSize.initialHeight,
       },
     ],
   },
@@ -46,13 +46,13 @@ const initialNodes: Node[] = [
       {
         type: 'source',
         position: Position.Bottom,
-        x: nodeSize.width * 0.5,
-        y: nodeSize.height,
+        x: nodeSize.initialWidth * 0.5,
+        y: nodeSize.initialHeight,
       },
       {
         type: 'target',
         position: Position.Top,
-        x: nodeSize.width * 0.5,
+        x: nodeSize.initialWidth * 0.5,
         y: 0,
       },
     ],
@@ -66,13 +66,13 @@ const initialNodes: Node[] = [
       {
         type: 'source',
         position: Position.Bottom,
-        x: nodeSize.width * 0.5,
-        y: nodeSize.height,
+        x: nodeSize.initialWidth * 0.5,
+        y: nodeSize.initialHeight,
       },
       {
         type: 'target',
         position: Position.Top,
-        x: nodeSize.width * 0.5,
+        x: nodeSize.initialWidth * 0.5,
         y: 0,
       },
     ],

--- a/examples/astro-xyflow/src/components/SvelteFlowExample/index.svelte
+++ b/examples/astro-xyflow/src/components/SvelteFlowExample/index.svelte
@@ -11,8 +11,8 @@
       data: { label: 'Node 0' },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      width: 100,
-      height: 40,
+      initialWidth: 100,
+      initialHeight: 40,
       handles: [
         { type: 'source', x: 100, y: 20, position: Position.Right },
         { type: 'target', x: 0, y: 20, position: Position.Left },
@@ -24,8 +24,8 @@
       data: { label: 'A' },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      width: 100,
-      height: 40,
+      initialWidth: 100,
+      initialHeight: 40,
       handles: [
         { type: 'source', x: 100, y: 20, position: Position.Right },
         { type: 'target', x: 0, y: 20, position: Position.Left },
@@ -37,8 +37,8 @@
       data: { label: 'B' },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      width: 100,
-      height: 40,
+      initialWidth: 100,
+      initialHeight: 40,
       handles: [
         { type: 'source', x: 100, y: 20, position: Position.Right },
         { type: 'target', x: 0, y: 20, position: Position.Left },
@@ -50,8 +50,8 @@
       data: { label: 'C' },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      width: 100,
-      height: 40,
+      initialWidth: 100,
+      initialHeight: 40,
       handles: [
         { type: 'source', x: 100, y: 20, position: Position.Right },
         { type: 'target', x: 0, y: 20, position: Position.Left },

--- a/examples/astro-xyflow/src/pages/index.astro
+++ b/examples/astro-xyflow/src/pages/index.astro
@@ -19,9 +19,9 @@ import SvelteFlowApp from '../components/SvelteFlowExample/index.svelte'
 	</head>
 	<body>
 		<h2>Svelte Flow</h2>
-		<SvelteFlowApp />
+		<SvelteFlowApp client:load />
 
 		<h2>React Flow</h2>
-		<ReactFlowApp />
+		<ReactFlowApp client:load />
 	</body>
 </html>

--- a/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
@@ -93,7 +93,12 @@ const NodeComponentWrapper = memo(function NodeComponentWrapper({
       y,
     };
   }, shallow);
-  if (!node || node.hidden || !(node.computed?.width || node.width) || !(node.computed?.height || node.height)) {
+  if (
+    !node ||
+    node.hidden ||
+    !(node.computed?.width || node.initialWidth) ||
+    !(node.computed?.height || node.initialHeight)
+  ) {
     return null;
   }
 
@@ -101,8 +106,8 @@ const NodeComponentWrapper = memo(function NodeComponentWrapper({
     <NodeComponent
       x={x}
       y={y}
-      width={node.computed?.width ?? node.width ?? 0}
-      height={node.computed?.height ?? node.height ?? 0}
+      width={node.computed?.width ?? node.initialWidth ?? 0}
+      height={node.computed?.height ?? node.initialHeight ?? 0}
       style={node.style}
       selected={!!node.selected}
       className={nodeClassNameFunc(node)}

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -123,19 +123,21 @@ export function NodeWrapper({
     return null;
   }
 
-  const width = node.width ?? undefined;
-  const height = node.height ?? undefined;
+  const initialWidth = node.initialWidth;
+  const initialHeight = node.initialHeight;
   const computedWidth = node.computed?.width;
   const computedHeight = node.computed?.height;
+  const inlineStyleWidth = computedWidth ? node.style?.width : initialWidth ?? node.style?.width;
+  const inlineStyleHeight = computedHeight ? node.style?.height : initialHeight ?? node.style?.height;
 
   const positionAbsoluteOrigin = getPositionWithOrigin({
     x: positionAbsoluteX,
     y: positionAbsoluteY,
-    width: computedWidth ?? width ?? 0,
-    height: computedHeight ?? height ?? 0,
+    width: computedWidth ?? initialWidth ?? 0,
+    height: computedHeight ?? initialHeight ?? 0,
     origin: node.origin || nodeOrigin,
   });
-  const initialized = (!!computedWidth && !!computedHeight) || (!!width && !!height);
+  const initialized = (!!computedWidth && !!computedHeight) || (!!initialWidth && !!initialHeight);
   const hasPointerEvents = isSelectable || isDraggable || onClick || onMouseEnter || onMouseMove || onMouseLeave;
 
   const onMouseEnterHandler = onMouseEnter ? (event: MouseEvent) => onMouseEnter(event, { ...node }) : undefined;
@@ -220,8 +222,8 @@ export function NodeWrapper({
         pointerEvents: hasPointerEvents ? 'all' : 'none',
         visibility: initialized ? 'visible' : 'hidden',
         ...node.style,
-        width: width ?? node.style?.width,
-        height: height ?? node.style?.height,
+        width: inlineStyleWidth,
+        height: inlineStyleHeight,
       }}
       data-id={id}
       data-testid={`rf__node-${id}`}

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -36,7 +36,7 @@ const getInitialState = ({
   let transform: Transform = [0, 0, 1];
 
   if (fitView && width && height) {
-    const nodesWithDimensions = nextNodes.filter((node) => node.width && node.height);
+    const nodesWithDimensions = nextNodes.filter((node) => node.initialWidth && node.initialHeight);
     const bounds = getNodesBounds(nodesWithDimensions, [0, 0]);
     const { x, y, zoom } = getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);
     transform = [x, y, zoom];

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -38,6 +38,8 @@
   export let height: NodeWrapperProps['height'] = undefined;
   export let dragHandle: NodeWrapperProps['dragHandle'] = undefined;
   export let initialized: NodeWrapperProps['initialized'] = false;
+  export let computedWidth: NodeWrapperProps['computedWidth'] = undefined;
+  export let computedHeight: NodeWrapperProps['computedHeight'] = undefined;
   let className: string = '';
   export { className as class };
 
@@ -133,6 +135,9 @@
 
     dispatch('nodeclick', { node, event });
   }
+
+  $: inlineStyleWidth = computedWidth ? '' : `width:${width}px;`;
+  $: inlineStyleHeight = computedHeight ? '' : `height:${height}px;`;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -170,9 +175,7 @@
     style:z-index={zIndex}
     style:transform="translate({positionOriginX}px, {positionOriginY}px)"
     style:visibility={initialized ? 'visible' : 'hidden'}
-    style="{style ?? ''}; {!width ? '' : `width:${width}px;`} {!height
-      ? ''
-      : `height:${height}px;`}"
+    style="{inlineStyleWidth} {inlineStyleHeight} {style ?? ''};"
     on:click={onSelectNodeHandler}
     on:mouseenter={(event) => dispatch('nodemouseenter', { node, event })}
     on:mouseleave={(event) => dispatch('nodemouseleave', { node, event })}

--- a/packages/svelte/src/lib/components/NodeWrapper/types.ts
+++ b/packages/svelte/src/lib/components/NodeWrapper/types.ts
@@ -30,4 +30,6 @@ export type NodeWrapperProps = Pick<
   zIndex: number;
   node: Node;
   initialized: boolean;
+  computedWidth?: number;
+  computedHeight?: number;
 };

--- a/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
+++ b/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
@@ -42,8 +42,8 @@
     {@const posOrigin = getPositionWithOrigin({
       x: node.computed?.positionAbsolute?.x ?? 0,
       y: node.computed?.positionAbsolute?.y ?? 0,
-      width: node.computed?.width ?? node.width ?? 0,
-      height: node.computed?.height ?? node.height ?? 0,
+      width: node.computed?.width ?? node.initialWidth ?? 0,
+      height: node.computed?.height ?? node.initialHeight ?? 0,
       origin: node.origin
     })}
     <NodeWrapper
@@ -74,10 +74,12 @@
       dragging={node.dragging}
       zIndex={node[internalsSymbol]?.z ?? 0}
       dragHandle={node.dragHandle}
-      width={node.width ?? undefined}
-      height={node.height ?? undefined}
+      width={node.initialWidth ?? undefined}
+      height={node.initialHeight ?? undefined}
+      computedWidth={node.computed?.width}
+      computedHeight={node.computed?.height}
       initialized={(!!node.computed?.width && !!node.computed?.height) ||
-        (!!node.width && !!node.height)}
+        (!!node.initialWidth && !!node.initialHeight)}
       {resizeObserver}
       on:nodeclick
       on:nodemouseenter

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -114,13 +114,13 @@
       {#if ariaLabel}<title id={labelledBy}>{ariaLabel}</title>{/if}
 
       {#each $nodes as node (node.id)}
-        {#if (node.computed?.width || node?.width) && (node.computed?.height || node.height)}
+        {#if (node.computed?.width || node?.initialWidth) && (node.computed?.height || node.initialHeight)}
           {@const pos = getNodePositionWithOrigin(node).positionAbsolute}
           <MinimapNode
             x={pos.x}
             y={pos.y}
-            width={node.computed?.width ?? node.width ?? 0}
-            height={node.computed?.height ?? node.height ?? 0}
+            width={node.computed?.width ?? node.initialWidth ?? 0}
+            height={node.computed?.height ?? node.initialHeight ?? 0}
             selected={node.selected}
             color={nodeColorFunc?.(node)}
             borderRadius={nodeBorderRadius}

--- a/packages/svelte/src/lib/plugins/NodeResizer/ResizeControl.svelte
+++ b/packages/svelte/src/lib/plugins/NodeResizer/ResizeControl.svelte
@@ -69,8 +69,11 @@
         onChange: (change: XYResizerChange) => {
           const node = $nodeLookup.get(id);
           if (node) {
-            node.height = change.isHeightChange ? change.height : node.height;
-            node.width = change.isWidthChange ? change.width : node.width;
+            const nextHeight = change.isHeightChange ? change.height : node.computed?.height;
+            const nextWidth = change.isWidthChange ? change.width : node.computed?.width;
+
+            node.style = `${node.style ?? ''}; height: ${nextHeight}px; width: ${nextWidth}px;`;
+
             node.position =
               change.isXPosChange || change.isYPosChange
                 ? { x: change.x, y: change.y }

--- a/packages/svelte/src/lib/store/initial-store.ts
+++ b/packages/svelte/src/lib/store/initial-store.ts
@@ -91,7 +91,7 @@ export const getInitialStore = ({
   let viewport: Viewport = { x: 0, y: 0, zoom: 1 };
 
   if (fitView && width && height) {
-    const nodesWithDimensions = nextNodes.filter((node) => node.width && node.height);
+    const nodesWithDimensions = nextNodes.filter((node) => node.initialWidth && node.initialHeight);
     const bounds = getNodesBounds(nodesWithDimensions, [0, 0]);
     viewport = getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);
   }
@@ -99,7 +99,7 @@ export const getInitialStore = ({
   return {
     flowId: writable<string | null>(null),
     nodes: createNodesStore(nextNodes, nodeLookup),
-    nodeLookup: readable<NodeLookup>(nodeLookup),
+    nodeLookup: readable<NodeLookup<Node>>(nodeLookup),
     edgeLookup: readable<EdgeLookup>(edgeLookup),
     visibleNodes: readable<Node[]>([]),
     edges: createEdgesStore(edges, connectionLookup, edgeLookup),

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -17,3 +17,5 @@ export type Node<
 export type NodeTypes = Record<string, ComponentType<SvelteComponent<NodeProps>>>;
 
 export type DefaultNodeOptions = Partial<Omit<Node, 'id'>>;
+
+export type NodeLookup = Map<string, Node>;

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -19,8 +19,8 @@ export type NodeBase<T = any, U extends string | undefined = string | undefined>
   connectable?: boolean;
   deletable?: boolean;
   dragHandle?: string;
-  width?: number | null;
-  height?: number | null;
+  initialWidth?: number;
+  initialHeight?: number;
   parentNode?: string;
   zIndex?: number;
   extent?: 'parent' | CoordinateExtent;

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -16,7 +16,10 @@ export type GetEdgePositionParams = {
 };
 
 function isNodeInitialized(node: NodeBase): boolean {
-  return !!(node?.[internalsSymbol]?.handleBounds || node?.handles?.length) && !!(node?.computed?.width || node?.width);
+  return (
+    !!(node?.[internalsSymbol]?.handleBounds || node?.handles?.length) &&
+    !!(node?.computed?.width || node?.initialWidth)
+  );
 }
 
 export function getEdgePosition(params: GetEdgePositionParams): EdgePosition | null {
@@ -75,8 +78,8 @@ function toHandleBounds(handles?: NodeHandle[]) {
   const target = [];
 
   for (const handle of handles) {
-    handle.width = handle.width || 1;
-    handle.height = handle.height || 1;
+    handle.width = handle.width ?? 1;
+    handle.height = handle.height ?? 1;
 
     if (handle.type === 'source') {
       source.push(handle as HandleElement);
@@ -94,8 +97,8 @@ function toHandleBounds(handles?: NodeHandle[]) {
 function getHandlePosition(position: Position, node: NodeBase, handle: HandleElement | null = null): number[] {
   const x = (handle?.x ?? 0) + (node.computed?.positionAbsolute?.x ?? 0);
   const y = (handle?.y ?? 0) + (node.computed?.positionAbsolute?.y ?? 0);
-  const width = handle?.width || (node?.computed?.width ?? node?.width ?? 0);
-  const height = handle?.height || (node?.computed?.height ?? node?.height ?? 0);
+  const width = handle?.width || (node?.computed?.width ?? node?.initialWidth ?? 0);
+  const height = handle?.height || (node?.computed?.height ?? node?.initialHeight ?? 0);
 
   switch (position) {
     case Position.Top:

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -70,8 +70,8 @@ export const nodeToRect = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Rec
 
   return {
     ...positionAbsolute,
-    width: node.computed?.width ?? node.width ?? 0,
-    height: node.computed?.height ?? node.height ?? 0,
+    width: node.computed?.width ?? node.initialWidth ?? 0,
+    height: node.computed?.height ?? node.initialHeight ?? 0,
   };
 };
 
@@ -80,8 +80,8 @@ export const nodeToBox = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Box 
 
   return {
     ...positionAbsolute,
-    x2: positionAbsolute.x + (node.computed?.width ?? node.width ?? 0),
-    y2: positionAbsolute.y + (node.computed?.height ?? node.height ?? 0),
+    x2: positionAbsolute.x + (node.computed?.width ?? node.initialWidth ?? 0),
+    y2: positionAbsolute.y + (node.computed?.height ?? node.initialHeight ?? 0),
   };
 };
 

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -114,8 +114,8 @@ export const getNodePositionWithOrigin = (
     };
   }
 
-  const offsetX = (node.computed?.width ?? node.width ?? 0) * nodeOrigin[0];
-  const offsetY = (node.computed?.height ?? node.height ?? 0) * nodeOrigin[1];
+  const offsetX = (node.computed?.width ?? node.initialWidth ?? 0) * nodeOrigin[0];
+  const offsetY = (node.computed?.height ?? node.initialHeight ?? 0) * nodeOrigin[1];
 
   const position: XYPosition = {
     x: node.position.x - offsetX,
@@ -154,8 +154,8 @@ export const getNodesBounds = (nodes: NodeBase[], nodeOrigin: NodeOrigin = [0, 0
         rectToBox({
           x,
           y,
-          width: node.computed?.width ?? node.width ?? 0,
-          height: node.computed?.height ?? node.height ?? 0,
+          width: node.computed?.width ?? node.initialWidth ?? 0,
+          height: node.computed?.height ?? node.initialHeight ?? 0,
         })
       );
     },
@@ -182,8 +182,8 @@ export const getNodesInside = <NodeType extends NodeBase>(
 
   const visibleNodes = nodes.reduce<NodeType[]>((res, node) => {
     const { computed, selectable = true, hidden = false } = node;
-    const width = computed?.width ?? node.width ?? null;
-    const height = computed?.height ?? node.height ?? null;
+    const width = computed?.width ?? node.initialWidth ?? null;
+    const height = computed?.height ?? node.initialHeight ?? null;
 
     if ((excludeNonSelectableNodes && !selectable) || hidden) {
       return res;


### PR DESCRIPTION
An issue with v12 is that flows behave differently if you pass in v11 nodes. In v12 `width`/ `height` are used an inline styles and you lose the auto default `width` / `height` behaviour. Once you set `width`/ `height`, you always need to update those values if your node dimensions change. The idea of this PR is to remove `width`/ `height` from the node attributes and add new attributes `initialWidth`/ `initialHeight`. Those values are only used if a node has no computed dimensions (which is the case on the server). Unfortunately this introduces a new issue: built-in nodes have a different size on the server and on the client if you only use `initialWidth`/ `initialHeight`, because the default styles do `.react-flow__node-input{ ... width: 150px}`. I am not sure how we could solve this with this new approach. 