### PR TITLE
fix Couldn't create edge for ${handleType} handle id: 

### DIFF
--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -88,7 +88,7 @@ export function NodeWrapper({
 
       return () => resizeObserver?.unobserve(currNode);
     }
-  }, [node.hidden]);
+  }, [node]);
 
   useEffect(() => {
     // when the user programmatically changes the source or handle position, we re-initialize the node

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -99,7 +99,7 @@ export function adoptUserProvidedNodes<NodeType extends NodeBase>(
       },
     };
     const z = (isNumeric(n.zIndex) ? n.zIndex : 0) + (n.selected ? selectedNodeZ : 0);
-    const currInternals = n?.[internalsSymbol] || currentStoreNode?.[internalsSymbol];
+    const currInternals = n?.[internalsSymbol]; //|| currentStoreNode?.[internalsSymbol];
 
     if (node.parentNode) {
       parentNodes[node.parentNode] = true;


### PR DESCRIPTION
```javascript
setNodes(newNodes);
setEdges(newEdges);
```

when handles in newNode has changed, but id not change, and the newEdge use the new handle,  the error  `Couldn't create edge for ${handleType} handle id: ` will show in console and the edge will not show.

so i change code at two places.
1. to not use the old stale handle cache . 
2. to make the resize observe the new node in order to make the updateNodeDimensions happen. then trigger the new edge  show.
