### PR TITLE
Remove white bar under MiniMap

### DIFF
--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -153,6 +153,7 @@ function MiniMapComponent<NodeType extends Node = Node>({
         aria-labelledby={labelledBy}
         ref={svg}
         onClick={onSvgClick}
+        display="block"
       >
         {ariaLabel && <title id={labelledBy}>{ariaLabel}</title>}
         <MiniMapNodes<NodeType>


### PR DESCRIPTION
Before:
<img width="237" alt="image" src="https://github.com/xyflow/xyflow/assets/16029639/dfc2f04f-0574-4c46-a3d3-c6c392dbe3b8">

After:
<img width="239" alt="image" src="https://github.com/xyflow/xyflow/assets/16029639/c9390d15-4090-4568-aa9c-b5f4bbf0a58c">

By changing the display from the svg from the default "inline" to "block", the svg and parent div get the same height (which I think is the intended behaviour + less ugly because of the removal of the white bar)