### PR TITLE
Fix 4060

### DIFF
--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -38,7 +38,7 @@ export function updateAbsolutePositions<NodeType extends NodeBase>(
         nodeLookup,
         {
           ...node.position,
-          z: node[internalsSymbol]?.z ?? 0,
+          z: 0,
         },
         parentNode?.origin || nodeOrigin
       );

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -38,7 +38,7 @@ export function updateAbsolutePositions<NodeType extends NodeBase>(
         nodeLookup,
         {
           ...node.position,
-          z: 0,
+          z: node.zIndex ?? 0,
         },
         parentNode?.origin || nodeOrigin
       );


### PR DESCRIPTION
Instead of starting with the base that the user set for the node, this was taking the calculated number (and it only looks for something higher).

Fix issue #4060 