### PR TITLE
[React] Fix: type `updateNodeData`  dataUpdate arg

### DIFF
--- a/packages/react/src/types/instance.ts
+++ b/packages/react/src/types/instance.ts
@@ -140,7 +140,7 @@ export type GeneralHelpers<NodeType extends Node = Node, EdgeType extends Edge =
    */
   updateNodeData: (
     id: string,
-    dataUpdate: object | ((node: NodeType) => object),
+    dataUpdate: NodeType['data'] | ((node: NodeType) => NodeType['data']),
     options?: { replace: boolean }
   ) => void;
 };


### PR DESCRIPTION
This was resulting in any object allowed as argument of updateNodeData, the fallback should still be object if generic is not passed to `useReactFlow`
<img width="400" alt="Screenshot 2024-05-14 at 20 35 15" src="https://github.com/xyflow/xyflow/assets/4820803/284a2e1f-af09-417e-8bb3-ae56bd1a9401">
