### PR TITLE
React Flow 11.11.0

### DIFF
--- a/.changeset/giant-waves-boil.md
+++ b/.changeset/giant-waves-boil.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': minor
----
-
-deprecate node.parentNode, rename to node.parentId

--- a/.changeset/heavy-hairs-decide.md
+++ b/.changeset/heavy-hairs-decide.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-fix(subflow): show correct selection box

--- a/.changeset/kind-rings-smash.md
+++ b/.changeset/kind-rings-smash.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-fixed smoothstep edge if center = 0

--- a/.changeset/nice-peaches-sit.md
+++ b/.changeset/nice-peaches-sit.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-fix(edge-marker): use quotes for marker urls to support css vars

--- a/.changeset/quiet-squids-sort.md
+++ b/.changeset/quiet-squids-sort.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-fix: re-observe nodes when hidden is toggled

--- a/.changeset/serious-socks-yawn.md
+++ b/.changeset/serious-socks-yawn.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-disableKeyboardA11y now correctly prevents escape key presses

--- a/.changeset/silent-years-explain.md
+++ b/.changeset/silent-years-explain.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-fix(nodes): re-measure/ re-init correctly

--- a/examples/vite-app/src/examples/FloatingEdges/FloatingConnectionLine.tsx
+++ b/examples/vite-app/src/examples/FloatingEdges/FloatingConnectionLine.tsx
@@ -3,38 +3,33 @@ import { getBezierPath, ConnectionLineComponentProps, Node } from 'reactflow';
 
 import { getEdgeParams } from './utils';
 
-const FloatingConnectionLine: FC<ConnectionLineComponentProps> = ({
-  targetX,
-  targetY,
-  sourcePosition,
-  targetPosition,
-  sourceNode,
-}) => {
-  if (!sourceNode) {
+const FloatingConnectionLine: FC<ConnectionLineComponentProps> = ({ toX, toY, fromPosition, toPosition, fromNode }) => {
+  if (!fromNode) {
     return null;
   }
 
-  const targetNode = {
+  const toNode = {
     id: 'connection-target',
     width: 1,
     height: 1,
-    position: { x: targetX, y: targetY },
+    position: { x: toX, y: toY },
+    positionAbsolute: { x: toX, y: toY },
   } as Node;
 
-  const { sx, sy } = getEdgeParams(sourceNode, targetNode);
-  const d = getBezierPath({
+  const { sx, sy } = getEdgeParams(fromNode, toNode);
+  const [d] = getBezierPath({
     sourceX: sx,
     sourceY: sy,
-    sourcePosition,
-    targetPosition,
-    targetX,
-    targetY,
+    sourcePosition: fromPosition,
+    targetPosition: toPosition,
+    targetX: toX,
+    targetY: toY,
   });
 
   return (
     <g>
       <path fill="none" stroke="#222" strokeWidth={1.5} className="animated" d={d} />
-      <circle cx={targetX} cy={targetY} fill="#fff" r={3} stroke="#222" strokeWidth={1.5} />
+      <circle cx={toX} cy={toY} fill="#fff" r={3} stroke="#222" strokeWidth={1.5} />
     </g>
   );
 };

--- a/examples/vite-app/src/examples/FloatingEdges/utils.ts
+++ b/examples/vite-app/src/examples/FloatingEdges/utils.ts
@@ -11,21 +11,17 @@ function getNodeIntersection(intersectionNode: Node, targetNode: Node): XYPositi
     position: intersectionNodePosition,
   } = intersectionNode;
 
-  const {
-    width: targetNodeWidth,
-    height: targetNodeHeight,
-    positionAbsolute: targetNodePosition,
-  } = targetNode;
+  const { width: targetNodeWidth, height: targetNodeHeight, positionAbsolute: targetNodePosition } = targetNode;
 
   const w = (intersectionNodeWidth ?? 0) / 2;
   const h = (intersectionNodeHeight ?? 0) / 2;
-  const targetW = (targetNodeWidth ?? 0) / 2
-  const targetH = (targetNodeHeight ?? 0) / 2
+  const targetW = (targetNodeWidth ?? 0) / 2;
+  const targetH = (targetNodeHeight ?? 0) / 2;
 
   const x2 = intersectionNodePosition.x + w;
   const y2 = intersectionNodePosition.y + h;
-  const x1 = targetNodePosition.x + targetW;
-  const y1 = targetNodePosition.y + targetH;
+  const x1 = (targetNodePosition?.x ?? 0) + targetW;
+  const y1 = (targetNodePosition?.y ?? 0) + targetH;
 
   const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
   const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
-  - @reactflow/core@11.10.5
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)], [[`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36)]:
+  - @reactflow/core@11.11.0
 
 ## 11.3.9
 

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/background
 
+## 11.3.10
+
+### Patch Changes
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+
 ## 11.3.9
 
 ### Patch Changes

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @reactflow/background
 
-## 11.3.6
+## 11.3.7
 
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.2
+
+## 11.3.6
+
+### Patch Changes
+
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
 
 ## 11.3.5

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/background
 
+## 11.3.8
+
+### Patch Changes
+
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+
 ## 11.3.7
 
 ### Patch Changes

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/background
 
+## 11.3.9
+
+### Patch Changes
+
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+
 ## 11.3.8
 
 ### Patch Changes

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/background",
-  "version": "11.3.9",
+  "version": "11.3.10",
   "description": "Background component with different variants for React Flow",
   "keywords": [
     "react",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/background",
-  "version": "11.3.6",
+  "version": "11.3.7",
   "description": "Background component with different variants for React Flow",
   "keywords": [
     "react",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/background",
-  "version": "11.3.8",
+  "version": "11.3.9",
   "description": "Background component with different variants for React Flow",
   "keywords": [
     "react",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/background",
-  "version": "11.3.7",
+  "version": "11.3.8",
   "description": "Background component with different variants for React Flow",
   "keywords": [
     "react",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/controls
 
+## 11.2.10
+
+### Patch Changes
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+
 ## 11.2.9
 
 ### Patch Changes

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
-  - @reactflow/core@11.10.5
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)], [[`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36)]:
+  - @reactflow/core@11.11.0
 
 ## 11.2.9
 

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @reactflow/controls
 
-## 11.2.6
+## 11.2.7
 
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.2
+
+## 11.2.6
+
+### Patch Changes
+
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
 
 ## 11.2.5

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/controls
 
+## 11.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+
 ## 11.2.8
 
 ### Patch Changes

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/controls
 
+## 11.2.8
+
+### Patch Changes
+
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+
 ## 11.2.7
 
 ### Patch Changes

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.11",
+  "version": "11.2.10",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.10",
+  "version": "11.2.11",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.9",
+  "version": "11.2.10",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.8",
+  "version": "11.2.9",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.7",
+  "version": "11.2.8",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.6",
+  "version": "11.2.7",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @reactflow/core
 
-## 11.10.5
+## 11.11.0
+
+### Minor Changes
+
+- [#4110](https://github.com/xyflow/xyflow/pull/4110) [`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36) Thanks [@moklick](https://github.com/moklick)! - deprecate node.parentNode, rename to node.parentId
 
 ### Patch Changes
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @reactflow/core
 
+## 11.10.5
+
+### Patch Changes
+
+- [#3957](https://github.com/xyflow/xyflow/pull/3957) [`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4) - fixed smoothstep edge if center = 0
+- [#4082](https://github.com/xyflow/xyflow/pull/4082) [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f) - fix: re-observe nodes when hidden is toggled
+- [#3935](https://github.com/xyflow/xyflow/pull/3935) [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1) - disableKeyboardA11y now correctly prevents escape key presses
+
 ## 11.10.4
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/core
 
+## 11.10.4
+
+### Patch Changes
+
+- [#3918](https://github.com/xyflow/xyflow/pull/3918) [`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690) - fix(edge-marker): use quotes for marker urls to support css vars
+- [#3897](https://github.com/xyflow/xyflow/pull/3897) [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d) - fix(nodes): re-measure/ re-init correctly
+
 ## 11.10.3
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reactflow/core
 
+## 11.10.3
+
+### Patch Changes
+
+- [#3829](https://github.com/xyflow/xyflow/pull/3829) [`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a) - fix(subflow): show correct selection box
+
 ## 11.10.2
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,17 @@
 # @reactflow/core
 
-## 11.10.1
+## 11.10.2
 
 ### Patch Changes
 
 - [#3807](https://github.com/xyflow/xyflow/pull/3807) [`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0) Thanks [@rhys-okane-instil](https://github.com/rhys-okane-instil)! - fix internally used getNodeRect function
 - [#3810](https://github.com/xyflow/xyflow/pull/3810) [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153) - fix(getNodesBounds): use position instead of positionAbsolute for subflows
+
+## 11.10.1
+
+### Patch Changes
+
+- [#3605](https://github.com/xyflow/xyflow/pull/3605) [`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5) - fix(react-flow-instance): add screenToFlow and flowToScreen types
 
 ## 11.10.0
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.10.3",
+  "version": "11.10.4",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.10.4",
+  "version": "11.10.5",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.10.5",
+  "version": "11.11.0",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.10.1",
+  "version": "11.10.2",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.10.2",
+  "version": "11.10.3",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/src/components/Nodes/wrapNode.tsx
+++ b/packages/core/src/components/Nodes/wrapNode.tsx
@@ -57,7 +57,8 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     hasHandleBounds,
   }: WrapNodeProps) => {
     const store = useStoreApi();
-    const nodeRef = useRef<HTMLDivElement>(null);
+    const nodeRef = useRef<HTMLDivElement | null>(null);
+    const prevNodeRef = useRef<HTMLDivElement | null>(null);
     const prevSourcePosition = useRef(sourcePosition);
     const prevTargetPosition = useRef(targetPosition);
     const prevType = useRef(type);
@@ -124,11 +125,9 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
     };
 
     useEffect(() => {
-      const currNode = nodeRef.current;
-
       return () => {
-        if (currNode) {
-          resizeObserver?.unobserve(currNode);
+        if (prevNodeRef.current) {
+          resizeObserver?.unobserve(prevNodeRef.current);
         }
       };
     }, []);
@@ -140,8 +139,11 @@ export default (NodeComponent: ComponentType<NodeProps>) => {
         if (!initialized || !hasHandleBounds) {
           // At this point we always want to make sure that the node gets re-measured / re-initialized.
           // We need to unobserve it first in case it is still observed
-          resizeObserver?.unobserve(currNode);
+          if (prevNodeRef.current) {
+            resizeObserver?.unobserve(prevNodeRef.current);
+          }
           resizeObserver?.observe(currNode);
+          prevNodeRef.current = currNode;
         }
       }
     }, [hidden, initialized, hasHandleBounds]);

--- a/packages/core/src/store/utils.ts
+++ b/packages/core/src/store/utils.ts
@@ -102,10 +102,12 @@ export function createNodeInternals(
       parentNodes[node.parentNode] = true;
     }
 
+    const resetHandleBounds = currInternals?.type && currInternals?.type !== node.type;
+
     Object.defineProperty(internals, internalsSymbol, {
       enumerable: false,
       value: {
-        handleBounds: currInternals?.[internalsSymbol]?.handleBounds,
+        handleBounds: resetHandleBounds ? undefined : currInternals?.[internalsSymbol]?.handleBounds,
         z,
       },
     });

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
-  - @reactflow/core@11.10.5
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)], [[`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36)]:
+  - @reactflow/core@11.11.0
 
 ## 11.7.9
 

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/minimap
 
+## 11.7.10
+
+### Patch Changes
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+
 ## 11.7.9
 
 ### Patch Changes

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/minimap
 
+## 11.7.8
+
+### Patch Changes
+
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+
 ## 11.7.7
 
 ### Patch Changes

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/minimap
 
+## 11.7.9
+
+### Patch Changes
+
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+
 ## 11.7.8
 
 ### Patch Changes

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @reactflow/minimap
 
-## 11.7.6
+## 11.7.7
 
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.1
+
+## 11.7.6
+
+### Patch Changes
+
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
 
 ## 11.7.5

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/minimap",
-  "version": "11.7.9",
+  "version": "11.7.10",
   "description": "Minimap component for React Flow.",
   "keywords": [
     "react",

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/minimap",
-  "version": "11.7.6",
+  "version": "11.7.7",
   "description": "Minimap component for React Flow.",
   "keywords": [
     "react",

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/minimap",
-  "version": "11.7.8",
+  "version": "11.7.9",
   "description": "Minimap component for React Flow.",
   "keywords": [
     "react",

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/minimap",
-  "version": "11.7.7",
+  "version": "11.7.8",
   "description": "Minimap component for React Flow.",
   "keywords": [
     "react",

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
-  - @reactflow/core@11.10.5
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)], [[`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36)]:
+  - @reactflow/core@11.11.0
 
 ## 2.2.9
 

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-resizer
 
+## 2.2.10
+
+### Patch Changes
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+
 ## 2.2.9
 
 ### Patch Changes

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @reactflow/node-resizer
 
-## 2.2.6
+## 2.2.7
 
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.1
+
+## 2.2.6
+
+### Patch Changes
+
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
 
 ## 2.2.5

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-resizer
 
+## 2.2.8
+
+### Patch Changes
+
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+
 ## 2.2.7
 
 ### Patch Changes

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-resizer
 
+## 2.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+
 ## 2.2.8
 
 ### Patch Changes

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-resizer",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "A helper component for resizing nodes.",
   "keywords": [
     "react",

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-resizer",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "A helper component for resizing nodes.",
   "keywords": [
     "react",

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-resizer",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "A helper component for resizing nodes.",
   "keywords": [
     "react",

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-resizer",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "A helper component for resizing nodes.",
   "keywords": [
     "react",

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
-  - @reactflow/core@11.10.5
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)], [[`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36)]:
+  - @reactflow/core@11.11.0
 
 ## 1.3.9
 

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-toolbar
 
+## 1.3.10
+
+### Patch Changes
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+
 ## 1.3.9
 
 ### Patch Changes

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @reactflow/node-toolbar
 
-## 1.3.6
+## 1.3.7
 
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.1
+
+## 1.3.6
+
+### Patch Changes
+
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
 
 ## 1.3.5

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-toolbar
 
+## 1.3.8
+
+### Patch Changes
+
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+
 ## 1.3.7
 
 ### Patch Changes

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-toolbar
 
+## 1.3.9
+
+### Patch Changes
+
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+
 ## 1.3.8
 
 ### Patch Changes

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-toolbar",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "A toolbar component for React Flow that can be attached to a node.",
   "keywords": [
     "react",

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-toolbar",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "A toolbar component for React Flow that can be attached to a node.",
   "keywords": [
     "react",

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-toolbar",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "A toolbar component for React Flow that can be attached to a node.",
   "keywords": [
     "react",

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-toolbar",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "A toolbar component for React Flow that can be attached to a node.",
   "keywords": [
     "react",

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,5 +1,21 @@
 # reactflow
 
+## 11.10.5
+
+### Patch Changes
+
+- [#3957](https://github.com/xyflow/xyflow/pull/3957) [`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4) - fixed smoothstep edge if center = 0
+- [#4082](https://github.com/xyflow/xyflow/pull/4082) [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f) - fix: re-observe nodes when hidden is toggled
+- [#3935](https://github.com/xyflow/xyflow/pull/3935) [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1) - `disableKeyboardA11y` now correctly prevents enter and escape key presses
+
+- Updated dependencies [[`c7a140bd`](https://github.com/xyflow/xyflow/commit/c7a140bd7bc4442bf4121b1bca936a05e19117a4), [`ba3809b1`](https://github.com/xyflow/xyflow/commit/ba3809b18413fa581a4e7098611ebcb9067c971f), [`6228d499`](https://github.com/xyflow/xyflow/commit/6228d499464408fc7bad0ce89b321a59ca5ecbe1)]:
+  - @reactflow/core@11.10.5
+  - @reactflow/background@11.3.10
+  - @reactflow/controls@11.2.10
+  - @reactflow/minimap@11.7.10
+  - @reactflow/node-resizer@2.2.10
+  - @reactflow/node-toolbar@1.3.10
+
 ## 11.10.4
 
 ### Patch Changes

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 11.11.0
 
-This is hopefully the last release for React Flow 11. It fixes some bugs and adds a deprecation warning for `node.parentNode` which is now called `node.parentId`. The reasons for this change are that `parentNode` is already used for the DOM API and that you pass an id instead of a node, so it should be more clear what to expect. 
+This is hopefully the last release for React Flow 11. It fixes some bugs and adds a deprecation warning for `node.parentNode` which is now called `node.parentId`. There are two reasons for this: `parentNode` poses a name collision with the DOM API and it actually is an id not a node.
 
 ### Minor Changes
 

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,6 +1,12 @@
 # reactflow
 
-## 11.10.5
+## 11.11.0
+
+This is hopefully the last release for React Flow 11. It fixes some bugs and adds a deprecation warning for `node.parentNode` which is now called `node.parentId`. The reasons for this change are that `parentNode` is already used for the DOM API and that you pass an id instead of a node, so it should be more clear what to expect. 
+
+### Minor Changes
+
+- [#4110](https://github.com/xyflow/xyflow/pull/4110) [`d80b9e7b`](https://github.com/xyflow/xyflow/commit/d80b9e7b18476f11d91a68cfcae0e3f5e5fcac36) - deprecate `node.parentNode`, rename to `node.parentId`
 
 ### Patch Changes
 

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # reactflow
 
-## 11.10.1
+## 11.10.2
 
 - [#3807](https://github.com/xyflow/xyflow/pull/3807) [`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0) Thanks [@rhys-okane-instil](https://github.com/rhys-okane-instil)! - fix internally used getNodeRect function
 - [#3810](https://github.com/xyflow/xyflow/pull/3810) [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153) - fix(getNodesBounds): use position instead of positionAbsolute for subflows
@@ -8,6 +8,19 @@
 ### Patch Changes
 
 - Updated dependencies [[`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0), [`814ae219`](https://github.com/xyflow/xyflow/commit/814ae219991804f4429a22f72b2774a372964153)]:
+  - @reactflow/core@11.10.1
+  - @reactflow/background@11.3.6
+  - @reactflow/controls@11.2.6
+  - @reactflow/minimap@11.7.6
+  - @reactflow/node-resizer@2.2.6
+  - @reactflow/node-toolbar@1.3.6
+
+## 11.10.1
+
+### Patch Changes
+
+- [#3605](https://github.com/xyflow/xyflow/pull/3605) [`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5) - fix(react-flow-instance): add screenToFlow and flowToScreen types
+- Updated dependencies [[`e71dec26`](https://github.com/xyflow/xyflow/commit/e71dec263c8a8296d0a890c2fc7d0a5aac94f9e5)]:
   - @reactflow/core@11.10.1
   - @reactflow/background@11.3.6
   - @reactflow/controls@11.2.6

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,5 +1,18 @@
 # reactflow
 
+## 11.10.3
+
+### Patch Changes
+
+- [#3829](https://github.com/xyflow/xyflow/pull/3829) [`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a) - fix(subflow): show correct selection box
+- Updated dependencies [[`b367173a`](https://github.com/xyflow/xyflow/commit/b367173a568cef0e3e84e42e50b2c15ec1d6e23a)]:
+  - @reactflow/core@11.10.3
+  - @reactflow/background@11.3.8
+  - @reactflow/controls@11.2.8
+  - @reactflow/minimap@11.7.8
+  - @reactflow/node-resizer@2.2.8
+  - @reactflow/node-toolbar@1.3.8
+
 ## 11.10.2
 
 - [#3807](https://github.com/xyflow/xyflow/pull/3807) [`59c44df5`](https://github.com/xyflow/xyflow/commit/59c44df5300a87aedde53393ac31b85f7fcbcaa0) Thanks [@rhys-okane-instil](https://github.com/rhys-okane-instil)! - fix internally used getNodeRect function

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,5 +1,19 @@
 # reactflow
 
+## 11.10.4
+
+### Patch Changes
+
+- [#3918](https://github.com/xyflow/xyflow/pull/3918) [`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690) - fix(edge-marker): use quotes for marker urls to support css vars
+- [#3897](https://github.com/xyflow/xyflow/pull/3897) [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d) - fix(nodes): re-measure/ re-init correctly
+- Updated dependencies [[`7c8c8574`](https://github.com/xyflow/xyflow/commit/7c8c85743dd78656203569567d862f95a6578690), [`7722305c`](https://github.com/xyflow/xyflow/commit/7722305cdfcda77fed97ea93c7d5d6b21f95e94d)]:
+  - @reactflow/core@11.10.4
+  - @reactflow/background@11.3.9
+  - @reactflow/controls@11.2.9
+  - @reactflow/minimap@11.7.9
+  - @reactflow/node-resizer@2.2.9
+  - @reactflow/node-toolbar@1.3.9
+
 ## 11.10.3
 
 ### Patch Changes

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.10.4",
+  "version": "11.10.5",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.10.5",
+  "version": "11.11.0",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.10.3",
+  "version": "11.10.4",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.10.2",
+  "version": "11.10.3",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.10.1",
+  "version": "11.10.2",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,7 +323,7 @@ importers:
   packages/node-resizer:
     dependencies:
       '@reactflow/core':
-        specifier: workspace:^11.6.0
+        specifier: workspace:*
         version: link:../core
       classcat:
         specifier: ^5.0.4
@@ -503,6 +503,281 @@ importers:
   tooling/tsconfig: {}
 
 packages:
+
+  /@colors/colors@1.5.0:
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==, tarball: https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz}
+    engines: {node: '>=0.1.90'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.18.20:
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.18.20:
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.18.20:
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.18.20:
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.18.20:
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.18.20:
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.18.20:
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.18.20:
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.18.20:
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.18.20:
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.18.20:
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.18.20:
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.18.20:
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.18.20:
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.18.20:
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.18.20:
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.18.20:
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.18.20:
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.18.20:
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.18.20:
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.18.20:
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.18.20:
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@types/yauzl@2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==, tarball: https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz}
+    requiresBuild: true
+    dependencies:
+      '@types/node': registry.npmjs.org/@types/node@14.18.28
+    dev: true
+    optional: true
+
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==, tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-64@1.7.0:
+    resolution: {integrity: sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==, tarball: https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.0.tgz}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-arm64@1.7.0:
+    resolution: {integrity: sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==, tarball: https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.0.tgz}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-64@1.7.0:
+    resolution: {integrity: sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==, tarball: https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.0.tgz}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-arm64@1.7.0:
+    resolution: {integrity: sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==, tarball: https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.0.tgz}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-64@1.7.0:
+    resolution: {integrity: sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==, tarball: https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.0.tgz}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-arm64@1.7.0:
+    resolution: {integrity: sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==, tarball: https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.0.tgz}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   registry.npmjs.org/@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz}
@@ -1056,15 +1331,6 @@ packages:
       prettier: registry.npmjs.org/prettier@2.7.1
     dev: true
 
-  registry.npmjs.org/@colors/colors@1.5.0:
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz}
-    name: '@colors/colors'
-    version: 1.5.0
-    engines: {node: '>=0.1.90'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   registry.npmjs.org/@cypress/request@2.88.12:
     resolution: {integrity: sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz}
     name: '@cypress/request'
@@ -1108,248 +1374,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  registry.npmjs.org/@esbuild/android-arm64@0.18.20:
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz}
-    name: '@esbuild/android-arm64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/android-arm@0.18.20:
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz}
-    name: '@esbuild/android-arm'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/android-x64@0.18.20:
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz}
-    name: '@esbuild/android-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/darwin-arm64@0.18.20:
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz}
-    name: '@esbuild/darwin-arm64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/darwin-x64@0.18.20:
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz}
-    name: '@esbuild/darwin-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/freebsd-arm64@0.18.20:
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz}
-    name: '@esbuild/freebsd-arm64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/freebsd-x64@0.18.20:
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz}
-    name: '@esbuild/freebsd-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-arm64@0.18.20:
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz}
-    name: '@esbuild/linux-arm64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-arm@0.18.20:
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz}
-    name: '@esbuild/linux-arm'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-ia32@0.18.20:
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz}
-    name: '@esbuild/linux-ia32'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-loong64@0.18.20:
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz}
-    name: '@esbuild/linux-loong64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-mips64el@0.18.20:
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz}
-    name: '@esbuild/linux-mips64el'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-ppc64@0.18.20:
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz}
-    name: '@esbuild/linux-ppc64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-riscv64@0.18.20:
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz}
-    name: '@esbuild/linux-riscv64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-s390x@0.18.20:
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz}
-    name: '@esbuild/linux-s390x'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/linux-x64@0.18.20:
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz}
-    name: '@esbuild/linux-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/netbsd-x64@0.18.20:
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz}
-    name: '@esbuild/netbsd-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/openbsd-x64@0.18.20:
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz}
-    name: '@esbuild/openbsd-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/sunos-x64@0.18.20:
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz}
-    name: '@esbuild/sunos-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/win32-arm64@0.18.20:
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz}
-    name: '@esbuild/win32-arm64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/win32-ia32@0.18.20:
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz}
-    name: '@esbuild/win32-ia32'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@esbuild/win32-x64@0.18.20:
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz}
-    name: '@esbuild/win32-x64'
-    version: 0.18.20
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   registry.npmjs.org/@eslint-community/eslint-utils@4.4.0(eslint@8.23.1):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz}
@@ -1993,6 +2017,7 @@ packages:
     resolution: {integrity: sha512-CK2fnrQlIgKlCV3N2kM+Gznb5USlwA1KFX3rJVHmgVk6NJxFPuQ86pAcvKnu37IA4BGlSRz7sEE1lHL1aLZ/eQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/node/-/node-14.18.28.tgz}
     name: '@types/node'
     version: 14.18.28
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -2070,16 +2095,6 @@ packages:
     name: '@types/sizzle'
     version: 2.3.3
     dev: true
-
-  registry.npmjs.org/@types/yauzl@2.10.0:
-    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz}
-    name: '@types/yauzl'
-    version: 2.10.0
-    requiresBuild: true
-    dependencies:
-      '@types/node': registry.npmjs.org/@types/node@14.18.28
-    dev: true
-    optional: true
 
   registry.npmjs.org/@typescript-eslint/eslint-plugin@6.3.0(@typescript-eslint/parser@6.3.0)(eslint@8.23.1)(typescript@4.9.4):
     resolution: {integrity: sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz}
@@ -2782,7 +2797,7 @@ packages:
       normalize-path: registry.npmjs.org/normalize-path@3.0.0
       readdirp: registry.npmjs.org/readdirp@3.6.0
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents@2.3.2
+      fsevents: 2.3.2
     dev: true
 
   registry.npmjs.org/ci-info@3.4.0:
@@ -2821,7 +2836,7 @@ packages:
     dependencies:
       string-width: registry.npmjs.org/string-width@4.2.3
     optionalDependencies:
-      '@colors/colors': registry.npmjs.org/@colors/colors@1.5.0
+      '@colors/colors': 1.5.0
     dev: true
 
   registry.npmjs.org/cli-truncate@2.1.0:
@@ -3535,28 +3550,28 @@ packages:
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': registry.npmjs.org/@esbuild/android-arm@0.18.20
-      '@esbuild/android-arm64': registry.npmjs.org/@esbuild/android-arm64@0.18.20
-      '@esbuild/android-x64': registry.npmjs.org/@esbuild/android-x64@0.18.20
-      '@esbuild/darwin-arm64': registry.npmjs.org/@esbuild/darwin-arm64@0.18.20
-      '@esbuild/darwin-x64': registry.npmjs.org/@esbuild/darwin-x64@0.18.20
-      '@esbuild/freebsd-arm64': registry.npmjs.org/@esbuild/freebsd-arm64@0.18.20
-      '@esbuild/freebsd-x64': registry.npmjs.org/@esbuild/freebsd-x64@0.18.20
-      '@esbuild/linux-arm': registry.npmjs.org/@esbuild/linux-arm@0.18.20
-      '@esbuild/linux-arm64': registry.npmjs.org/@esbuild/linux-arm64@0.18.20
-      '@esbuild/linux-ia32': registry.npmjs.org/@esbuild/linux-ia32@0.18.20
-      '@esbuild/linux-loong64': registry.npmjs.org/@esbuild/linux-loong64@0.18.20
-      '@esbuild/linux-mips64el': registry.npmjs.org/@esbuild/linux-mips64el@0.18.20
-      '@esbuild/linux-ppc64': registry.npmjs.org/@esbuild/linux-ppc64@0.18.20
-      '@esbuild/linux-riscv64': registry.npmjs.org/@esbuild/linux-riscv64@0.18.20
-      '@esbuild/linux-s390x': registry.npmjs.org/@esbuild/linux-s390x@0.18.20
-      '@esbuild/linux-x64': registry.npmjs.org/@esbuild/linux-x64@0.18.20
-      '@esbuild/netbsd-x64': registry.npmjs.org/@esbuild/netbsd-x64@0.18.20
-      '@esbuild/openbsd-x64': registry.npmjs.org/@esbuild/openbsd-x64@0.18.20
-      '@esbuild/sunos-x64': registry.npmjs.org/@esbuild/sunos-x64@0.18.20
-      '@esbuild/win32-arm64': registry.npmjs.org/@esbuild/win32-arm64@0.18.20
-      '@esbuild/win32-ia32': registry.npmjs.org/@esbuild/win32-ia32@0.18.20
-      '@esbuild/win32-x64': registry.npmjs.org/@esbuild/win32-x64@0.18.20
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
     dev: true
 
   registry.npmjs.org/escalade@3.1.1:
@@ -3912,7 +3927,7 @@ packages:
       get-stream: registry.npmjs.org/get-stream@5.2.0
       yauzl: registry.npmjs.org/yauzl@2.10.0
     optionalDependencies:
-      '@types/yauzl': registry.npmjs.org/@types/yauzl@2.10.0
+      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4151,16 +4166,6 @@ packages:
     name: fs.realpath
     version: 1.0.0
     dev: true
-
-  registry.npmjs.org/fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
-    name: fsevents
-    version: 2.3.2
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   registry.npmjs.org/function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz}
@@ -4992,7 +4997,7 @@ packages:
     name: jsonfile
     version: 4.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs@4.2.11
+      graceful-fs: 4.2.11
     dev: true
 
   registry.npmjs.org/jsonfile@6.1.0:
@@ -5002,7 +5007,7 @@ packages:
     dependencies:
       universalify: registry.npmjs.org/universalify@2.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs@4.2.11
+      graceful-fs: 4.2.11
     dev: true
 
   registry.npmjs.org/jsprim@2.0.2:
@@ -6383,7 +6388,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents@2.3.2
+      fsevents: 2.3.2
     dev: true
 
   registry.npmjs.org/rollup@3.9.1:
@@ -6393,7 +6398,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents@2.3.2
+      fsevents: 2.3.2
     dev: true
 
   registry.npmjs.org/run-parallel@1.2.0:
@@ -7050,66 +7055,6 @@ packages:
       safe-buffer: registry.npmjs.org/safe-buffer@5.2.1
     dev: true
 
-  registry.npmjs.org/turbo-darwin-64@1.7.0:
-    resolution: {integrity: sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.0.tgz}
-    name: turbo-darwin-64
-    version: 1.7.0
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/turbo-darwin-arm64@1.7.0:
-    resolution: {integrity: sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.0.tgz}
-    name: turbo-darwin-arm64
-    version: 1.7.0
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/turbo-linux-64@1.7.0:
-    resolution: {integrity: sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.0.tgz}
-    name: turbo-linux-64
-    version: 1.7.0
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/turbo-linux-arm64@1.7.0:
-    resolution: {integrity: sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.0.tgz}
-    name: turbo-linux-arm64
-    version: 1.7.0
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/turbo-windows-64@1.7.0:
-    resolution: {integrity: sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.0.tgz}
-    name: turbo-windows-64
-    version: 1.7.0
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/turbo-windows-arm64@1.7.0:
-    resolution: {integrity: sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.0.tgz}
-    name: turbo-windows-arm64
-    version: 1.7.0
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   registry.npmjs.org/turbo@1.7.0:
     resolution: {integrity: sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/turbo/-/turbo-1.7.0.tgz}
     name: turbo
@@ -7117,12 +7062,12 @@ packages:
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: registry.npmjs.org/turbo-darwin-64@1.7.0
-      turbo-darwin-arm64: registry.npmjs.org/turbo-darwin-arm64@1.7.0
-      turbo-linux-64: registry.npmjs.org/turbo-linux-64@1.7.0
-      turbo-linux-arm64: registry.npmjs.org/turbo-linux-arm64@1.7.0
-      turbo-windows-64: registry.npmjs.org/turbo-windows-64@1.7.0
-      turbo-windows-arm64: registry.npmjs.org/turbo-windows-arm64@1.7.0
+      turbo-darwin-64: 1.7.0
+      turbo-darwin-arm64: 1.7.0
+      turbo-linux-64: 1.7.0
+      turbo-linux-arm64: 1.7.0
+      turbo-windows-64: 1.7.0
+      turbo-windows-arm64: 1.7.0
     dev: true
 
   registry.npmjs.org/tweetnacl@0.14.5:
@@ -7402,7 +7347,7 @@ packages:
       postcss: registry.npmjs.org/postcss@8.4.27
       rollup: registry.npmjs.org/rollup@3.28.0
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents@2.3.2
+      fsevents: 2.3.2
     dev: true
 
   registry.npmjs.org/wait-on@6.0.0(debug@4.3.2):


### PR DESCRIPTION
- adds deprecation warning for `node.parentNode` which is now called `node.parentId`
- fix: re-observe nodes when hidden is toggled #4064
- fix: handle smoothstep edge if center = 0
- `disableKeyboardA11y` now correctly prevents escape/enter key presses for nodes and edges