### PR TITLE
fix(useNodesData): fix crash when passing invalid node id

### DIFF
--- a/packages/system/src/utils/shallow-node-data.ts
+++ b/packages/system/src/utils/shallow-node-data.ts
@@ -2,7 +2,11 @@ import { NodeBase } from '../types';
 
 type NodeData = Pick<NodeBase, 'id' | 'type' | 'data'>;
 
-export function shallowNodeData(a: NodeData | NodeData[], b: NodeData | NodeData[]) {
+export function shallowNodeData(a: NodeData | null | NodeData[], b: NodeData | null | NodeData[]) {
+  if (a === null || b === null) {
+    return false;
+  }
+
   const _a = Array.isArray(a) ? a : [a];
   const _b = Array.isArray(b) ? b : [b];
 


### PR DESCRIPTION
### Issue:
When passing invalid(or unavailable) node id to `useNodesData` it  return `null` which leads to a cash due to missing null check inside custom equality function.

### Fix:
Add null check inside equality function - `shallowNodeData`.