### PR TITLE
fixed minimap styling by props & mask-stroke-width

### DIFF
--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -51,8 +51,8 @@ function MiniMapComponent({
   nodeComponent,
   bgColor,
   maskColor,
-  maskStrokeColor = 'none',
-  maskStrokeWidth = 1,
+  maskStrokeColor,
+  maskStrokeWidth,
   position = 'bottom-right',
   onClick,
   onNodeClick,
@@ -133,6 +133,9 @@ function MiniMapComponent({
           ...style,
           '--xy-minimap-background-color-props': typeof bgColor === 'string' ? bgColor : undefined,
           '--xy-minimap-mask-background-color-props': typeof maskColor === 'string' ? maskColor : undefined,
+          '--xy-minimap-mask-stroke-color-props': typeof maskStrokeColor === 'string' ? maskStrokeColor : undefined,
+          '--xy-minimap-mask-stroke-width-props':
+            typeof maskStrokeWidth === 'number' ? maskStrokeWidth * viewScale : undefined,
           '--xy-minimap-node-background-color-props': typeof nodeColor === 'string' ? nodeColor : undefined,
           '--xy-minimap-node-stroke-color-props': typeof nodeStrokeColor === 'string' ? nodeStrokeColor : undefined,
           '--xy-minimap-node-stroke-width-props': typeof nodeStrokeWidth === 'string' ? nodeStrokeWidth : undefined,
@@ -166,8 +169,6 @@ function MiniMapComponent({
           d={`M${x - offset},${y - offset}h${width + offset * 2}v${height + offset * 2}h${-width - offset * 2}z
         M${viewBB.x},${viewBB.y}h${viewBB.width}v${viewBB.height}h${-viewBB.width}z`}
           fillRule="evenodd"
-          stroke={maskStrokeColor}
-          strokeWidth={maskStrokeWidth * viewScale}
           pointerEvents="none"
         />
       </svg>

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -49,6 +49,7 @@ function MiniMapComponent({
   // We need to rename the prop to be `CapitalCase` so that JSX will render it as
   // a component properly.
   nodeComponent,
+  bgColor,
   maskColor,
   maskStrokeColor = 'none',
   maskStrokeWidth = 1,
@@ -130,7 +131,8 @@ function MiniMapComponent({
       style={
         {
           ...style,
-          '--xy-minimap-mask-color-props': typeof maskColor === 'string' ? maskColor : undefined,
+          '--xy-minimap-background-color-props': typeof bgColor === 'string' ? bgColor : undefined,
+          '--xy-minimap-mask-background-color-props': typeof maskColor === 'string' ? maskColor : undefined,
           '--xy-minimap-node-background-color-props': typeof nodeColor === 'string' ? nodeColor : undefined,
           '--xy-minimap-node-stroke-color-props': typeof nodeStrokeColor === 'string' ? nodeStrokeColor : undefined,
           '--xy-minimap-node-stroke-width-props': typeof nodeStrokeWidth === 'string' ? nodeStrokeWidth : undefined,
@@ -143,6 +145,7 @@ function MiniMapComponent({
         width={elementWidth}
         height={elementHeight}
         viewBox={`${x} ${y} ${width} ${height}`}
+        className="react-flow__minimap-svg"
         role="img"
         aria-labelledby={labelledBy}
         ref={svg}
@@ -164,7 +167,7 @@ function MiniMapComponent({
         M${viewBB.x},${viewBB.y}h${viewBB.width}v${viewBB.height}h${-viewBB.width}z`}
           fillRule="evenodd"
           stroke={maskStrokeColor}
-          strokeWidth={maskStrokeWidth}
+          strokeWidth={maskStrokeWidth * viewScale}
           pointerEvents="none"
         />
       </svg>

--- a/packages/react/src/additional-components/MiniMap/types.ts
+++ b/packages/react/src/additional-components/MiniMap/types.ts
@@ -19,6 +19,8 @@ export type MiniMapProps<NodeType extends Node = Node> = Omit<HTMLAttributes<SVG
   nodeStrokeWidth?: number;
   /** Component used to render nodes on minimap */
   nodeComponent?: ComponentType<MiniMapNodeProps>;
+  /** Background color of minimap */
+  bgColor?: string;
   /** Color of mask representing viewport */
   maskColor?: string;
   /** Stroke color of mask representing viewport */

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -27,7 +27,7 @@
   export let bgColor: $$Props['bgColor'] = undefined;
   export let maskColor: $$Props['maskColor'] = undefined;
   export let maskStrokeColor: $$Props['maskStrokeColor'] = undefined;
-  export let maskStrokeWidth: $$Props['maskStrokeWidth'] = undefined;
+  export let maskStrokeWidth: $$Props['maskStrokeWidth'] = 1;
   export let width: $$Props['width'] = undefined;
   export let height: $$Props['height'] = undefined;
   export let pannable: $$Props['pannable'] = true;
@@ -83,7 +83,7 @@
 
 <Panel
   {position}
-  {style}
+  style={style + `;--xy-minimap-background-color-props:${bgColor}`}
   class={cc(['svelte-flow__minimap', className])}
   data-testid="svelte-flow__minimap"
 >
@@ -92,12 +92,10 @@
       width={elementWidth}
       height={elementHeight}
       viewBox="{x} {y} {viewboxWidth} {viewboxHeight}"
+      class="svelte-flow__minimap-svg"
       role="img"
       aria-labelledby={labelledBy}
-      style:--xy-minimap-background-color-props={bgColor}
-      style:--xy-minimap-mask-color-props={maskColor}
-      style:--xy-minimap-mask-stroke-color-props={maskStrokeColor}
-      style:--xy-minimap-mask-stroke-width-props={maskStrokeWidth}
+      style:--xy-minimap-mask-background-color-props={maskColor}
       use:interactive={{
         panZoom: $panZoom,
         viewport,
@@ -137,6 +135,8 @@
           offset * 2}h{-viewboxWidth - offset * 2}z
       M{viewBB.x},{viewBB.y}h{viewBB.width}v{viewBB.height}h{-viewBB.width}z"
         fill-rule="evenodd"
+        stroke={maskStrokeColor}
+        stroke-width={maskStrokeWidth ?? 1 * viewScale}
         pointer-events="none"
       />
     </svg>

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -97,7 +97,9 @@
       aria-labelledby={labelledBy}
       style:--xy-minimap-mask-background-color-props={maskColor}
       style:--xy-minimap-mask-stroke-color-props={maskStrokeColor}
-      style:--xy-minimap-mask-stroke-width-props={(maskStrokeWidth ?? 0) * viewScale}
+      style:--xy-minimap-mask-stroke-width-props={maskStrokeWidth
+        ? maskStrokeWidth * viewScale
+        : undefined}
       use:interactive={{
         panZoom: $panZoom,
         viewport,

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -27,7 +27,7 @@
   export let bgColor: $$Props['bgColor'] = undefined;
   export let maskColor: $$Props['maskColor'] = undefined;
   export let maskStrokeColor: $$Props['maskStrokeColor'] = undefined;
-  export let maskStrokeWidth: $$Props['maskStrokeWidth'] = 1;
+  export let maskStrokeWidth: $$Props['maskStrokeWidth'] = undefined;
   export let width: $$Props['width'] = undefined;
   export let height: $$Props['height'] = undefined;
   export let pannable: $$Props['pannable'] = true;
@@ -83,7 +83,7 @@
 
 <Panel
   {position}
-  style={style + `;--xy-minimap-background-color-props:${bgColor}`}
+  style={style + (bgColor ? `;--xy-minimap-background-color-props:${bgColor}` : '')}
   class={cc(['svelte-flow__minimap', className])}
   data-testid="svelte-flow__minimap"
 >
@@ -96,6 +96,8 @@
       role="img"
       aria-labelledby={labelledBy}
       style:--xy-minimap-mask-background-color-props={maskColor}
+      style:--xy-minimap-mask-stroke-color-props={maskStrokeColor}
+      style:--xy-minimap-mask-stroke-width-props={(maskStrokeWidth ?? 0) * viewScale}
       use:interactive={{
         panZoom: $panZoom,
         viewport,
@@ -135,8 +137,6 @@
           offset * 2}h{-viewboxWidth - offset * 2}z
       M{viewBB.x},{viewBB.y}h{viewBB.width}v{viewBB.height}h{-viewBB.width}z"
         fill-rule="evenodd"
-        stroke={maskStrokeColor}
-        stroke-width={maskStrokeWidth ?? 1 * viewScale}
         pointer-events="none"
       />
     </svg>

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -12,6 +12,8 @@
 
   --xy-minimap-background-color-default: #fff;
   --xy-minimap-mask-background-color-default: rgb(240, 240, 240, 0.6);
+  --xy-minimap-mask-stroke-color-default: transparent;
+  --xy-minimap-mask-stroke-width-default: 0;
   --xy-minimap-node-background-color-default: #e2e2e2;
   --xy-minimap-node-stroke-color-default: transparent;
   --xy-minimap-node-stroke-width-default: 2;
@@ -34,6 +36,8 @@
 
   --xy-minimap-background-color-default: #141414;
   --xy-minimap-mask-background-color-default: rgb(60, 60, 60, 0.6);
+  --xy-minimap-mask-stroke-color-default: transparent;
+  --xy-minimap-mask-stroke-width-default: 0;
   --xy-minimap-node-background-color-default: #2b2b2b;
   --xy-minimap-node-stroke-color-default: transparent;
   --xy-minimap-node-stroke-width-default: 2;
@@ -311,8 +315,8 @@ svg.xy-flow__connectionline {
 
 .xy-flow__minimap {
   background: var(
-    --xy-minimap-background-color,
-    var(--xy-minimap-background-color-props, var(--xy-minimap-background-color-default))
+    --xy-minimap-background-color-props,
+    var(--xy-minimap-background-color, var(--xy-minimap-background-color-default))
   );
 
   &-svg {
@@ -323,6 +327,14 @@ svg.xy-flow__connectionline {
     fill: var(
       --xy-minimap-mask-background-color-props,
       var(--xy-minimap-mask-background-color, var(--xy-minimap-mask-background-color-default))
+    );
+    stroke: var(
+      --xy-minimap-mask-stroke-color-props,
+      var(--xy-minimap-mask-stroke-color, var(--xy-minimap-mask-stroke-color-default))
+    );
+    stroke-width: var(
+      --xy-minimap-mask-stroke-width-props,
+      var(--xy-minimap-mask-stroke-width, var(--xy-minimap-mask-stroke-width-default))
     );
   }
 

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -310,7 +310,14 @@ svg.xy-flow__connectionline {
 }
 
 .xy-flow__minimap {
-  background: var(--xy-minimap-background-color, var(--xy-minimap-background-color-default));
+  background: var(
+    --xy-minimap-background-color,
+    var(--xy-minimap-background-color-props, var(--xy-minimap-background-color-default))
+  );
+
+  &-svg {
+    display: block;
+  }
 
   &-mask {
     fill: var(

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -13,7 +13,7 @@
   --xy-minimap-background-color-default: #fff;
   --xy-minimap-mask-background-color-default: rgb(240, 240, 240, 0.6);
   --xy-minimap-mask-stroke-color-default: transparent;
-  --xy-minimap-mask-stroke-width-default: 0;
+  --xy-minimap-mask-stroke-width-default: 1;
   --xy-minimap-node-background-color-default: #e2e2e2;
   --xy-minimap-node-stroke-color-default: transparent;
   --xy-minimap-node-stroke-width-default: 2;
@@ -37,7 +37,7 @@
   --xy-minimap-background-color-default: #141414;
   --xy-minimap-mask-background-color-default: rgb(60, 60, 60, 0.6);
   --xy-minimap-mask-stroke-color-default: transparent;
-  --xy-minimap-mask-stroke-width-default: 0;
+  --xy-minimap-mask-stroke-width-default: 1;
   --xy-minimap-node-background-color-default: #2b2b2b;
   --xy-minimap-node-stroke-color-default: transparent;
   --xy-minimap-node-stroke-width-default: 2;


### PR DESCRIPTION
- minimap styling from props now works as expected
- fixed svg styles to remove unnecessary spacing
- fixed mask-stroke-width scaling with zoom level