### PR TITLE
[SvelteFlow] Make handleId and isTarget reactive

### DIFF
--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -31,12 +31,12 @@
   let className: $$Props['class'] = undefined;
   export { className as class };
 
-  const isTarget = type === 'target';
+  $: isTarget = type === 'target';
   const nodeId = getContext<string>('svelteflow__node_id');
   const connectable = getContext<Writable<boolean>>('svelteflow__node_connectable');
   $: isConnectable = isConnectable !== undefined ? isConnectable : $connectable;
 
-  const handleId = id || null;
+  $: handleId = id || null;
 
   const store = useStore();
   const {


### PR DESCRIPTION
I have no idea about `isTarget` but my handles can change dynamically, including their IDs. Anyway I think it's best if anything that depends on a property reacts to changes to that property.

I've confirmed that the change works for me and my dynamic handles.