### PR TITLE
Update handle lookup onPointerMove

### DIFF
--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -113,13 +113,6 @@ function onPointerDown(
   let isValid = false;
   let handleDomNode: Element | null = null;
 
-  const handleLookup = getHandleLookup({
-    nodes,
-    nodeId,
-    handleId,
-    handleType,
-  });
-
   // when the user is moving the mouse close to the edge of the canvas while connecting we move the canvas
   function autoPan(): void {
     if (!autoPanOnConnect || !containerBounds) {
@@ -154,7 +147,7 @@ function onPointerDown(
     closestHandle = getClosestHandle(
       pointToRendererPoint(connectionPosition, transform, false, [1, 1]),
       connectionRadius,
-      handleLookup
+      getHandleLookup({ nodes, nodeId, handleId, handleType })
     );
 
     if (!autoPanStarted) {


### PR DESCRIPTION
This is an attempt to solve issues laid in #3983. It's obviously not efficient but if there is a way to get notified when node internals are updated then the result can be memoized.

closes #3983