### PR TITLE
fix: Correct parent node lookup in evaluateAbsolutePosition

### DIFF
--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -247,7 +247,7 @@ export function evaluateAbsolutePosition(
   const positionAbsolute = { ...position };
 
   while (nextParentId) {
-    const parent = nodeLookup.get(parentId);
+    const parent = nodeLookup.get(nextParentId);
     nextParentId = parent?.parentId;
 
     if (parent) {


### PR DESCRIPTION
### Summary

This PR fixes a bug in the `evaluateAbsolutePosition` function where the incorrect parent node was being retrieved from the `nodeLookup` in each iteration of the while loop.

### Changes

- Modified the line `const parent = nodeLookup.get(parentId);` to `const parent = nodeLookup.get(nextParentId);`.

### Reason

The original implementation used `parentId` to look up the parent node, which did not change within the loop. This resulted in the same parent node being used for each iteration, leading to incorrect calculations of the absolute position. By using `nextParentId`, we ensure that the correct parent node is retrieved and used in each iteration.