### PR TITLE
fix(edge-marker): use quotes for marker urls to support css vars 

### DIFF
--- a/.changeset/nice-peaches-sit.md
+++ b/.changeset/nice-peaches-sit.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+fix(edge-marker): use quotes for marker urls to support css vars

--- a/packages/core/src/components/Edges/wrapEdge.tsx
+++ b/packages/core/src/components/Edges/wrapEdge.tsx
@@ -64,8 +64,8 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
     const [updating, setUpdating] = useState<boolean>(false);
     const store = useStoreApi();
 
-    const markerStartUrl = useMemo(() => `url(#${getMarkerId(markerStart, rfId)})`, [markerStart, rfId]);
-    const markerEndUrl = useMemo(() => `url(#${getMarkerId(markerEnd, rfId)})`, [markerEnd, rfId]);
+    const markerStartUrl = useMemo(() => `url('#${getMarkerId(markerStart, rfId)}')`, [markerStart, rfId]);
+    const markerEndUrl = useMemo(() => `url('#${getMarkerId(markerEnd, rfId)}')`, [markerEnd, rfId]);
 
     if (hidden) {
       return null;


### PR DESCRIPTION
closes #3915