### PR TITLE
Proposal on how to handle measured node dimensions and internals 

### DIFF
--- a/examples/react/src/examples/EasyConnect/FloatingEdge.tsx
+++ b/examples/react/src/examples/EasyConnect/FloatingEdge.tsx
@@ -1,11 +1,10 @@
-import { useCallback } from 'react';
-import { useStore, getStraightPath, EdgeProps } from '@xyflow/react';
+import { getStraightPath, EdgeProps, useInternalNode } from '@xyflow/react';
 
 import { getEdgeParams } from './utils.js';
 
 function FloatingEdge({ id, source, target, markerEnd, style }: EdgeProps) {
-  const sourceNode = useStore(useCallback((store) => store.nodes.find((n) => n.id === source), [source]));
-  const targetNode = useStore(useCallback((store) => store.nodes.find((n) => n.id === target), [target]));
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
 
   if (!sourceNode || !targetNode) {
     return null;

--- a/examples/react/src/examples/EasyConnect/utils.tsx
+++ b/examples/react/src/examples/EasyConnect/utils.tsx
@@ -9,8 +9,8 @@ function getNodeIntersection(intersectionNode: Node, targetNode: Node) {
     width: intersectionNodeWidth,
     height: intersectionNodeHeight,
     positionAbsolute: intersectionNodePosition,
-  } = intersectionNode.computed || {};
-  const targetPosition = targetNode.computed?.positionAbsolute!;
+  } = intersectionNode.internals || {};
+  const targetPosition = targetNode.internals?.positionAbsolute!;
 
   const w = intersectionNodeWidth! / 2;
   const h = intersectionNodeHeight! / 2;
@@ -33,7 +33,7 @@ function getNodeIntersection(intersectionNode: Node, targetNode: Node) {
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
 function getEdgePosition(node: Node, intersectionPoint: XYPosition) {
-  const n = { ...node.computed?.positionAbsolute, ...node };
+  const n = { ...node.internals?.positionAbsolute, ...node };
   const nx = Math.round(n.x!);
   const ny = Math.round(n.y!);
   const px = Math.round(intersectionPoint.x);
@@ -42,13 +42,13 @@ function getEdgePosition(node: Node, intersectionPoint: XYPosition) {
   if (px <= nx + 1) {
     return Position.Left;
   }
-  if (px >= nx + n.computed?.width! - 1) {
+  if (px >= nx + n.internals?.width! - 1) {
     return Position.Right;
   }
   if (py <= ny + 1) {
     return Position.Top;
   }
-  if (py >= n.y! + n.computed?.height! - 1) {
+  if (py >= n.y! + n.internals?.height! - 1) {
     return Position.Bottom;
   }
 

--- a/examples/react/src/examples/Layouting/index.tsx
+++ b/examples/react/src/examples/Layouting/index.tsx
@@ -31,7 +31,7 @@ const nodeExtent: CoordinateExtent = [
 const LayoutFlow = () => {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialItems.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialItems.edges);
-  const { fitView } = useReactFlow();
+  const { fitView, getInternalNode } = useReactFlow();
 
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -45,7 +45,12 @@ const LayoutFlow = () => {
     dagreGraph.setGraph({ rankdir: direction });
 
     nodes.forEach((node) => {
-      dagreGraph.setNode(node.id, { width: 150, height: 50 });
+      const internalNode = getInternalNode(node.id);
+
+      dagreGraph.setNode(node.id, {
+        width: internalNode?.internals.width ?? 150,
+        height: internalNode?.internals.height ?? 50,
+      });
     });
 
     edges.forEach((edge) => {

--- a/examples/react/src/examples/Subflow/index.tsx
+++ b/examples/react/src/examples/Subflow/index.tsx
@@ -14,6 +14,8 @@ import {
   Background,
   Panel,
   NodeOrigin,
+  OnNodesChange,
+  applyNodeChanges,
 } from '@xyflow/react';
 
 import DebugNode from './DebugNode';
@@ -88,24 +90,22 @@ const initialNodes: Node[] = [
     id: '5',
     type: 'group',
     data: { label: 'Node 5' },
-    position: { x: 650, y: 250 },
-    className: 'light',
+    position: { x: 650, y: 100 },
     style: { width: 100, height: 100 },
     zIndex: 1000,
   },
-  // {
-  //   id: '5a',
-  //   data: { label: 'Node 5a' },
-  //   position: { x: 0, y: 0 },
-  //   className: 'light',
-  //   parentNode: '5',
-  //   extent: 'parent',
-  // },
+  {
+    id: '5a',
+    data: { label: 'Node 5a' },
+    position: { x: 50, y: 50 },
+    parentNode: '5',
+    extent: 'parent',
+    expandParent: true,
+  },
   {
     id: '5b',
     data: { label: 'Node 5b' },
-    position: { x: 225, y: 50 },
-    className: 'light',
+    position: { x: 200, y: 200 },
     parentNode: '5',
     expandParent: true,
   },
@@ -151,8 +151,18 @@ const nodeTypes = {
 
 const Subflow = () => {
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes] = useState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onNodesChange: OnNodesChange = useCallback(
+    (changes) =>
+      setNodes((nds) => {
+        const nextNodes = applyNodeChanges(changes, nds);
+
+        return nextNodes;
+      }),
+    []
+  );
 
   const onConnect = useCallback((connection: Connection) => setEdges((eds) => addEdge(connection, eds)), [setEdges]);
   const onInit = useCallback((reactFlowInstance: ReactFlowInstance) => setRfInstance(reactFlowInstance), []);

--- a/examples/react/src/examples/Subflow/index.tsx
+++ b/examples/react/src/examples/Subflow/index.tsx
@@ -25,65 +25,65 @@ const onEdgeClick = (_: MouseEvent, edge: Edge) => console.log('click', edge);
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.5 };
 const initialNodes: Node[] = [
-  {
-    id: '1',
-    type: 'input',
-    data: { label: 'Node 1' },
-    position: { x: 250, y: 5 },
-    className: 'light',
-    origin: [0.5, 0.5],
-  },
-  {
-    id: '4',
-    data: { label: 'Node 4' },
-    position: { x: 100, y: 200 },
-    className: 'light',
-    origin: [0.5, 0.5],
-    style: {
-      backgroundColor: 'rgba(255,50, 50, 0.5)',
-      width: 500,
-      height: 300,
-    },
-  },
-  {
-    id: '4a',
-    data: { label: 'Node 4a' },
-    position: { x: 15, y: 15 },
-    className: 'light',
-    parentNode: '4',
-    origin: [0.5, 0.5],
+  // {
+  //   id: '1',
+  //   type: 'input',
+  //   data: { label: 'Node 1' },
+  //   position: { x: 250, y: 5 },
+  //   className: 'light',
+  //   origin: [0.5, 0.5],
+  // },
+  // {
+  //   id: '4',
+  //   data: { label: 'Node 4' },
+  //   position: { x: 100, y: 200 },
+  //   className: 'light',
+  //   origin: [0.5, 0.5],
+  //   style: {
+  //     backgroundColor: 'rgba(255,50, 50, 0.5)',
+  //     width: 500,
+  //     height: 300,
+  //   },
+  // },
+  // {
+  //   id: '4a',
+  //   data: { label: 'Node 4a' },
+  //   position: { x: 15, y: 15 },
+  //   className: 'light',
+  //   parentNode: '4',
+  //   origin: [0.5, 0.5],
 
-    extent: [
-      [0, 0],
-      [100, 100],
-    ],
-  },
-  {
-    id: '4b',
-    data: { label: 'Node 4b' },
-    position: { x: 100, y: 60 },
-    className: 'light',
-    style: {
-      backgroundColor: 'rgba(50, 50, 255, 0.5)',
-      height: 200,
-      width: 300,
-    },
-    parentNode: '4',
-  },
-  {
-    id: '4b1',
-    data: { label: 'Node 4b1' },
-    position: { x: 40, y: 20 },
-    className: 'light',
-    parentNode: '4b',
-  },
-  {
-    id: '4b2',
-    data: { label: 'Node 4b2' },
-    position: { x: 20, y: 100 },
-    className: 'light',
-    parentNode: '4b',
-  },
+  //   extent: [
+  //     [0, 0],
+  //     [100, 100],
+  //   ],
+  // },
+  // {
+  //   id: '4b',
+  //   data: { label: 'Node 4b' },
+  //   position: { x: 100, y: 60 },
+  //   className: 'light',
+  //   style: {
+  //     backgroundColor: 'rgba(50, 50, 255, 0.5)',
+  //     height: 200,
+  //     width: 300,
+  //   },
+  //   parentNode: '4',
+  // },
+  // {
+  //   id: '4b1',
+  //   data: { label: 'Node 4b1' },
+  //   position: { x: 40, y: 20 },
+  //   className: 'light',
+  //   parentNode: '4b',
+  // },
+  // {
+  //   id: '4b2',
+  //   data: { label: 'Node 4b2' },
+  //   position: { x: 20, y: 100 },
+  //   className: 'light',
+  //   parentNode: '4b',
+  // },
   {
     id: '5',
     type: 'group',
@@ -93,14 +93,14 @@ const initialNodes: Node[] = [
     style: { width: 100, height: 100 },
     zIndex: 1000,
   },
-  {
-    id: '5a',
-    data: { label: 'Node 5a' },
-    position: { x: 0, y: 0 },
-    className: 'light',
-    parentNode: '5',
-    extent: 'parent',
-  },
+  // {
+  //   id: '5a',
+  //   data: { label: 'Node 5a' },
+  //   position: { x: 0, y: 0 },
+  //   className: 'light',
+  //   parentNode: '5',
+  //   extent: 'parent',
+  // },
   {
     id: '5b',
     data: { label: 'Node 5b' },
@@ -109,40 +109,40 @@ const initialNodes: Node[] = [
     parentNode: '5',
     expandParent: true,
   },
-  {
-    id: '2',
-    data: { label: 'Node 2' },
-    position: { x: 100, y: 100 },
-    className: 'light',
-  },
-  {
-    id: '3',
-    data: { label: 'Node 3' },
-    position: { x: 400, y: 100 },
-    className: 'light',
-    extent: 'parent',
-  },
+  // {
+  //   id: '2',
+  //   data: { label: 'Node 2' },
+  //   position: { x: 100, y: 100 },
+  //   className: 'light',
+  // },
+  // {
+  //   id: '3',
+  //   data: { label: 'Node 3' },
+  //   position: { x: 400, y: 100 },
+  //   className: 'light',
+  //   extent: 'parent',
+  // },
 ];
 
 const initialEdges: Edge[] = [
-  {
-    id: 'e1-2',
-    source: '1',
-    target: '2',
-    markerEnd: {
-      type: MarkerType.Arrow,
-      strokeWidth: 2,
-      width: 15,
-      height: 15,
-      color: '#f00',
-    },
-  },
-  { id: 'e1-3', source: '1', target: '3' },
-  { id: 'e3-4', source: '3', target: '4', zIndex: 100 },
-  { id: 'e3-4b', source: '3', target: '4b' },
-  { id: 'e4a-4b1', source: '4a', target: '4b1' },
-  { id: 'e4a-4b2', source: '4a', target: '4b2', zIndex: 100 },
-  { id: 'e4b1-4b2', source: '4b1', target: '4b2' },
+  // {
+  //   id: 'e1-2',
+  //   source: '1',
+  //   target: '2',
+  //   markerEnd: {
+  //     type: MarkerType.Arrow,
+  //     strokeWidth: 2,
+  //     width: 15,
+  //     height: 15,
+  //     color: '#f00',
+  //   },
+  // },
+  // { id: 'e1-3', source: '1', target: '3' },
+  // { id: 'e3-4', source: '3', target: '4', zIndex: 100 },
+  // { id: 'e3-4b', source: '3', target: '4b' },
+  // { id: 'e4a-4b1', source: '4a', target: '4b1' },
+  // { id: 'e4a-4b2', source: '4a', target: '4b2', zIndex: 100 },
+  // { id: 'e4b1-4b2', source: '4b1', target: '4b2' },
 ];
 
 const nodeTypes = {
@@ -207,15 +207,16 @@ const Subflow = () => {
       onInit={onInit}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
-      onNodeClick={onNodeClick}
-      onEdgeClick={onEdgeClick}
+      // onNodeClick={onNodeClick}
+      // onEdgeClick={onEdgeClick}
       onConnect={onConnect}
-      onNodeDrag={onNodeDrag}
-      onNodeDragStop={onNodeDragStop}
+      // onNodeDrag={onNodeDrag}
+      // onNodeDragStop={onNodeDragStop}
       className="react-flow-basic-example"
       onlyRenderVisibleElements={false}
       nodeTypes={nodeTypes}
       fitView
+      debug
     >
       <MiniMap />
       <Controls />

--- a/examples/react/src/examples/Switch/index.tsx
+++ b/examples/react/src/examples/Switch/index.tsx
@@ -99,10 +99,10 @@ const BasicFlow = () => {
       onEdgesChange={onEdgesChange}
       onNodeClick={onNodeClick}
       onConnect={onConnect}
-      onNodeDragStart={onNodeDragStart}
-      onNodeDrag={onNodeDrag}
-      onNodeDragStop={onNodeDragStop}
-      nodeDragThreshold={10}
+      // onNodeDragStart={onNodeDragStart}
+      // onNodeDrag={onNodeDrag}
+      // onNodeDragStop={onNodeDragStop}
+      // nodeDragThreshold={10}
     >
       <div style={{ position: 'absolute', right: 10, top: 10, zIndex: 4 }}>
         <button

--- a/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
@@ -6,7 +6,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useStore } from '../../hooks/useStore';
 import { MiniMapNode } from './MiniMapNode';
-import type { ReactFlowState, Node } from '../../types';
+import type { ReactFlowState, Node, InternalNode } from '../../types';
 import type { MiniMapNodes as MiniMapNodesProps, GetMiniMapNodeAttribute, MiniMapNodeProps } from './types';
 
 declare const window: any;
@@ -85,7 +85,7 @@ function NodeComponentWrapperInner<NodeType extends Node>({
   shapeRendering: string;
 }) {
   const { node, x, y } = useStore((s) => {
-    const node = s.nodeLookup.get(id) as NodeType;
+    const node = s.nodeLookup.get(id) as InternalNode<NodeType>;
     const { x, y } = getNodePositionWithOrigin(node, node?.origin || nodeOrigin).positionAbsolute;
 
     return {
@@ -109,10 +109,10 @@ function NodeComponentWrapperInner<NodeType extends Node>({
       height={height}
       style={node.style}
       selected={!!node.selected}
-      className={nodeClassNameFunc(node)}
-      color={nodeColorFunc(node)}
+      className={nodeClassNameFunc(node.computed.userProvidedNode)}
+      color={nodeColorFunc(node.computed.userProvidedNode)}
       borderRadius={nodeBorderRadius}
-      strokeColor={nodeStrokeColorFunc(node)}
+      strokeColor={nodeStrokeColorFunc(node.computed.userProvidedNode)}
       strokeWidth={nodeStrokeWidth}
       shapeRendering={shapeRendering}
       onClick={onClick}

--- a/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
@@ -109,10 +109,10 @@ function NodeComponentWrapperInner<NodeType extends Node>({
       height={height}
       style={node.style}
       selected={!!node.selected}
-      className={nodeClassNameFunc(node.computed.userProvidedNode)}
-      color={nodeColorFunc(node.computed.userProvidedNode)}
+      className={nodeClassNameFunc(node.internals.userProvidedNode)}
+      color={nodeColorFunc(node.internals.userProvidedNode)}
       borderRadius={nodeBorderRadius}
-      strokeColor={nodeStrokeColorFunc(node.computed.userProvidedNode)}
+      strokeColor={nodeStrokeColorFunc(node.internals.userProvidedNode)}
       strokeWidth={nodeStrokeWidth}
       shapeRendering={shapeRendering}
       onClick={onClick}

--- a/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
+++ b/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
@@ -10,10 +10,10 @@ import { NodeToolbarPortal } from './NodeToolbarPortal';
 import type { NodeToolbarProps } from './types';
 
 const nodeEqualityFn = (a?: Node, b?: Node) =>
-  a?.computed?.positionAbsolute?.x !== b?.computed?.positionAbsolute?.x ||
-  a?.computed?.positionAbsolute?.y !== b?.computed?.positionAbsolute?.y ||
-  a?.computed?.width !== b?.computed?.width ||
-  a?.computed?.height !== b?.computed?.height ||
+  a?.[internalsSymbol]?.positionAbsolute?.x !== b?.[internalsSymbol]?.positionAbsolute?.x ||
+  a?.[internalsSymbol]?.positionAbsolute?.y !== b?.[internalsSymbol]?.positionAbsolute?.y ||
+  a?.[internalsSymbol]?.width !== b?.[internalsSymbol]?.width ||
+  a?.[internalsSymbol]?.height !== b?.[internalsSymbol]?.height ||
   a?.selected !== b?.selected ||
   a?.[internalsSymbol]?.z !== b?.[internalsSymbol]?.z;
 

--- a/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
+++ b/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
@@ -1,23 +1,23 @@
 import { useCallback, CSSProperties } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
-import { getNodesBounds, Rect, Position, internalsSymbol, getNodeToolbarTransform } from '@xyflow/system';
+import { getNodesBounds, Rect, Position, getNodeToolbarTransform } from '@xyflow/system';
 
-import { Node, ReactFlowState } from '../../types';
+import { InternalNode, ReactFlowState } from '../../types';
 import { useStore } from '../../hooks/useStore';
 import { useNodeId } from '../../contexts/NodeIdContext';
 import { NodeToolbarPortal } from './NodeToolbarPortal';
 import type { NodeToolbarProps } from './types';
 
-const nodeEqualityFn = (a?: Node, b?: Node) =>
-  a?.[internalsSymbol]?.positionAbsolute?.x !== b?.[internalsSymbol]?.positionAbsolute?.x ||
-  a?.[internalsSymbol]?.positionAbsolute?.y !== b?.[internalsSymbol]?.positionAbsolute?.y ||
-  a?.[internalsSymbol]?.width !== b?.[internalsSymbol]?.width ||
-  a?.[internalsSymbol]?.height !== b?.[internalsSymbol]?.height ||
+const nodeEqualityFn = (a?: InternalNode, b?: InternalNode) =>
+  a?.computed.positionAbsolute?.x !== b?.computed.positionAbsolute?.x ||
+  a?.computed.positionAbsolute?.y !== b?.computed.positionAbsolute?.y ||
+  a?.computed.width !== b?.computed.width ||
+  a?.computed.height !== b?.computed.height ||
   a?.selected !== b?.selected ||
-  a?.[internalsSymbol]?.z !== b?.[internalsSymbol]?.z;
+  a?.computed.z !== b?.computed.z;
 
-const nodesEqualityFn = (a: Node[], b: Node[]) => {
+const nodesEqualityFn = (a: InternalNode[], b: InternalNode[]) => {
   if (a.length !== b.length) {
     return false;
   }
@@ -49,10 +49,10 @@ export function NodeToolbar({
   const contextNodeId = useNodeId();
 
   const nodesSelector = useCallback(
-    (state: ReactFlowState): Node[] => {
+    (state: ReactFlowState): InternalNode[] => {
       const nodeIds = Array.isArray(nodeId) ? nodeId : [nodeId || contextNodeId || ''];
 
-      return nodeIds.reduce<Node[]>((acc, id) => {
+      return nodeIds.reduce<InternalNode[]>((acc, id) => {
         const node = state.nodeLookup.get(id);
         if (node) {
           acc.push(node);
@@ -74,7 +74,7 @@ export function NodeToolbar({
   }
 
   const nodeRect: Rect = getNodesBounds(nodes, { nodeOrigin });
-  const zIndex: number = Math.max(...nodes.map((node) => (node[internalsSymbol]?.z || 1) + 1));
+  const zIndex: number = Math.max(...nodes.map((node) => (node.computed.z || 1) + 1));
 
   const wrapperStyle: CSSProperties = {
     position: 'absolute',

--- a/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
+++ b/packages/react/src/additional-components/NodeToolbar/NodeToolbar.tsx
@@ -10,12 +10,12 @@ import { NodeToolbarPortal } from './NodeToolbarPortal';
 import type { NodeToolbarProps } from './types';
 
 const nodeEqualityFn = (a?: InternalNode, b?: InternalNode) =>
-  a?.computed.positionAbsolute?.x !== b?.computed.positionAbsolute?.x ||
-  a?.computed.positionAbsolute?.y !== b?.computed.positionAbsolute?.y ||
-  a?.computed.width !== b?.computed.width ||
-  a?.computed.height !== b?.computed.height ||
+  a?.internals.positionAbsolute?.x !== b?.internals.positionAbsolute?.x ||
+  a?.internals.positionAbsolute?.y !== b?.internals.positionAbsolute?.y ||
+  a?.internals.width !== b?.internals.width ||
+  a?.internals.height !== b?.internals.height ||
   a?.selected !== b?.selected ||
-  a?.computed.z !== b?.computed.z;
+  a?.internals.z !== b?.internals.z;
 
 const nodesEqualityFn = (a: InternalNode[], b: InternalNode[]) => {
   if (a.length !== b.length) {
@@ -74,7 +74,7 @@ export function NodeToolbar({
   }
 
   const nodeRect: Rect = getNodesBounds(nodes, { nodeOrigin });
-  const zIndex: number = Math.max(...nodes.map((node) => (node.computed.z || 1) + 1));
+  const zIndex: number = Math.max(...nodes.map((node) => (node.internals.z || 1) + 1));
 
   const wrapperStyle: CSSProperties = {
     position: 'absolute',

--- a/packages/react/src/components/ConnectionLine/index.tsx
+++ b/packages/react/src/components/ConnectionLine/index.tsx
@@ -52,7 +52,7 @@ const ConnectionLine = ({
     ),
     shallow
   );
-  const fromHandleBounds = fromNode?.computed.handleBounds;
+  const fromHandleBounds = fromNode?.internals.handleBounds;
   let handleBounds = fromHandleBounds?.[handleType];
 
   if (connectionMode === ConnectionMode.Loose) {
@@ -64,10 +64,10 @@ const ConnectionLine = ({
   }
 
   const fromHandle = handleId ? handleBounds.find((d) => d.id === handleId) : handleBounds[0];
-  const fromHandleX = fromHandle ? fromHandle.x + fromHandle.width / 2 : (fromNode.computed?.width ?? 0) / 2;
-  const fromHandleY = fromHandle ? fromHandle.y + fromHandle.height / 2 : fromNode.computed?.height ?? 0;
-  const fromX = (fromNode.computed?.positionAbsolute?.x ?? 0) + fromHandleX;
-  const fromY = (fromNode.computed?.positionAbsolute?.y ?? 0) + fromHandleY;
+  const fromHandleX = fromHandle ? fromHandle.x + fromHandle.width / 2 : (fromNode.internals.width ?? 0) / 2;
+  const fromHandleY = fromHandle ? fromHandle.y + fromHandle.height / 2 : fromNode.internals.height ?? 0;
+  const fromX = (fromNode.internals.positionAbsolute?.x ?? 0) + fromHandleX;
+  const fromY = (fromNode.internals.positionAbsolute?.y ?? 0) + fromHandleY;
   const fromPosition = fromHandle?.position;
   const toPosition = fromPosition ? oppositePosition[fromPosition] : null;
 

--- a/packages/react/src/components/ConnectionLine/index.tsx
+++ b/packages/react/src/components/ConnectionLine/index.tsx
@@ -2,7 +2,6 @@ import { CSSProperties, useCallback } from 'react';
 import { shallow } from 'zustand/shallow';
 import cc from 'classcat';
 import {
-  internalsSymbol,
   Position,
   ConnectionLineType,
   ConnectionMode,
@@ -53,7 +52,7 @@ const ConnectionLine = ({
     ),
     shallow
   );
-  const fromHandleBounds = fromNode?.[internalsSymbol]?.handleBounds;
+  const fromHandleBounds = fromNode?.computed.handleBounds;
   let handleBounds = fromHandleBounds?.[handleType];
 
   if (connectionMode === ConnectionMode.Loose) {

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -47,8 +47,8 @@ export function NodeWrapper<NodeType extends Node>({
     const node = s.nodeLookup.get(id)! as NodeType;
 
     const positionAbsolute = nodeExtent
-      ? clampPosition(node.computed?.positionAbsolute, nodeExtent)
-      : node.computed?.positionAbsolute || { x: 0, y: 0 };
+      ? clampPosition(node[internalsSymbol]?.positionAbsolute, nodeExtent)
+      : node[internalsSymbol]?.positionAbsolute || { x: 0, y: 0 };
 
     return {
       node,

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -126,7 +126,7 @@ export function NodeWrapper<NodeType extends Node>({
       if (targetPosChanged) {
         prevTargetPosition.current = userNode.targetPosition;
       }
-      store.getState().updateNodeDimensions(new Map([[id, { id, nodeElement: nodeRef.current, forceUpdate: true }]]));
+      store.getState().updateInternalNodeValues(new Map([[id, { id, nodeElement: nodeRef.current, force: true }]]));
     }
   }, [id, nodeType, userNode.sourcePosition, userNode.targetPosition]);
 

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -47,19 +47,19 @@ export function NodeWrapper<NodeType extends Node>({
       const internalNode = s.nodeLookup.get(id)! as InternalNode;
 
       const positionAbsolute = nodeExtent
-        ? clampPosition(internalNode.computed.positionAbsolute, nodeExtent)
-        : internalNode.computed.positionAbsolute || { x: 0, y: 0 };
+        ? clampPosition(internalNode.internals.positionAbsolute, nodeExtent)
+        : internalNode.internals.positionAbsolute || { x: 0, y: 0 };
 
       return {
         internalNode,
-        userNode: internalNode.computed.userProvidedNode as NodeType,
+        userNode: internalNode.internals.userProvidedNode as NodeType,
         // we are mutating positionAbsolute, z and isParent attributes for sub flows
         // so we we need to force a re-render when some change
         positionAbsoluteX: positionAbsolute.x,
         positionAbsoluteY: positionAbsolute.y,
-        zIndex: internalNode.computed.z ?? 0,
-        isParent: !!internalNode.computed.isParent,
-        hasHandleBounds: !!internalNode.computed.handleBounds,
+        zIndex: internalNode.internals.z ?? 0,
+        isParent: !!internalNode.internals.isParent,
+        hasHandleBounds: !!internalNode.internals.handleBounds,
       };
     },
     shallow

--- a/packages/react/src/components/NodeWrapper/utils.tsx
+++ b/packages/react/src/components/NodeWrapper/utils.tsx
@@ -4,7 +4,7 @@ import { InputNode } from '../Nodes/InputNode';
 import { DefaultNode } from '../Nodes/DefaultNode';
 import { GroupNode } from '../Nodes/GroupNode';
 import { OutputNode } from '../Nodes/OutputNode';
-import type { Node, NodeTypes } from '../../types';
+import type { InternalNode, NodeTypes } from '../../types';
 
 export const arrowKeyDiffs: Record<string, XYPosition> = {
   ArrowUp: { x: 0, y: -1 },
@@ -20,13 +20,13 @@ export const builtinNodeTypes: NodeTypes = {
   group: GroupNode,
 };
 
-export function getNodeInlineStyleDimensions<NodeType extends Node = Node>(
+export function getNodeInlineStyleDimensions<NodeType extends InternalNode = InternalNode>(
   node: NodeType
 ): {
   width: number | string | undefined;
   height: number | string | undefined;
 } {
-  if (!node.computed) {
+  if (!node.computed.width && !node.computed.height) {
     return {
       width: node.width ?? node.initialWidth ?? node.style?.width,
       height: node.height ?? node.initialHeight ?? node.style?.height,

--- a/packages/react/src/components/NodeWrapper/utils.tsx
+++ b/packages/react/src/components/NodeWrapper/utils.tsx
@@ -26,7 +26,7 @@ export function getNodeInlineStyleDimensions<NodeType extends InternalNode = Int
   width: number | string | undefined;
   height: number | string | undefined;
 } {
-  if (!node.computed.width && !node.computed.height) {
+  if (!node.internals.width && !node.internals.height) {
     return {
       width: node.width ?? node.initialWidth ?? node.style?.width,
       height: node.height ?? node.initialHeight ?? node.style?.height,

--- a/packages/react/src/components/NodesSelection/index.tsx
+++ b/packages/react/src/components/NodesSelection/index.tsx
@@ -5,7 +5,7 @@
 import { useRef, useEffect, type MouseEvent, type KeyboardEvent } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
-import { getNodesBounds } from '@xyflow/system';
+import { getInternalNodesBounds } from '@xyflow/system';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
 import { useDrag } from '../../hooks/useDrag';
@@ -20,8 +20,10 @@ export type NodesSelectionProps<NodeType> = {
 };
 
 const selector = (s: ReactFlowState) => {
-  const selectedNodes = s.nodes.filter((n) => n.selected);
-  const { width, height, x, y } = getNodesBounds(selectedNodes, { nodeOrigin: s.nodeOrigin });
+  const { width, height, x, y } = getInternalNodesBounds(s.nodeLookup, {
+    nodeOrigin: s.nodeOrigin,
+    filter: (n) => !!n.selected,
+  });
 
   return {
     width,
@@ -54,7 +56,7 @@ export function NodesSelection<NodeType extends Node>({
     nodeRef,
   });
 
-  if (userSelectionActive || !width || !height) {
+  if (userSelectionActive || !width || !height || width === -Infinity || height === -Infinity) {
     return null;
   }
 

--- a/packages/react/src/container/NodeRenderer/useResizeObserver.ts
+++ b/packages/react/src/container/NodeRenderer/useResizeObserver.ts
@@ -3,10 +3,10 @@ import { useEffect, useMemo, useRef } from 'react';
 import { ReactFlowState } from '../../types';
 import { useStore } from '../../hooks/useStore';
 
-const selector = (s: ReactFlowState) => s.updateNodeDimensions;
+const selector = (s: ReactFlowState) => s.updateInternalNodeValues;
 
 export function useResizeObserver() {
-  const updateNodeDimensions = useStore(selector);
+  const updateInternalNodeValues = useStore(selector);
   const resizeObserverRef = useRef<ResizeObserver>();
 
   const resizeObserver = useMemo(() => {
@@ -19,16 +19,14 @@ export function useResizeObserver() {
 
       entries.forEach((entry: ResizeObserverEntry) => {
         const id = entry.target.getAttribute('data-id') as string;
+
         updates.set(id, {
           id,
           nodeElement: entry.target as HTMLDivElement,
-          forceUpdate: true,
         });
       });
 
-      console.log('React Flow: resize observer updates', Array.from(updates.values()));
-
-      updateNodeDimensions(updates);
+      updateInternalNodeValues(updates);
     });
 
     resizeObserverRef.current = observer;

--- a/packages/react/src/container/NodeRenderer/useResizeObserver.ts
+++ b/packages/react/src/container/NodeRenderer/useResizeObserver.ts
@@ -26,6 +26,8 @@ export function useResizeObserver() {
         });
       });
 
+      console.log('React Flow: resize observer updates', Array.from(updates.values()));
+
       updateNodeDimensions(updates);
     });
 

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -128,8 +128,16 @@ export function Pane({
   };
 
   const onMouseMove = (event: ReactMouseEvent): void => {
-    const { userSelectionRect, edges, transform, nodeOrigin, nodeLookup, triggerNodeChanges, triggerEdgeChanges } =
-      store.getState();
+    const {
+      userSelectionRect,
+      edges,
+      transform,
+      nodeOrigin,
+      nodeLookup,
+      edgeLookup,
+      triggerNodeChanges,
+      triggerEdgeChanges,
+    } = store.getState();
     if (!isSelecting || !containerBounds.current || !userSelectionRect) {
       return;
     }
@@ -172,13 +180,13 @@ export function Pane({
 
     if (prevSelectedNodesCount.current !== selectedNodeIds.size) {
       prevSelectedNodesCount.current = selectedNodeIds.size;
-      const changes = getSelectionChanges(Array.from(nodeLookup.values()), selectedNodeIds, true) as NodeChange[];
+      const changes = getSelectionChanges(nodeLookup, selectedNodeIds, true) as NodeChange[];
       triggerNodeChanges(changes);
     }
 
     if (prevSelectedEdgesCount.current !== selectedEdgeIds.size) {
       prevSelectedEdgesCount.current = selectedEdgeIds.size;
-      const changes = getSelectionChanges(edges, selectedEdgeIds) as EdgeChange[];
+      const changes = getSelectionChanges(edgeLookup, selectedEdgeIds) as EdgeChange[];
       triggerEdgeChanges(changes);
     }
 

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -128,7 +128,7 @@ export function Pane({
   };
 
   const onMouseMove = (event: ReactMouseEvent): void => {
-    const { userSelectionRect, edges, transform, nodeOrigin, nodes, triggerNodeChanges, triggerEdgeChanges } =
+    const { userSelectionRect, edges, transform, nodeOrigin, nodeLookup, triggerNodeChanges, triggerEdgeChanges } =
       store.getState();
     if (!isSelecting || !containerBounds.current || !userSelectionRect) {
       return;
@@ -149,7 +149,7 @@ export function Pane({
     };
 
     const selectedNodes = getNodesInside(
-      nodes,
+      nodeLookup,
       nextUserSelectRect,
       transform,
       selectionMode === SelectionMode.Partial,
@@ -172,7 +172,7 @@ export function Pane({
 
     if (prevSelectedNodesCount.current !== selectedNodeIds.size) {
       prevSelectedNodesCount.current = selectedNodeIds.size;
-      const changes = getSelectionChanges(nodes, selectedNodeIds, true) as NodeChange[];
+      const changes = getSelectionChanges(Array.from(nodeLookup.values()), selectedNodeIds, true) as NodeChange[];
       triggerNodeChanges(changes);
     }
 

--- a/packages/react/src/hooks/useInternalNode.ts
+++ b/packages/react/src/hooks/useInternalNode.ts
@@ -1,0 +1,8 @@
+import type { InternalNode, Node } from '../types/nodes';
+import { useStore } from './useStore';
+
+export function useInternalNode<NodeType extends Node = Node>(id: string): InternalNode<NodeType> | undefined {
+  const node = useStore((s) => s.nodeLookup.get(id) as InternalNode<NodeType> | undefined);
+
+  return node;
+}

--- a/packages/react/src/hooks/useMoveSelectedNodes.ts
+++ b/packages/react/src/hooks/useMoveSelectedNodes.ts
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import { calculateNodePosition, snapPosition, type XYPosition } from '@xyflow/system';
 
-import { Node } from '../types';
+import { InternalNode } from '../types';
 import { useStoreApi } from './useStore';
 
-const selectedAndDraggable = (nodesDraggable: boolean) => (n: Node) =>
+const selectedAndDraggable = (nodesDraggable: boolean) => (n: InternalNode) =>
   n.selected && (n.draggable || (nodesDraggable && typeof n.draggable === 'undefined'));
 
 /**
@@ -17,18 +17,15 @@ export function useMoveSelectedNodes() {
   const store = useStoreApi();
 
   const moveSelectedNodes = useCallback((params: { direction: XYPosition; factor: number }) => {
-    const {
-      nodeExtent,
-      nodes,
-      snapToGrid,
-      snapGrid,
-      nodesDraggable,
-      onError,
-      updateNodePositions,
-      nodeLookup,
-      nodeOrigin,
-    } = store.getState();
-    const selectedNodes = nodes.filter(selectedAndDraggable(nodesDraggable));
+    const { nodeExtent, snapToGrid, snapGrid, nodesDraggable, onError, updateNodePositions, nodeLookup, nodeOrigin } =
+      store.getState();
+    const selectedNodes = [];
+
+    for (const [, node] of nodeLookup) {
+      if (selectedAndDraggable(nodesDraggable)(node)) {
+        selectedNodes.push(node);
+      }
+    }
     // by default a node moves 5px on each key press
     // if snap grid is enabled, we use that for the velocity
     const xVelo = snapToGrid ? snapGrid[0] : 5;

--- a/packages/react/src/hooks/useMoveSelectedNodes.ts
+++ b/packages/react/src/hooks/useMoveSelectedNodes.ts
@@ -35,10 +35,10 @@ export function useMoveSelectedNodes() {
     const yDiff = params.direction.y * yVelo * params.factor;
 
     const nodeUpdates = selectedNodes.map((node) => {
-      if (node.computed?.positionAbsolute) {
+      if (node.internals?.positionAbsolute) {
         let nextPosition = {
-          x: node.computed.positionAbsolute.x + xDiff,
-          y: node.computed.positionAbsolute.y + yDiff,
+          x: node.internals.positionAbsolute.x + xDiff,
+          y: node.internals.positionAbsolute.y + yDiff,
         };
 
         if (snapToGrid) {
@@ -55,7 +55,7 @@ export function useMoveSelectedNodes() {
         });
 
         node.position = position;
-        node.computed.positionAbsolute = positionAbsolute;
+        node.internals.positionAbsolute = positionAbsolute;
       }
 
       return node;

--- a/packages/react/src/hooks/useNodesInitialized.ts
+++ b/packages/react/src/hooks/useNodesInitialized.ts
@@ -1,5 +1,3 @@
-import { internalsSymbol } from '@xyflow/system';
-
 import { useStore } from './useStore';
 import type { ReactFlowState } from '../types';
 
@@ -8,13 +6,13 @@ export type UseNodesInitializedOptions = {
 };
 
 const selector = (options: UseNodesInitializedOptions) => (s: ReactFlowState) => {
-  if (s.nodes.length === 0) {
+  if (s.nodeLookup.size === 0) {
     return false;
   }
 
-  for (const node of s.nodes) {
+  for (const node of s.nodeLookup.values()) {
     if (options.includeHiddenNodes || !node.hidden) {
-      if (node[internalsSymbol]?.handleBounds === undefined) {
+      if (node.computed.handleBounds === undefined) {
         return false;
       }
     }

--- a/packages/react/src/hooks/useNodesInitialized.ts
+++ b/packages/react/src/hooks/useNodesInitialized.ts
@@ -12,7 +12,7 @@ const selector = (options: UseNodesInitializedOptions) => (s: ReactFlowState) =>
 
   for (const node of s.nodeLookup.values()) {
     if (options.includeHiddenNodes || !node.hidden) {
-      if (node.computed.handleBounds === undefined) {
+      if (node.internals.handleBounds === undefined) {
         return false;
       }
     }

--- a/packages/react/src/hooks/useReactFlow.ts
+++ b/packages/react/src/hooks/useReactFlow.ts
@@ -32,7 +32,7 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
   }, []);
 
   const getNode = useCallback<Instance.GetNode<NodeType>>((id) => {
-    return store.getState().nodeLookup.get(id) as NodeType;
+    return store.getState().nodeLookup.get(id)?.computed.userProvidedNode as NodeType;
   }, []);
 
   const getEdges = useCallback<Instance.GetEdges<EdgeType>>(() => {
@@ -225,9 +225,7 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
 
   const getNodeRect = useCallback((nodeOrRect: NodeType | { id: NodeType['id'] }): Rect | null => {
     const node =
-      isNode(nodeOrRect) && nodeHasDimensions(nodeOrRect)
-        ? nodeOrRect
-        : (store.getState().nodeLookup.get(nodeOrRect.id) as NodeType);
+      isNode(nodeOrRect) && nodeHasDimensions(nodeOrRect) ? nodeOrRect : store.getState().nodeLookup.get(nodeOrRect.id);
 
     return node ? nodeToRect(node) : null;
   }, []);
@@ -242,7 +240,8 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
       }
 
       return (nodes || store.getState().nodes).filter((n) => {
-        if (!isRect && (n.id === nodeOrRect!.id || !n.computed?.positionAbsolute)) {
+        const internalNode = store.getState().nodeLookup.get(n.id);
+        if (!isRect && (n.id === nodeOrRect!.id || !internalNode?.computed.positionAbsolute)) {
           return false;
         }
 

--- a/packages/react/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/react/src/hooks/useUpdateNodeInternals.ts
@@ -13,7 +13,7 @@ export function useUpdateNodeInternals(): UpdateNodeInternals {
   const store = useStoreApi();
 
   return useCallback<UpdateNodeInternals>((id: string | string[]) => {
-    const { domNode, updateNodeDimensions } = store.getState();
+    const { domNode, updateInternalNodeValues } = store.getState();
     const updateIds = Array.isArray(id) ? id : [id];
     const updates = new Map<string, NodeDimensionUpdate>();
 
@@ -21,10 +21,10 @@ export function useUpdateNodeInternals(): UpdateNodeInternals {
       const nodeElement = domNode?.querySelector(`.react-flow__node[data-id="${updateId}"]`) as HTMLDivElement;
 
       if (nodeElement) {
-        updates.set(updateId, { id: updateId, nodeElement, forceUpdate: true });
+        updates.set(updateId, { id: updateId, nodeElement });
       }
     });
 
-    requestAnimationFrame(() => updateNodeDimensions(updates));
+    requestAnimationFrame(() => updateInternalNodeValues(updates));
   }, []);
 }

--- a/packages/react/src/hooks/useViewportHelper.ts
+++ b/packages/react/src/hooks/useViewportHelper.ts
@@ -48,12 +48,13 @@ const useViewportHelper = (): ViewportHelperFunctions => {
         return { x, y, zoom };
       },
       fitView: (options) => {
-        const { nodes, width, height, nodeOrigin, minZoom, maxZoom, panZoom } = store.getState();
+        const { nodes, nodeLookup, width, height, nodeOrigin, minZoom, maxZoom, panZoom } = store.getState();
 
         return panZoom
           ? fitView(
               {
                 nodes,
+                nodeLookup,
                 width,
                 height,
                 nodeOrigin,

--- a/packages/react/src/hooks/useVisibleNodeIds.ts
+++ b/packages/react/src/hooks/useVisibleNodeIds.ts
@@ -1,13 +1,13 @@
+import { useCallback } from 'react';
 import { getNodesInside } from '@xyflow/system';
 import { shallow } from 'zustand/shallow';
 
 import { useStore } from './useStore';
-import type { Node, ReactFlowState } from '../types';
-import { useCallback } from 'react';
+import type { ReactFlowState } from '../types';
 
 const selector = (onlyRenderVisible: boolean) => (s: ReactFlowState) => {
   return onlyRenderVisible
-    ? getNodesInside<Node>(s.nodes, { x: 0, y: 0, width: s.width, height: s.height }, s.transform, true).map(
+    ? getNodesInside(s.nodeLookup, { x: 0, y: 0, width: s.width, height: s.height }, s.transform, true).map(
         (node) => node.id
       )
     : Array.from(s.nodeLookup.keys());

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export { useNodesInitialized, type UseNodesInitializedOptions } from './hooks/us
 export { useHandleConnections } from './hooks/useHandleConnections';
 export { useNodesData } from './hooks/useNodesData';
 export { useConnection } from './hooks/useConnection';
+export { useInternalNode } from './hooks/useInternalNode';
 export { useNodeId } from './contexts/NodeIdContext';
 
 export { applyNodeChanges, applyEdgeChanges } from './utils/changes';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -28,7 +28,7 @@ export { useNodesData } from './hooks/useNodesData';
 export { useConnection } from './hooks/useConnection';
 export { useNodeId } from './contexts/NodeIdContext';
 
-export { applyNodeChanges, applyEdgeChanges, handleParentExpand } from './utils/changes';
+export { applyNodeChanges, applyEdgeChanges } from './utils/changes';
 export { isNode, isEdge } from './utils/general';
 
 export * from './additional-components';
@@ -103,5 +103,4 @@ export {
   addEdge,
   updateEdge,
   getConnectedEdges,
-  internalsSymbol,
 } from '@xyflow/system';

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -131,7 +131,7 @@ const createRFStore = ({
             id: node.id,
             type: 'position',
             position: node.position,
-            positionAbsolute: node.computed.positionAbsolute,
+            positionAbsolute: node.internals.positionAbsolute,
             dragging,
           };
 
@@ -185,7 +185,7 @@ const createRFStore = ({
         }
       },
       addSelectedNodes: (selectedNodeIds) => {
-        const { multiSelectionActive, edges, nodes, triggerNodeChanges, triggerEdgeChanges } = get();
+        const { multiSelectionActive, edgeLookup, nodeLookup, triggerNodeChanges, triggerEdgeChanges } = get();
 
         if (multiSelectionActive) {
           const nodeChanges = selectedNodeIds.map((nodeId) => createSelectionChange(nodeId, true));
@@ -193,11 +193,11 @@ const createRFStore = ({
           return;
         }
 
-        triggerNodeChanges(getSelectionChanges(nodes, new Set([...selectedNodeIds]), true));
-        triggerEdgeChanges(getSelectionChanges(edges));
+        triggerNodeChanges(getSelectionChanges(nodeLookup, new Set([...selectedNodeIds]), true));
+        triggerEdgeChanges(getSelectionChanges(edgeLookup));
       },
       addSelectedEdges: (selectedEdgeIds) => {
-        const { multiSelectionActive, edges, nodes, triggerNodeChanges, triggerEdgeChanges } = get();
+        const { multiSelectionActive, edgeLookup, nodeLookup, triggerNodeChanges, triggerEdgeChanges } = get();
 
         if (multiSelectionActive) {
           const changedEdges = selectedEdgeIds.map((edgeId) => createSelectionChange(edgeId, true));
@@ -205,8 +205,8 @@ const createRFStore = ({
           return;
         }
 
-        triggerEdgeChanges(getSelectionChanges(edges, new Set([...selectedEdgeIds])));
-        triggerNodeChanges(getSelectionChanges(nodes, new Set(), true));
+        triggerEdgeChanges(getSelectionChanges(edgeLookup, new Set([...selectedEdgeIds])));
+        triggerNodeChanges(getSelectionChanges(nodeLookup, new Set(), true));
       },
       unselectNodesAndEdges: ({ nodes, edges }: UnselectNodesAndEdgesParams = {}) => {
         const { edges: storeEdges, nodes: storeNodes, triggerNodeChanges, triggerEdgeChanges } = get();
@@ -260,7 +260,7 @@ const createRFStore = ({
         nodeLookup.forEach((node) => {
           const positionAbsolute = clampPosition(node.position, nodeExtent);
 
-          nodeLookup.set(node.id, { ...node, computed: { ...node.computed, positionAbsolute } });
+          nodeLookup.set(node.id, { ...node, internals: { ...node.internals, positionAbsolute } });
         });
 
         set({

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -8,6 +8,7 @@ import {
   Dimensions,
   updateNodeDimensions as updateNodeDimensionsSystem,
   updateConnectionLookup,
+  internalsSymbol,
 } from '@xyflow/system';
 
 import { applyEdgeChanges, applyNodeChanges, createSelectionChange, getSelectionChanges } from '../utils/changes';
@@ -100,11 +101,11 @@ const createRFStore = ({
           domNode,
           nodeOrigin,
           (id: string, dimensions: Dimensions) => {
-            changes.push({
+            /*changes.push({
               id: id,
               type: 'dimensions',
               dimensions,
-            });
+            });*/
           }
         );
 
@@ -130,6 +131,8 @@ const createRFStore = ({
         // attribute which they get from this handler.
         set({ nodes: nextNodes, fitViewDone: nextFitViewDone });
 
+        console.log(changes, nextNodes);
+
         if (changes?.length > 0) {
           if (debug) {
             console.log('React Flow: trigger node changes', changes);
@@ -143,7 +146,7 @@ const createRFStore = ({
             id: node.id,
             type: 'position',
             position: node.position,
-            positionAbsolute: node.computed?.positionAbsolute,
+            positionAbsolute: node[internalsSymbol]?.positionAbsolute,
             dragging,
           };
 

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -35,7 +35,7 @@ const getInitialState = ({
   const storeNodes = defaultNodes ?? nodes ?? [];
 
   updateConnectionLookup(connectionLookup, edgeLookup, storeEdges);
-  const nextNodes = adoptUserProvidedNodes(storeNodes, nodeLookup, {
+  adoptUserProvidedNodes(storeNodes, nodeLookup, {
     nodeOrigin: [0, 0],
     elevateNodesOnSelect: false,
   });
@@ -43,7 +43,7 @@ const getInitialState = ({
   let transform: Transform = [0, 0, 1];
 
   if (fitView && width && height) {
-    const nodesWithDimensions = nextNodes.filter(
+    const nodesWithDimensions = storeNodes.filter(
       (node) => (node.width || node.initialWidth) && (node.height || node.initialHeight)
     );
     // @todo users nodeOrigin should be used here
@@ -57,7 +57,7 @@ const getInitialState = ({
     width: 0,
     height: 0,
     transform,
-    nodes: nextNodes,
+    nodes: storeNodes,
     nodeLookup,
     edges: storeEdges,
     edgeLookup,

--- a/packages/react/src/types/instance.ts
+++ b/packages/react/src/types/instance.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import type { Rect, Viewport } from '@xyflow/system';
-import type { Node, Edge, ViewportHelperFunctions } from '.';
+import type { NodeHandleBounds, NodeLookup, Rect, Viewport, XYPosition } from '@xyflow/system';
+import type { Node, Edge, ViewportHelperFunctions, InternalNode } from '.';
 
 export type ReactFlowJsonObject<NodeType extends Node = Node, EdgeType extends Edge = Edge> = {
   nodes: NodeType[];
@@ -165,5 +165,17 @@ export type ReactFlowInstance<NodeType extends Node = Node, EdgeType extends Edg
    * updateNodeData('node-1', { label: 'A new label' });
    */
   updateNodeData: Instance.UpdateNodeData<NodeType>;
+
+  getInternalNode: (id: string) => InternalNode<NodeType> | undefined;
+  getInternalNodeValues: (id: string) =>
+    | {
+        width?: number;
+        height?: number;
+        positionAbsolute?: XYPosition;
+        handles?: NodeHandleBounds;
+        zIndex?: number;
+      }
+    | undefined;
+  getInternalNodeLookup: () => NodeLookup<InternalNode<NodeType>>;
   viewportInitialized: boolean;
 } & Omit<ViewportHelperFunctions, 'initialized'>;

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -1,5 +1,12 @@
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
-import type { CoordinateExtent, NodeBase, NodeOrigin, OnError, NodeProps as NodePropsBase } from '@xyflow/system';
+import type {
+  CoordinateExtent,
+  NodeBase,
+  InternalNodeBase,
+  NodeOrigin,
+  OnError,
+  NodeProps as NodePropsBase,
+} from '@xyflow/system';
 
 import { NodeTypes } from './general';
 
@@ -16,6 +23,8 @@ export type Node<
   resizing?: boolean;
   focusable?: boolean;
 };
+
+export type InternalNode<NodeType extends Node = Node> = InternalNodeBase<NodeType>;
 
 export type NodeMouseHandler<NodeType extends Node = Node> = (event: ReactMouseEvent, node: NodeType) => void;
 export type SelectionDragHandler<NodeType extends Node = Node> = (event: ReactMouseEvent, nodes: NodeType[]) => void;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -154,7 +154,7 @@ export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   setNodes: (nodes: NodeType[]) => void;
   setEdges: (edges: EdgeType[]) => void;
   setDefaultNodesAndEdges: (nodes?: NodeType[], edges?: EdgeType[]) => void;
-  updateNodeDimensions: (updates: Map<string, NodeDimensionUpdate>) => void;
+  updateInternalNodeValues: (updates: Map<string, NodeDimensionUpdate>) => void;
   updateNodePositions: UpdateNodePositions;
   resetSelectedElements: () => void;
   unselectNodesAndEdges: (params?: UnselectNodesAndEdgesParams) => void;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -44,6 +44,7 @@ import type {
   OnBeforeDelete,
   IsValidConnection,
   EdgeChange,
+  InternalNode,
 } from '.';
 
 export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge = Edge> = {
@@ -52,7 +53,7 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
   height: number;
   transform: Transform;
   nodes: NodeType[];
-  nodeLookup: NodeLookup<NodeType>;
+  nodeLookup: NodeLookup<InternalNode<NodeType>>;
   edges: Edge[];
   edgeLookup: EdgeLookup<EdgeType>;
   connectionLookup: ConnectionLookup;

--- a/packages/react/src/utils/changes.ts
+++ b/packages/react/src/utils/changes.ts
@@ -1,51 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EdgeLookup, NodeLookup } from '@xyflow/system';
-import type { Node, Edge, EdgeChange, NodeChange, NodeSelectionChange, EdgeSelectionChange } from '../types';
-
-export function handleParentExpand(updatedElements: any[], updateItem: any) {
-  for (const [index, item] of updatedElements.entries()) {
-    if (item.id === updateItem.parentNode) {
-      const parent = { ...item };
-      parent.computed ??= {};
-
-      const extendWidth = updateItem.position.x + updateItem.computed.width - parent.computed.width;
-      const extendHeight = updateItem.position.y + updateItem.computed.height - parent.computed.height;
-
-      if (extendWidth > 0 || extendHeight > 0 || updateItem.position.x < 0 || updateItem.position.y < 0) {
-        parent.width = parent.width ?? parent.computed.width;
-        parent.height = parent.height ?? parent.computed.height;
-
-        if (extendWidth > 0) {
-          parent.width += extendWidth;
-        }
-
-        if (extendHeight > 0) {
-          parent.height += extendHeight;
-        }
-
-        if (updateItem.position.x < 0) {
-          const xDiff = Math.abs(updateItem.position.x);
-          parent.position.x = parent.position.x - xDiff;
-          parent.width += xDiff;
-          updateItem.position.x = 0;
-        }
-
-        if (updateItem.position.y < 0) {
-          const yDiff = Math.abs(updateItem.position.y);
-          parent.position.y = parent.position.y - yDiff;
-          parent.height += yDiff;
-          updateItem.position.y = 0;
-        }
-
-        parent.computed.width = parent.width;
-        parent.computed.height = parent.height;
-
-        updatedElements[index] = parent;
-      }
-      break;
-    }
-  }
-}
+import type {
+  Node,
+  Edge,
+  EdgeChange,
+  NodeChange,
+  NodeSelectionChange,
+  EdgeSelectionChange,
+  InternalNode,
+} from '../types';
 
 // This function applies changes to nodes or edges that are triggered by React Flow internally.
 // When you drag a node for example, React Flow will send a position change update.
@@ -103,7 +66,7 @@ function applyChanges(changes: any[], elements: any[]): any[] {
     const updatedElement = { ...element };
 
     for (const change of changes) {
-      applyChange(change, updatedElement, updatedElements);
+      applyChange(change, updatedElement);
     }
 
     updatedElements.push(updatedElement);
@@ -113,7 +76,7 @@ function applyChanges(changes: any[], elements: any[]): any[] {
 }
 
 // Applies a single change to an element. This is a *mutable* update.
-function applyChange(change: any, element: any, elements: any[] = []): any {
+function applyChange(change: any, element: any): any {
   switch (change.type) {
     case 'select': {
       element.selected = change.selected;
@@ -134,17 +97,15 @@ function applyChange(change: any, element: any, elements: any[] = []): any {
         element.dragging = change.dragging;
       }
 
-      if (element.expandParent) {
-        handleParentExpand(elements, element);
-      }
       break;
     }
 
     case 'dimensions': {
       if (typeof change.dimensions !== 'undefined') {
-        element.computed ??= {};
-        element.computed.width = change.dimensions.width;
-        element.computed.height = change.dimensions.height;
+        // @todo do we still need to apply this change here
+        // or can we reanme dimension change to resize change?
+        element.width = change.dimensions.width;
+        element.height = change.dimensions.height;
 
         if (change.resizing) {
           element.width = change.dimensions.width;
@@ -154,10 +115,6 @@ function applyChange(change: any, element: any, elements: any[] = []): any {
 
       if (typeof change.resizing === 'boolean') {
         element.resizing = change.resizing;
-      }
-
-      if (element.expandParent) {
-        handleParentExpand(elements, element);
       }
 
       break;
@@ -266,7 +223,7 @@ export function getElementsDiffChanges({
   lookup,
 }: {
   items: Node[] | undefined;
-  lookup: NodeLookup<Node>;
+  lookup: NodeLookup<InternalNode<Node>>;
 }): NodeChange[];
 export function getElementsDiffChanges({
   items,

--- a/packages/react/src/utils/changes.ts
+++ b/packages/react/src/utils/changes.ts
@@ -88,9 +88,10 @@ function applyChange(change: any, element: any): any {
         element.position = change.position;
       }
 
+      // @todo do we still need to apply this change here or do we only want to handle it internally?
       if (typeof change.positionAbsolute !== 'undefined') {
-        element.computed ??= {};
-        element.computed.positionAbsolute = change.positionAbsolute;
+        element.internals ??= {};
+        element.internals.positionAbsolute = change.positionAbsolute;
       }
 
       if (typeof change.dragging !== 'undefined') {
@@ -185,13 +186,13 @@ export function createSelectionChange(id: string, selected: boolean): NodeSelect
 }
 
 export function getSelectionChanges(
-  items: any[],
+  items: Map<string, any>,
   selectedIds: Set<string> = new Set(),
   mutateItem = false
 ): NodeSelectionChange[] | EdgeSelectionChange[] {
   const changes: NodeSelectionChange[] | EdgeSelectionChange[] = [];
 
-  for (const item of items) {
+  for (const [, item] of items) {
     const willBeSelected = selectedIds.has(item.id);
 
     // we don't want to set all items to selected=false on the first selection

--- a/packages/react/src/utils/general.ts
+++ b/packages/react/src/utils/general.ts
@@ -1,7 +1,7 @@
 import { ReactNode, Ref, RefAttributes, forwardRef } from 'react';
-import { isNodeBase, isEdgeBase } from '@xyflow/system';
+import { isNodeBase, isEdgeBase, isInternalNodeBase } from '@xyflow/system';
 
-import type { Edge, Node } from '../types';
+import type { Edge, InternalNode, Node } from '../types';
 
 /**
  * Test whether an object is useable as a Node
@@ -12,6 +12,8 @@ import type { Edge, Node } from '../types';
  */
 export const isNode = <NodeType extends Node = Node>(element: unknown): element is NodeType =>
   isNodeBase<NodeType>(element);
+
+export const isInternalNode = (element: unknown): element is InternalNode => isInternalNodeBase(element);
 
 /**
  * Test whether an object is useable as an Edge

--- a/packages/system/src/types/changes.ts
+++ b/packages/system/src/types/changes.ts
@@ -1,0 +1,69 @@
+import type { XYPosition, Dimensions, NodeBase, EdgeBase } from '.';
+
+export type NodeDimensionChange = {
+  id: string;
+  type: 'dimensions';
+  dimensions?: Dimensions;
+  resizing?: boolean;
+};
+
+export type NodePositionChange = {
+  id: string;
+  type: 'position';
+  position?: XYPosition;
+  positionAbsolute?: XYPosition;
+  dragging?: boolean;
+};
+
+export type NodeSelectionChange = {
+  id: string;
+  type: 'select';
+  selected: boolean;
+};
+
+export type NodeRemoveChange = {
+  id: string;
+  type: 'remove';
+};
+
+export type NodeAddChange<NodeType extends NodeBase = NodeBase> = {
+  item: NodeType;
+  type: 'add';
+};
+
+export type NodeReplaceChange<NodeType extends NodeBase = NodeBase> = {
+  id: string;
+  item: NodeType;
+  type: 'replace';
+};
+
+/**
+ * Union type of all possible node changes.
+ * @public
+ */
+export type NodeChange<NodeType extends NodeBase = NodeBase> =
+  | NodeDimensionChange
+  | NodePositionChange
+  | NodeSelectionChange
+  | NodeRemoveChange
+  | NodeAddChange<NodeType>
+  | NodeReplaceChange<NodeType>;
+
+export type EdgeSelectionChange = NodeSelectionChange;
+export type EdgeRemoveChange = NodeRemoveChange;
+export type EdgeAddChange<EdgeType extends EdgeBase = EdgeBase> = {
+  item: EdgeType;
+  type: 'add';
+};
+
+export type EdgeReplaceChange<EdgeType extends EdgeBase = EdgeBase> = {
+  id: string;
+  item: EdgeType;
+  type: 'replace';
+};
+
+export type EdgeChange<EdgeType extends EdgeBase = EdgeBase> =
+  | EdgeSelectionChange
+  | EdgeRemoveChange
+  | EdgeAddChange<EdgeType>
+  | EdgeReplaceChange<EdgeType>;

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -2,7 +2,7 @@
 import type { D3DragEvent, Selection as D3Selection, SubjectPosition, ZoomBehavior } from 'd3';
 
 import type { XYPosition, Rect } from './utils';
-import type { NodeBase, NodeDragItem, NodeOrigin } from './nodes';
+import type { InternalNodeBase, NodeBase, NodeDragItem, NodeLookup, NodeOrigin } from './nodes';
 import type { ConnectingHandle, HandleType } from './handles';
 import { PanZoomInstance } from './panzoom';
 import { EdgeBase } from '..';
@@ -56,6 +56,7 @@ export type FitViewParamsBase<NodeType extends NodeBase> = {
   width: number;
   height: number;
   panZoom: PanZoomInstance;
+  nodeLookup: NodeLookup<InternalNodeBase>;
   minZoom: number;
   maxZoom: number;
   nodeOrigin?: NodeOrigin;
@@ -127,7 +128,7 @@ export type SelectionRect = Rect & {
 
 export type OnError = (id: string, message: string) => void;
 
-export type UpdateNodePositions = (dragItems: NodeDragItem[] | NodeBase[], dragging?: boolean) => void;
+export type UpdateNodePositions = (dragItems: NodeDragItem[] | InternalNodeBase[], dragging?: boolean) => void;
 export type PanBy = (delta: XYPosition) => boolean;
 
 export type UpdateConnection = (params: {

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -63,7 +63,7 @@ export type NodeBase<
 
 export type InternalNodeBase<NodeType extends NodeBase = NodeBase> = NodeType & {
   // Only used internally
-  computed: {
+  internals: {
     z?: number;
     // @todo should we rename this to "handles" and use same type as node.handles?
     handleBounds?: NodeHandleBounds;
@@ -123,7 +123,7 @@ export type NodeDragItem = {
   dragging?: boolean;
   origin?: NodeOrigin;
   expandParent?: boolean;
-  computed: {
+  internals: {
     width: number | null;
     height: number | null;
     positionAbsolute: XYPosition;

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -65,6 +65,7 @@ export type InternalNodeBase<NodeType extends NodeBase = NodeBase> = NodeType & 
   // Only used internally
   computed: {
     z?: number;
+    // @todo should we rename this to "handles" and use same type as node.handles?
     handleBounds?: NodeHandleBounds;
     isParent?: boolean;
     width?: number;
@@ -104,7 +105,7 @@ export type NodeHandleBounds = {
 export type NodeDimensionUpdate = {
   id: string;
   nodeElement: HTMLDivElement;
-  forceUpdate?: boolean;
+  force?: boolean;
 };
 
 export type NodeBounds = XYPosition & {

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -60,17 +60,16 @@ export type NodeBase<
    */
   origin?: NodeOrigin;
   handles?: NodeHandle[];
-  computed?: {
-    width?: number;
-    height?: number;
-    positionAbsolute?: XYPosition;
-  };
 
   // Only used internally
   [internalsSymbol]?: {
     z?: number;
     handleBounds?: NodeHandleBounds;
     isParent?: boolean;
+    width?: number;
+    height?: number;
+    positionAbsolute?: XYPosition;
+
     /** Holds a reference to the original node object provided by the user
      * (which may lack some fields, like `computed` or `[internalSymbol]`. Used
      * as an optimization to avoid certain operations. */
@@ -117,16 +116,16 @@ export type NodeDragItem = {
   position: XYPosition;
   // distance from the mouse cursor to the node when start dragging
   distance: XYPosition;
-  computed: {
-    width: number | null;
-    height: number | null;
-    positionAbsolute: XYPosition;
-  };
   extent?: 'parent' | CoordinateExtent;
   parentNode?: string;
   dragging?: boolean;
   origin?: NodeOrigin;
   expandParent?: boolean;
+  [internalsSymbol]: {
+    width: number | null;
+    height: number | null;
+    positionAbsolute: XYPosition;
+  };
 };
 
 export type NodeOrigin = [number, number];

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -1,4 +1,3 @@
-import { internalsSymbol } from '../constants';
 import type { XYPosition, Position, CoordinateExtent, HandleElement } from '.';
 import { Optional } from '../utils/types';
 
@@ -60,9 +59,11 @@ export type NodeBase<
    */
   origin?: NodeOrigin;
   handles?: NodeHandle[];
+};
 
+export type InternalNodeBase<NodeType extends NodeBase = NodeBase> = NodeType & {
   // Only used internally
-  [internalsSymbol]?: {
+  computed: {
     z?: number;
     handleBounds?: NodeHandleBounds;
     isParent?: boolean;
@@ -73,7 +74,7 @@ export type NodeBase<
     /** Holds a reference to the original node object provided by the user
      * (which may lack some fields, like `computed` or `[internalSymbol]`. Used
      * as an optimization to avoid certain operations. */
-    userProvidedNode: NodeBase<NodeData, NodeType>;
+    userProvidedNode: NodeType;
   };
 };
 
@@ -121,7 +122,7 @@ export type NodeDragItem = {
   dragging?: boolean;
   origin?: NodeOrigin;
   expandParent?: boolean;
-  [internalsSymbol]: {
+  computed: {
     width: number | null;
     height: number | null;
     positionAbsolute: XYPosition;
@@ -136,4 +137,4 @@ export type NodeHandle = Optional<HandleElement, 'width' | 'height'>;
 
 export type Align = 'center' | 'start' | 'end';
 
-export type NodeLookup<NodeType extends NodeBase = NodeBase> = Map<string, NodeType>;
+export type NodeLookup<NodeType extends InternalNodeBase = InternalNodeBase> = Map<string, NodeType>;

--- a/packages/system/src/utils/edges/general.ts
+++ b/packages/system/src/utils/edges/general.ts
@@ -1,5 +1,5 @@
-import { Connection, Transform, errorMessages, internalsSymbol, isEdgeBase } from '../..';
-import { EdgeBase, NodeBase } from '../../types';
+import { Connection, InternalNodeBase, Transform, errorMessages, isEdgeBase } from '../..';
+import { EdgeBase } from '../../types';
 import { getOverlappingArea, boxToRect, nodeToBox, getBoundsOfBoxes, devWarn } from '../general';
 
 // this is used for straight edges and simple smoothstep edges (LTR, RTL, BTT, TTB)
@@ -24,8 +24,8 @@ export function getEdgeCenter({
 }
 
 export type GetEdgeZIndexParams = {
-  sourceNode: NodeBase;
-  targetNode: NodeBase;
+  sourceNode: InternalNodeBase;
+  targetNode: InternalNodeBase;
   selected?: boolean;
   zIndex?: number;
   elevateOnSelect?: boolean;
@@ -43,14 +43,14 @@ export function getElevatedEdgeZIndex({
   }
 
   const edgeOrConnectedNodeSelected = selected || targetNode.selected || sourceNode.selected;
-  const selectedZIndex = Math.max(sourceNode[internalsSymbol]?.z || 0, targetNode[internalsSymbol]?.z || 0, 1000);
+  const selectedZIndex = Math.max(sourceNode.computed?.z || 0, targetNode.computed?.z || 0, 1000);
 
   return zIndex + (edgeOrConnectedNodeSelected ? selectedZIndex : 0);
 }
 
 type IsEdgeVisibleParams = {
-  sourceNode: NodeBase;
-  targetNode: NodeBase;
+  sourceNode: InternalNodeBase;
+  targetNode: InternalNodeBase;
   width: number;
   height: number;
   transform: Transform;

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -1,25 +1,25 @@
 import { EdgePosition } from '../../types/edges';
 import { ConnectionMode, OnError } from '../../types/general';
-import { NodeBase, NodeHandle } from '../../types/nodes';
+import { InternalNodeBase, NodeHandle } from '../../types/nodes';
 import { Position } from '../../types/utils';
-import { errorMessages, internalsSymbol } from '../../constants';
+import { errorMessages } from '../../constants';
 import { HandleElement } from '../../types';
 import { getNodeDimensions } from '../general';
 
 export type GetEdgePositionParams = {
   id: string;
-  sourceNode: NodeBase;
+  sourceNode: InternalNodeBase;
   sourceHandle: string | null;
-  targetNode: NodeBase;
+  targetNode: InternalNodeBase;
   targetHandle: string | null;
   connectionMode: ConnectionMode;
   onError?: OnError;
 };
 
-function isNodeInitialized(node: NodeBase): boolean {
+function isNodeInitialized(node: InternalNodeBase): boolean {
   return (
-    !!(node?.[internalsSymbol]?.handleBounds || node?.handles?.length) &&
-    !!(node?.[internalsSymbol]?.width || node?.width || node?.initialWidth)
+    !!(node?.computed?.handleBounds || node?.handles?.length) &&
+    !!(node?.computed?.width || node?.width || node?.initialWidth)
   );
 }
 
@@ -30,8 +30,8 @@ export function getEdgePosition(params: GetEdgePositionParams): EdgePosition | n
     return null;
   }
 
-  const sourceHandleBounds = sourceNode[internalsSymbol]?.handleBounds || toHandleBounds(sourceNode.handles);
-  const targetHandleBounds = targetNode[internalsSymbol]?.handleBounds || toHandleBounds(targetNode.handles);
+  const sourceHandleBounds = sourceNode.computed?.handleBounds || toHandleBounds(sourceNode.handles);
+  const targetHandleBounds = targetNode.computed?.handleBounds || toHandleBounds(targetNode.handles);
 
   const sourceHandle = getHandle(sourceHandleBounds?.source ?? [], params.sourceHandle);
   const targetHandle = getHandle(
@@ -95,9 +95,9 @@ function toHandleBounds(handles?: NodeHandle[]) {
   };
 }
 
-function getHandlePosition(position: Position, node: NodeBase, handle: HandleElement | null = null): number[] {
-  const x = (handle?.x ?? 0) + (node[internalsSymbol]?.positionAbsolute?.x ?? 0);
-  const y = (handle?.y ?? 0) + (node[internalsSymbol]?.positionAbsolute?.y ?? 0);
+function getHandlePosition(position: Position, node: InternalNodeBase, handle: HandleElement | null = null): number[] {
+  const x = (handle?.x ?? 0) + (node.computed.positionAbsolute?.x ?? 0);
+  const y = (handle?.y ?? 0) + (node.computed.positionAbsolute?.y ?? 0);
   const { width, height } = handle ?? getNodeDimensions(node);
 
   switch (position) {

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -18,8 +18,8 @@ export type GetEdgePositionParams = {
 
 function isNodeInitialized(node: InternalNodeBase): boolean {
   return (
-    !!(node?.computed?.handleBounds || node?.handles?.length) &&
-    !!(node?.computed?.width || node?.width || node?.initialWidth)
+    !!(node?.internals.handleBounds || node?.handles?.length) &&
+    !!(node?.internals.width || node?.width || node?.initialWidth)
   );
 }
 
@@ -30,8 +30,8 @@ export function getEdgePosition(params: GetEdgePositionParams): EdgePosition | n
     return null;
   }
 
-  const sourceHandleBounds = sourceNode.computed?.handleBounds || toHandleBounds(sourceNode.handles);
-  const targetHandleBounds = targetNode.computed?.handleBounds || toHandleBounds(targetNode.handles);
+  const sourceHandleBounds = sourceNode.internals.handleBounds || toHandleBounds(sourceNode.handles);
+  const targetHandleBounds = targetNode.internals.handleBounds || toHandleBounds(targetNode.handles);
 
   const sourceHandle = getHandle(sourceHandleBounds?.source ?? [], params.sourceHandle);
   const targetHandle = getHandle(
@@ -96,8 +96,8 @@ function toHandleBounds(handles?: NodeHandle[]) {
 }
 
 function getHandlePosition(position: Position, node: InternalNodeBase, handle: HandleElement | null = null): number[] {
-  const x = (handle?.x ?? 0) + (node.computed.positionAbsolute?.x ?? 0);
-  const y = (handle?.y ?? 0) + (node.computed.positionAbsolute?.y ?? 0);
+  const x = (handle?.x ?? 0) + (node.internals.positionAbsolute?.x ?? 0);
+  const y = (handle?.y ?? 0) + (node.internals.positionAbsolute?.y ?? 0);
   const { width, height } = handle ?? getNodeDimensions(node);
 
   switch (position) {

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -19,7 +19,7 @@ export type GetEdgePositionParams = {
 function isNodeInitialized(node: NodeBase): boolean {
   return (
     !!(node?.[internalsSymbol]?.handleBounds || node?.handles?.length) &&
-    !!(node?.computed?.width || node?.width || node?.initialWidth)
+    !!(node?.[internalsSymbol]?.width || node?.width || node?.initialWidth)
   );
 }
 
@@ -96,8 +96,8 @@ function toHandleBounds(handles?: NodeHandle[]) {
 }
 
 function getHandlePosition(position: Position, node: NodeBase, handle: HandleElement | null = null): number[] {
-  const x = (handle?.x ?? 0) + (node.computed?.positionAbsolute?.x ?? 0);
-  const y = (handle?.y ?? 0) + (node.computed?.positionAbsolute?.y ?? 0);
+  const x = (handle?.x ?? 0) + (node[internalsSymbol]?.positionAbsolute?.x ?? 0);
+  const y = (handle?.y ?? 0) + (node[internalsSymbol]?.positionAbsolute?.y ?? 0);
   const { width, height } = handle ?? getNodeDimensions(node);
 
   switch (position) {

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -71,8 +71,8 @@ export const nodeToRect = (node: InternalNodeBase, nodeOrigin: NodeOrigin = [0, 
 
   return {
     ...positionAbsolute,
-    width: node.computed.width ?? node.width ?? 0,
-    height: node.computed.height ?? node.height ?? 0,
+    width: node.internals.width ?? node.width ?? 0,
+    height: node.internals.height ?? node.height ?? 0,
   };
 };
 
@@ -81,8 +81,8 @@ export const nodeToBox = (node: InternalNodeBase, nodeOrigin: NodeOrigin = [0, 0
 
   return {
     ...positionAbsolute,
-    x2: positionAbsolute.x + (node.computed.width ?? node.width ?? 0),
-    y2: positionAbsolute.y + (node.computed.height ?? node.height ?? 0),
+    x2: positionAbsolute.x + (node.internals.width ?? node.width ?? 0),
+    y2: positionAbsolute.y + (node.internals.height ?? node.height ?? 0),
   };
 };
 
@@ -207,19 +207,19 @@ export function isCoordinateExtent(extent?: CoordinateExtent | 'parent'): extent
 export function getNodeDimensions<NodeType extends InternalNodeBase | NodeBase>(
   node: NodeType
 ): { width: number; height: number } {
-  const computedDimensions = 'computed' in node ? node.computed : { width: undefined, height: undefined };
+  const internalDimensions = 'internals' in node ? node.internals : { width: undefined, height: undefined };
 
   return {
-    width: computedDimensions.width ?? node.width ?? node.initialWidth ?? 0,
-    height: computedDimensions.height ?? node.height ?? node.initialHeight ?? 0,
+    width: internalDimensions.width ?? node.width ?? node.initialWidth ?? 0,
+    height: internalDimensions.height ?? node.height ?? node.initialHeight ?? 0,
   };
 }
 
 export function nodeHasDimensions<NodeType extends InternalNodeBase | NodeBase>(node: NodeType): boolean {
-  const computedDimensions = 'computed' in node ? node.computed : { width: undefined, height: undefined };
+  const internalDimensions = 'internals' in node ? node.internals : { width: undefined, height: undefined };
 
   return (
-    (computedDimensions.width ?? node.width ?? node.initialWidth) !== undefined &&
-    (computedDimensions.height ?? node.height ?? node.initialHeight) !== undefined
+    (internalDimensions.width ?? node.width ?? node.initialWidth) !== undefined &&
+    (internalDimensions.height ?? node.height ?? node.initialHeight) !== undefined
   );
 }

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -1,4 +1,3 @@
-import { internalsSymbol } from '../constants';
 import type {
   Dimensions,
   XYPosition,
@@ -9,6 +8,7 @@ import type {
   NodeOrigin,
   SnapGrid,
   Transform,
+  InternalNodeBase,
 } from '../types';
 import { type Viewport } from '../types';
 import { getNodePositionWithOrigin } from './graph';
@@ -66,23 +66,23 @@ export const boxToRect = ({ x, y, x2, y2 }: Box): Rect => ({
   height: y2 - y,
 });
 
-export const nodeToRect = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Rect => {
+export const nodeToRect = (node: InternalNodeBase, nodeOrigin: NodeOrigin = [0, 0]): Rect => {
   const { positionAbsolute } = getNodePositionWithOrigin(node, node.origin || nodeOrigin);
 
   return {
     ...positionAbsolute,
-    width: node[internalsSymbol]?.width ?? node.width ?? 0,
-    height: node[internalsSymbol]?.height ?? node.height ?? 0,
+    width: node.computed.width ?? node.width ?? 0,
+    height: node.computed.height ?? node.height ?? 0,
   };
 };
 
-export const nodeToBox = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Box => {
+export const nodeToBox = (node: InternalNodeBase, nodeOrigin: NodeOrigin = [0, 0]): Box => {
   const { positionAbsolute } = getNodePositionWithOrigin(node, node.origin || nodeOrigin);
 
   return {
     ...positionAbsolute,
-    x2: positionAbsolute.x + (node[internalsSymbol]?.width ?? node.width ?? 0),
-    y2: positionAbsolute.y + (node[internalsSymbol]?.height ?? node.height ?? 0),
+    x2: positionAbsolute.x + (node.computed.width ?? node.width ?? 0),
+    y2: positionAbsolute.y + (node.computed.height ?? node.height ?? 0),
   };
 };
 
@@ -204,18 +204,22 @@ export function isCoordinateExtent(extent?: CoordinateExtent | 'parent'): extent
   return extent !== undefined && extent !== 'parent';
 }
 
-export function getNodeDimensions<NodeType extends NodeBase = NodeBase>(
+export function getNodeDimensions<NodeType extends InternalNodeBase | NodeBase>(
   node: NodeType
 ): { width: number; height: number } {
+  const computedDimensions = 'computed' in node ? node.computed : { width: undefined, height: undefined };
+
   return {
-    width: node[internalsSymbol]?.width ?? node.width ?? node.initialWidth ?? 0,
-    height: node[internalsSymbol]?.height ?? node.height ?? node.initialHeight ?? 0,
+    width: computedDimensions.width ?? node.width ?? node.initialWidth ?? 0,
+    height: computedDimensions.height ?? node.height ?? node.initialHeight ?? 0,
   };
 }
 
-export function nodeHasDimensions<NodeType extends NodeBase = NodeBase>(node: NodeType): boolean {
+export function nodeHasDimensions<NodeType extends InternalNodeBase | NodeBase>(node: NodeType): boolean {
+  const computedDimensions = 'computed' in node ? node.computed : { width: undefined, height: undefined };
+
   return (
-    (node[internalsSymbol]?.width ?? node.width ?? node.initialWidth) !== undefined &&
-    (node[internalsSymbol]?.height ?? node.height ?? node.initialHeight) !== undefined
+    (computedDimensions.width ?? node.width ?? node.initialWidth) !== undefined &&
+    (computedDimensions.height ?? node.height ?? node.initialHeight) !== undefined
   );
 }

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -1,3 +1,4 @@
+import { internalsSymbol } from '../constants';
 import type {
   Dimensions,
   XYPosition,
@@ -70,8 +71,8 @@ export const nodeToRect = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Rec
 
   return {
     ...positionAbsolute,
-    width: node.computed?.width ?? node.width ?? 0,
-    height: node.computed?.height ?? node.height ?? 0,
+    width: node[internalsSymbol]?.width ?? node.width ?? 0,
+    height: node[internalsSymbol]?.height ?? node.height ?? 0,
   };
 };
 
@@ -80,8 +81,8 @@ export const nodeToBox = (node: NodeBase, nodeOrigin: NodeOrigin = [0, 0]): Box 
 
   return {
     ...positionAbsolute,
-    x2: positionAbsolute.x + (node.computed?.width ?? node.width ?? 0),
-    y2: positionAbsolute.y + (node.computed?.height ?? node.height ?? 0),
+    x2: positionAbsolute.x + (node[internalsSymbol]?.width ?? node.width ?? 0),
+    y2: positionAbsolute.y + (node[internalsSymbol]?.height ?? node.height ?? 0),
   };
 };
 
@@ -207,14 +208,14 @@ export function getNodeDimensions<NodeType extends NodeBase = NodeBase>(
   node: NodeType
 ): { width: number; height: number } {
   return {
-    width: node.computed?.width ?? node.width ?? node.initialWidth ?? 0,
-    height: node.computed?.height ?? node.height ?? node.initialHeight ?? 0,
+    width: node[internalsSymbol]?.width ?? node.width ?? node.initialWidth ?? 0,
+    height: node[internalsSymbol]?.height ?? node.height ?? node.initialHeight ?? 0,
   };
 }
 
 export function nodeHasDimensions<NodeType extends NodeBase = NodeBase>(node: NodeType): boolean {
   return (
-    (node.computed?.width ?? node.width ?? node.initialWidth) !== undefined &&
-    (node.computed?.height ?? node.height ?? node.initialHeight) !== undefined
+    (node[internalsSymbol]?.width ?? node.width ?? node.initialWidth) !== undefined &&
+    (node[internalsSymbol]?.height ?? node.height ?? node.initialHeight) !== undefined
   );
 }

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -131,12 +131,12 @@ export const getNodePositionWithOrigin = (
     y: node.position.y - offsetY,
   };
 
-  if (isInternalNodeBase(node) && node.computed.positionAbsolute) {
+  if (isInternalNodeBase(node) && node.internals.positionAbsolute) {
     return {
       position,
       positionAbsolute: {
-        x: node.computed.positionAbsolute.x - offsetX,
-        y: node.computed.positionAbsolute.y - offsetY,
+        x: node.internals.positionAbsolute.x - offsetX,
+        y: node.internals.positionAbsolute.y - offsetY,
       },
     };
   }
@@ -241,8 +241,8 @@ export const getNodesInside = <NodeType extends InternalNodeBase>(
 
   nodeLookup.forEach((node) => {
     const { selectable = true, hidden = false } = node;
-    const width = node.computed.width ?? node.width ?? node.initialWidth ?? null;
-    const height = node.computed.height ?? node.height ?? node.initialHeight ?? null;
+    const width = node.internals.width ?? node.width ?? node.initialWidth ?? null;
+    const height = node.internals.height ?? node.height ?? node.initialHeight ?? null;
 
     if ((excludeNonSelectableNodes && !selectable) || hidden) {
       return;
@@ -291,8 +291,8 @@ export function fitView<Params extends FitViewParamsBase<NodeBase>, Options exte
     const internalNode = nodeLookup.get(n.id);
     const isVisible =
       internalNode &&
-      internalNode.computed.width &&
-      internalNode.computed.height &&
+      internalNode.internals.width &&
+      internalNode.internals.height &&
       (options?.includeHiddenNodes || !n.hidden);
 
     if (isVisible) {
@@ -340,7 +340,7 @@ function clampNodeExtent<NodeType extends InternalNodeBase>(
   if (!extent || extent === 'parent') {
     return extent;
   }
-  return [extent[0], [extent[1][0] - (node.computed.width ?? 0), extent[1][1] - (node.computed.height ?? 0)]];
+  return [extent[0], [extent[1][0] - (node.internals.width ?? 0), extent[1][1] - (node.internals.height ?? 0)]];
 }
 
 /**
@@ -375,10 +375,10 @@ export function calculateNodePosition<NodeType extends InternalNodeBase>({
     if (!parentNode) {
       onError?.('005', errorMessages['error005']());
     } else {
-      const nodeWidth = node.computed.width;
-      const nodeHeight = node.computed.height;
-      const parentWidth = parentNode.computed.width;
-      const parentHeight = parentNode.computed.height;
+      const nodeWidth = node.internals.width;
+      const nodeHeight = node.internals.height;
+      const parentWidth = parentNode.internals.width;
+      const parentHeight = parentNode.internals.height;
 
       if (nodeWidth && nodeHeight && parentWidth && parentHeight) {
         const currNodeOrigin = node.origin || nodeOrigin;

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -40,24 +40,24 @@ export function updateAbsolutePositions<NodeType extends NodeBase>(
         nodeLookup,
         {
           ...node.position,
-          z: internalNode.computed.z ?? 0,
+          z: internalNode.internals.z ?? 0,
         },
         parentNode?.origin || nodeOrigin
       );
 
       const positionChanged =
-        x !== internalNode.computed.positionAbsolute?.x || y !== internalNode.computed.positionAbsolute?.y;
-      internalNode.computed.positionAbsolute = positionChanged
+        x !== internalNode.internals.positionAbsolute?.x || y !== internalNode.internals.positionAbsolute?.y;
+      internalNode.internals.positionAbsolute = positionChanged
         ? {
             x,
             y,
           }
-        : internalNode.computed.positionAbsolute;
+        : internalNode.internals.positionAbsolute;
 
-      internalNode.computed.z = z;
+      internalNode.internals.z = z;
 
       if (parentNodes?.[node.id]) {
-        internalNode.computed.isParent = true;
+        internalNode.internals.isParent = true;
       }
     }
   });
@@ -87,7 +87,7 @@ export function adoptUserProvidedNodes<NodeType extends NodeBase>(
   nodes.forEach((n) => {
     const storeNode = tmpLookup.get(n.id);
 
-    if (n === storeNode?.computed.userProvidedNode) {
+    if (n === storeNode?.internals.userProvidedNode) {
       nodeLookup.set(n.id, storeNode);
       return storeNode;
     }
@@ -95,15 +95,15 @@ export function adoptUserProvidedNodes<NodeType extends NodeBase>(
     const node: InternalNodeBase<NodeType> = {
       ...options.defaults,
       ...n,
-      computed: {
-        handleBounds: storeNode?.computed?.handleBounds,
+      internals: {
+        handleBounds: storeNode?.internals?.handleBounds,
         positionAbsolute: n.position,
         // @todo how to deal with stored dimensions?
         // if we do not add computed.width/height to user nodes
         // it's hard to figure out, if node needs to be re-measured
         // we can't just use the existing dimensions, because they might be outdated
-        width: n.width ?? storeNode?.computed.width,
-        height: n.height ?? storeNode?.computed.height,
+        width: n.width ?? storeNode?.internals.width,
+        height: n.height ?? storeNode?.internals.height,
         userProvidedNode: n,
         z: (isNumeric(n.zIndex) ? n.zIndex : 0) + (n.selected ? selectedNodeZ : 0),
       },
@@ -138,7 +138,7 @@ function calculateXYZPosition<NodeType extends NodeBase>(
     {
       x: (result.x ?? 0) + parentNodePosition.x,
       y: (result.y ?? 0) + parentNodePosition.y,
-      z: (parentNode.computed.z ?? 0) > (result.z ?? 0) ? parentNode.computed.z ?? 0 : result.z ?? 0,
+      z: (parentNode.internals.z ?? 0) > (result.z ?? 0) ? parentNode.internals.z ?? 0 : result.z ?? 0,
     },
     parentNode.origin || nodeOrigin
   );
@@ -231,9 +231,9 @@ export function updateNodeDimensions<NodeType extends InternalNodeBase>(
       const doUpdate = !!(
         dimensions.width &&
         dimensions.height &&
-        (internalNode.computed.width !== dimensions.width ||
-          internalNode.computed.height !== dimensions.height ||
-          !internalNode.computed?.handleBounds ||
+        (internalNode.internals.width !== dimensions.width ||
+          internalNode.internals.height !== dimensions.height ||
+          !internalNode.internals?.handleBounds ||
           update.force)
       );
 
@@ -242,8 +242,8 @@ export function updateNodeDimensions<NodeType extends InternalNodeBase>(
 
         const newNode = {
           ...internalNode,
-          computed: {
-            ...internalNode.computed,
+          internals: {
+            ...internalNode.internals,
             ...dimensions,
             handleBounds: {
               source: getHandleBounds('.source', update.nodeElement, zoom, internalNode.origin || nodeOrigin),

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -137,13 +137,13 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         ];
 
         if (dragItems.length > 1 && nodeExtent && !n.extent) {
-          adjustedNodeExtent[0][0] = n.computed.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
+          adjustedNodeExtent[0][0] = n.internals.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
           adjustedNodeExtent[1][0] =
-            n.computed.positionAbsolute.x + (n.computed.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
+            n.internals.positionAbsolute.x + (n.internals.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
 
-          adjustedNodeExtent[0][1] = n.computed.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
+          adjustedNodeExtent[0][1] = n.internals.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
           adjustedNodeExtent[1][1] =
-            n.computed.positionAbsolute.y + (n.computed.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
+            n.internals.positionAbsolute.y + (n.internals.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
         }
 
         const { position, positionAbsolute } = calculateNodePosition({
@@ -159,7 +159,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         hasChange = hasChange || n.position.x !== position.x || n.position.y !== position.y;
 
         n.position = position;
-        n.computed.positionAbsolute = positionAbsolute;
+        n.internals.positionAbsolute = positionAbsolute;
 
         return n;
       });
@@ -209,7 +209,6 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
 
     function startDrag(event: UseDragEvent) {
       const {
-        nodes,
         nodeLookup,
         multiSelectionActive,
         nodesDraggable,
@@ -237,7 +236,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
 
       const pointerPos = getPointerPosition(event.sourceEvent, { transform, snapGrid, snapToGrid });
       lastPos = pointerPos;
-      dragItems = getDragItems(nodes, nodesDraggable, pointerPos, nodeLookup, nodeId);
+      dragItems = getDragItems(nodesDraggable, pointerPos, nodeLookup, nodeId);
 
       if (dragItems.length > 0 && (onDragStart || onNodeDragStart || (!nodeId && onSelectionDragStart))) {
         const [currentNode, currentNodes] = getEventHandlerParams({

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -27,6 +27,7 @@ import type {
   UpdateNodePositions,
   Box,
 } from '../types';
+import { internalsSymbol } from '..';
 
 export type OnDrag = (event: MouseEvent, dragItems: NodeDragItem[], node: NodeBase, nodes: NodeBase[]) => void;
 
@@ -136,13 +137,13 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         ];
 
         if (dragItems.length > 1 && nodeExtent && !n.extent) {
-          adjustedNodeExtent[0][0] = n.computed.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
+          adjustedNodeExtent[0][0] = n[internalsSymbol]?.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
           adjustedNodeExtent[1][0] =
-            n.computed.positionAbsolute.x + (n.computed?.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
+            n[internalsSymbol]?.positionAbsolute.x + (n[internalsSymbol]?.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
 
-          adjustedNodeExtent[0][1] = n.computed.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
+          adjustedNodeExtent[0][1] = n[internalsSymbol]?.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
           adjustedNodeExtent[1][1] =
-            n.computed.positionAbsolute.y + (n.computed?.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
+            n[internalsSymbol]?.positionAbsolute.y + (n[internalsSymbol]?.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
         }
 
         const { position, positionAbsolute } = calculateNodePosition({
@@ -158,7 +159,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         hasChange = hasChange || n.position.x !== position.x || n.position.y !== position.y;
 
         n.position = position;
-        n.computed.positionAbsolute = positionAbsolute;
+        n[internalsSymbol].positionAbsolute = positionAbsolute;
 
         return n;
       });

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -26,14 +26,14 @@ import type {
   OnSelectionDrag,
   UpdateNodePositions,
   Box,
+  InternalNodeBase,
 } from '../types';
-import { internalsSymbol } from '..';
 
 export type OnDrag = (event: MouseEvent, dragItems: NodeDragItem[], node: NodeBase, nodes: NodeBase[]) => void;
 
 type StoreItems<OnNodeDrag> = {
   nodes: NodeBase[];
-  nodeLookup: Map<string, NodeBase>;
+  nodeLookup: Map<string, InternalNodeBase>;
   edges: EdgeBase[];
   nodeExtent: CoordinateExtent;
   snapGrid: SnapGrid;
@@ -137,13 +137,13 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         ];
 
         if (dragItems.length > 1 && nodeExtent && !n.extent) {
-          adjustedNodeExtent[0][0] = n[internalsSymbol]?.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
+          adjustedNodeExtent[0][0] = n.computed.positionAbsolute.x - nodesBox.x + nodeExtent[0][0];
           adjustedNodeExtent[1][0] =
-            n[internalsSymbol]?.positionAbsolute.x + (n[internalsSymbol]?.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
+            n.computed.positionAbsolute.x + (n.computed.width ?? 0) - nodesBox.x2 + nodeExtent[1][0];
 
-          adjustedNodeExtent[0][1] = n[internalsSymbol]?.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
+          adjustedNodeExtent[0][1] = n.computed.positionAbsolute.y - nodesBox.y + nodeExtent[0][1];
           adjustedNodeExtent[1][1] =
-            n[internalsSymbol]?.positionAbsolute.y + (n[internalsSymbol]?.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
+            n.computed.positionAbsolute.y + (n.computed.height ?? 0) - nodesBox.y2 + nodeExtent[1][1];
         }
 
         const { position, positionAbsolute } = calculateNodePosition({
@@ -159,7 +159,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         hasChange = hasChange || n.position.x !== position.x || n.position.y !== position.y;
 
         n.position = position;
-        n[internalsSymbol].positionAbsolute = positionAbsolute;
+        n.computed.positionAbsolute = positionAbsolute;
 
         return n;
       });
@@ -237,7 +237,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
 
       const pointerPos = getPointerPosition(event.sourceEvent, { transform, snapGrid, snapToGrid });
       lastPos = pointerPos;
-      dragItems = getDragItems(nodes, nodesDraggable, pointerPos, nodeId);
+      dragItems = getDragItems(nodes, nodesDraggable, pointerPos, nodeLookup, nodeId);
 
       if (dragItems.length > 0 && (onDragStart || onNodeDragStart || (!nodeId && onSelectionDragStart))) {
         const [currentNode, currentNodes] = getEventHandlerParams({

--- a/packages/system/src/xydrag/utils.ts
+++ b/packages/system/src/xydrag/utils.ts
@@ -1,3 +1,4 @@
+import { internalsSymbol } from '..';
 import { type NodeDragItem, type XYPosition, NodeBase } from '../types';
 
 export function wrapSelectionDragFunc(selectionFunc?: (event: MouseEvent, nodes: NodeBase[]) => void) {
@@ -52,8 +53,8 @@ export function getDragItems<NodeType extends NodeBase>(
       id: n.id,
       position: n.position || { x: 0, y: 0 },
       distance: {
-        x: mousePos.x - (n.computed?.positionAbsolute?.x ?? 0),
-        y: mousePos.y - (n.computed?.positionAbsolute?.y ?? 0),
+        x: mousePos.x - (n[internalsSymbol]?.positionAbsolute?.x ?? 0),
+        y: mousePos.y - (n[internalsSymbol]?.positionAbsolute?.y ?? 0),
       },
       delta: {
         x: 0,
@@ -63,10 +64,10 @@ export function getDragItems<NodeType extends NodeBase>(
       parentNode: n.parentNode,
       origin: n.origin,
       expandParent: n.expandParent,
-      computed: {
-        positionAbsolute: n.computed?.positionAbsolute || { x: 0, y: 0 },
-        width: n.computed?.width || 0,
-        height: n.computed?.height || 0,
+      [internalsSymbol]: {
+        positionAbsolute: n[internalsSymbol]?.positionAbsolute || { x: 0, y: 0 },
+        width: n[internalsSymbol]?.width || 0,
+        height: n[internalsSymbol]?.height || 0,
       },
     }));
 }
@@ -89,10 +90,6 @@ export function getEventHandlerParams<NodeType extends NodeBase>({
     return {
       ...node,
       position: n.position,
-      computed: {
-        ...n.computed,
-        positionAbsolute: n.computed.positionAbsolute,
-      },
     };
   });
 

--- a/packages/system/src/xyhandle/utils.ts
+++ b/packages/system/src/xyhandle/utils.ts
@@ -5,8 +5,8 @@ import {
   type XYPosition,
   type NodeBase,
   type ConnectionHandle,
+  InternalNodeBase,
 } from '../types';
-import { internalsSymbol } from '../constants';
 
 // this functions collects all handles and adds an absolute position
 // so that we can later find the closest handle to the mouse position
@@ -62,7 +62,7 @@ export function getClosestHandle(
 }
 
 type GetHandleLookupParams = {
-  nodes: NodeBase[];
+  nodes: InternalNodeBase[];
   nodeId: string;
   handleId: string | null;
   handleType: string;
@@ -70,8 +70,8 @@ type GetHandleLookupParams = {
 
 export function getHandleLookup({ nodes, nodeId, handleId, handleType }: GetHandleLookupParams) {
   return nodes.reduce<ConnectionHandle[]>((res, node) => {
-    if (node[internalsSymbol]) {
-      const { handleBounds } = node[internalsSymbol];
+    if (node.computed) {
+      const { handleBounds } = node.computed;
       let sourceHandles: ConnectionHandle[] = [];
       let targetHandles: ConnectionHandle[] = [];
 


### PR DESCRIPTION
V12 is a few weeks in alpha testing and it seems that a lot of people are still struggling with the measured node dimensions. This PR is an attempt to make it easier to understand how to access those values. 

## v11 

In v11 users receive the measured dimensions in a dimension change event. After applying the changes, the dimensions are stored in `node.width` and `node.height. This caused a lot of confusion, because users assume that they can use those attributes for setting the actual dimensions (which is not the case..) when it's only used to save the measured ones. We are also using those attributes as an indicator if a node is initialized.

1. user passes nodes
2. react flow measures nodes
3. rf sends dimension changes
4. user applies dimension (node.width and node.height is set now) 
5. node is initialized and visible

## v12 alpha

In v12 we wanted to make this more clear, so we decided to add another attribute called `node.computed` and store the measured dimensions there. We also needed to make this change, because wanted to be able to use `node.width` and `node.height` for specifying node dimensions on user side which is necessary for SSR. In my view this solution is better than what we have in v11, but it's still a bit confusing and you need to know that measured dimensions get added after you receive the initial dimension change events.   

1. user passes nodes
2. react flow measures nodes
3. rf sends dimension changes
4. user applies dimension (node.computed.width and node.computed.height is set now) 
5. node is initialized and visible

## a better solution for v12?

With this PR I am proposing another solution for the node dimensions dilemma. With this PR we are not adding the measured dimensions to the user nodes, but only store them internally. This means that users won't receive the initial dimension change event and need to get the values with new helper functions and hooks: 

1. user passes nodes
2. react flow measures nodes
3. rf stores dimensions internally
4. node is initialized and visible

This PR introduces a new `InternalNode` type that combines the previous `computed` and `[internalsSymbol]` values in an `internals` attribute. The existing `Node` type got a cleanup and doesn't include `computed` and `[internalsSymbol]` anymore. This separation between the node types makes it more clear what to expect on library and on user side. User can access the the internals in a custom node with the `useInternalNode` hook:

```js
const internalNode = useInternalNode(id);
const nodeWidth = internalNode.internals.width;
```

or with the `getInternalNode` helper function:

```js
const { getInternalNode } = useReactFlow();

const onLayout = (direction: string) => {
  const dagreGraph = new dagre.graphlib.Graph();
  dagreGraph.setGraph();
  
  nodes.forEach((node) => {
    const internalNode = getInternalNode(node.id);

    dagreGraph.setNode(node.id, {
      width: internalNode?.internals.width ?? 150,
      height: internalNode?.internals.height ?? 50,
    });
  });
 ...
```

## wdyt?

Any feedback is highly appreciated. We are not sure, if we really want to go this path, because it would introduce a new library behaviour that is way more different than the current v12 (and v11) implementation.
