### PR TITLE
Expose parentNode to custom nodes

### DIFF
--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -44,6 +44,7 @@
   export let height: NodeWrapperProps['height'] = undefined;
   export let dragHandle: NodeWrapperProps['dragHandle'] = undefined;
   export let initialized: NodeWrapperProps['initialized'] = false;
+  export let parentNode: NodeWrapperProps['parentNode'] = undefined;
   let className: string = '';
   export { className as class };
 
@@ -205,6 +206,7 @@
       positionAbsoluteY={positionY}
       {width}
       {height}
+      {parentNode}
     />
   </div>
 {/if}

--- a/packages/svelte/src/lib/components/NodeWrapper/types.ts
+++ b/packages/svelte/src/lib/components/NodeWrapper/types.ts
@@ -20,6 +20,7 @@ export type NodeWrapperProps = Pick<
   | 'height'
   | 'initialWidth'
   | 'initialHeight'
+  | 'parentNode'
 > & {
   computedWidth?: number;
   computedHeight?: number;

--- a/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
+++ b/packages/svelte/src/lib/container/NodeRenderer/NodeRenderer.svelte
@@ -87,6 +87,7 @@
       computedWidth={node.computed?.width}
       computedHeight={node.computed?.height}
       {resizeObserver}
+      parentNode={node.parentNode}
       on:nodeclick
       on:nodemouseenter
       on:nodemousemove

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -85,7 +85,7 @@ export type NodeBase<
  */
 export type NodeProps<NodeType extends NodeBase> = Pick<
   NodeType,
-  'id' | 'data' | 'width' | 'height' | 'sourcePosition' | 'targetPosition' | 'selected' | 'dragHandle'
+  'id' | 'data' | 'width' | 'height' | 'sourcePosition' | 'targetPosition' | 'selected' | 'dragHandle' | 'parentNode'
 > &
   Required<Pick<NodeType, 'type' | 'dragging' | 'zIndex'>> & {
     /** whether a node is connectable or not */


### PR DESCRIPTION
Exposing parentNode to custom nodes so that they can react to the parentNode changing. 

This implementation is only done for Svelte as I haven' t used and don't fully understand were and how to add it. The NodeProps type in system was changed which may affect the react types. I could try to make the changes I think would needed.