### PR TITLE
Svelte Flow: Use provided default node before falling back to built in default

### DIFF
--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -61,7 +61,7 @@
   }
 
   const nodeComponent: ComponentType<SvelteComponent<NodeProps>> =
-    $nodeTypes[nodeType] || DefaultNode;
+    $nodeTypes[nodeType] || $nodeTypes['default'] || DefaultNode;
   const dispatch = createEventDispatcher<{
     nodeclick: { node: Node; event: MouseEvent | TouchEvent };
     nodecontextmenu: { node: Node; event: MouseEvent | TouchEvent };


### PR DESCRIPTION
Try and fallback to a provided default node from the nodeTypes store and if that returns a falsey value, fallback to the builtin DefaultNode.

### Example:

If you're unsure about the available nodeTypes available at runtime and want to provide a more clear fallback, svelteflow won't fallback to the provided default in nodeTypes and instead fallback to the svelteflow provided default.

```svelte
<script>
  // ...

  const nodeTypes = {
    default: FallbackNode,
  };
</script>

<SvelteFlow {nodeTypes}>
  <!-- ... -->
</SvelteFlow>
```