### PR TITLE
React Flow 11.11.4

### DIFF
--- a/.changeset/cool-falcons-argue.md
+++ b/.changeset/cool-falcons-argue.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+rename updateEdge to reconectEdge

--- a/.changeset/cool-falcons-argue.md
+++ b/.changeset/cool-falcons-argue.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-rename updateEdge to reconectEdge

--- a/.changeset/smooth-news-promise.md
+++ b/.changeset/smooth-news-promise.md
@@ -1,0 +1,5 @@
+---
+'@reactflow/core': patch
+---
+
+abort drag when multiple touches are detected

--- a/.changeset/smooth-news-promise.md
+++ b/.changeset/smooth-news-promise.md
@@ -1,5 +1,0 @@
----
-'@reactflow/core': patch
----
-
-abort drag when multiple touches are detected

--- a/examples/vite-app/src/examples/Undirectional/index.tsx
+++ b/examples/vite-app/src/examples/Undirectional/index.tsx
@@ -9,7 +9,7 @@ import ReactFlow, {
   Edge,
   ConnectionLineType,
   ConnectionMode,
-  updateEdge,
+  reconnectEdge,
   useNodesState,
   useEdgesState,
 } from 'reactflow';
@@ -185,8 +185,8 @@ const UpdateNodeInternalsFlow = () => {
   const { screenToFlowPosition } = useReactFlow();
 
   const onConnect = useCallback((params: Edge | Connection) => setEdges((els) => addEdge(params, els)), [setEdges]);
-  const onEdgeUpdate = useCallback(
-    (oldEdge: Edge, newConnection: Connection) => setEdges((els) => updateEdge(oldEdge, newConnection, els)),
+  const onReconnect = useCallback(
+    (oldEdge: Edge, newConnection: Connection) => setEdges((els) => reconnectEdge(oldEdge, newConnection, els)),
     []
   );
 
@@ -214,7 +214,7 @@ const UpdateNodeInternalsFlow = () => {
       onPaneClick={onPaneClick}
       connectionLineType={ConnectionLineType.Bezier}
       connectionMode={ConnectionMode.Loose}
-      onEdgeUpdate={onEdgeUpdate}
+      onReconnect={onReconnect}
     />
   );
 };

--- a/examples/vite-app/src/examples/UpdatableEdge/index.tsx
+++ b/examples/vite-app/src/examples/UpdatableEdge/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, MouseEvent as ReactMouseEvent } from 'react';
 import ReactFlow, {
   Controls,
-  updateEdge,
+  reconnectEdge,
   addEdge,
   applyNodeChanges,
   applyEdgeChanges,
@@ -91,22 +91,22 @@ const initialNodes: Node[] = [
 ];
 
 const initialEdges: Edge[] = [
-  { id: 'e1-3', source: '1', target: '3', label: 'This edge can only be updated from source', updatable: 'source' },
-  { id: 'e2-4', source: '2', target: '4', label: 'This edge can only be updated from target', updatable: 'target' },
+  { id: 'e1-3', source: '1', target: '3', label: 'This edge can only be updated from source', reconnectable: 'source' },
+  { id: 'e2-4', source: '2', target: '4', label: 'This edge can only be updated from target', reconnectable: 'target' },
   { id: 'e5-6', source: '5', target: '6', label: 'This edge can be updated from both sides' },
 ];
 
 const onInit = (reactFlowInstance: ReactFlowInstance) => reactFlowInstance.fitView();
-const onEdgeUpdateStart = (_: ReactMouseEvent, edge: Edge, handleType: HandleType) =>
+const onReconnectStart = (_: ReactMouseEvent, edge: Edge, handleType: HandleType) =>
   console.log(`start update ${handleType} handle`, edge);
-const onEdgeUpdateEnd = (_: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) =>
+const onReconnectEnd = (_: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) =>
   console.log(`end update ${handleType} handle`, edge);
 
 const UpdatableEdge = () => {
   const [nodes, setNodes] = useState<Node[]>(initialNodes);
   const [edges, setEdges] = useState<Edge[]>(initialEdges);
-  const onEdgeUpdate = (oldEdge: Edge, newConnection: Connection) =>
-    setEdges((els) => updateEdge(oldEdge, newConnection, els));
+  const onReconnect = (oldEdge: Edge, newConnection: Connection) =>
+    setEdges((els) => reconnectEdge(oldEdge, newConnection, els));
   const onConnect = (connection: Connection) => setEdges((els) => addEdge(connection, els));
 
   const onNodesChange = useCallback((changes: NodeChange[]) => {
@@ -125,10 +125,10 @@ const UpdatableEdge = () => {
       onEdgesChange={onEdgesChange}
       onInit={onInit}
       snapToGrid={true}
-      onEdgeUpdate={onEdgeUpdate}
+      onReconnect={onReconnect}
       onConnect={onConnect}
-      onEdgeUpdateStart={onEdgeUpdateStart}
-      onEdgeUpdateEnd={onEdgeUpdateEnd}
+      onReconnectStart={onReconnectStart}
+      onReconnectEnd={onReconnectEnd}
     >
       <Controls />
     </ReactFlow>

--- a/examples/vite-app/src/examples/Validation/index.tsx
+++ b/examples/vite-app/src/examples/Validation/index.tsx
@@ -12,7 +12,7 @@ import ReactFlow, {
   OnConnectStart,
   OnConnectEnd,
   OnConnect,
-  updateEdge,
+  reconnectEdge,
   Edge,
 } from 'reactflow';
 
@@ -78,8 +78,8 @@ const ValidationFlow = () => {
     [value]
   );
 
-  const onEdgeUpdate = useCallback(
-    (oldEdge: Edge, newConnection: Connection) => setEdges((els) => updateEdge(oldEdge, newConnection, els)),
+  const onReconnect = useCallback(
+    (oldEdge: Edge, newConnection: Connection) => setEdges((els) => reconnectEdge(oldEdge, newConnection, els)),
     [setEdges]
   );
 
@@ -95,7 +95,7 @@ const ValidationFlow = () => {
       nodeTypes={nodeTypes}
       onConnectStart={onConnectStart}
       onConnectEnd={onConnectEnd}
-      onEdgeUpdate={onEdgeUpdate}
+      onReconnect={onReconnect}
       isValidConnection={isValidConnection}
       fitView
     >

--- a/packages/background/CHANGELOG.md
+++ b/packages/background/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/background
 
+## 11.3.14
+
+### Patch Changes
+
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+
 ## 11.3.13
 
 ### Patch Changes

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/background",
-  "version": "11.3.13",
+  "version": "11.3.14",
   "description": "Background component with different variants for React Flow",
   "keywords": [
     "react",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/controls
 
+## 11.2.14
+
+### Patch Changes
+
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+
 ## 11.2.13
 
 ### Patch Changes

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/controls",
-  "version": "11.2.13",
+  "version": "11.2.14",
   "description": "Component to control the viewport of a React Flow instance",
   "keywords": [
     "react",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/core
 
+## 11.11.4
+
+### Patch Changes
+
+- [#4389](https://github.com/xyflow/xyflow/pull/4389) [`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211) - rename updateEdge to reconectEdge
+- [#4387](https://github.com/xyflow/xyflow/pull/4387) [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9) - abort drag when multiple touches are detected
+
 ## 11.11.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/core",
-  "version": "11.11.3",
+  "version": "11.11.4",
   "description": "Core components and util functions of React Flow.",
   "keywords": [
     "react",

--- a/packages/core/src/components/Edges/wrapEdge.tsx
+++ b/packages/core/src/components/Edges/wrapEdge.tsx
@@ -46,16 +46,16 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
     onMouseEnter,
     onMouseMove,
     onMouseLeave,
-    edgeUpdaterRadius,
-    onEdgeUpdate,
-    onEdgeUpdateStart,
-    onEdgeUpdateEnd,
+    reconnectRadius,
+    onReconnect,
+    onReconnectStart,
+    onReconnectEnd,
     markerEnd,
     markerStart,
     rfId,
     ariaLabel,
     isFocusable,
-    isUpdatable,
+    isReconnectable,
     pathOptions,
     interactionWidth,
     disableKeyboardA11y,
@@ -118,14 +118,14 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
       const edge = edges.find((e) => e.id === id)!;
 
       setUpdating(true);
-      onEdgeUpdateStart?.(event, edge, handleType);
+      onReconnectStart?.(event, edge, handleType);
 
-      const _onEdgeUpdateEnd = (evt: MouseEvent | TouchEvent) => {
+      const _onReconnectEnd = (evt: MouseEvent | TouchEvent) => {
         setUpdating(false);
-        onEdgeUpdateEnd?.(evt, edge, handleType);
+        onReconnectEnd?.(evt, edge, handleType);
       };
 
-      const onConnectEdge = (connection: Connection) => onEdgeUpdate?.(edge, connection);
+      const onConnectEdge = (connection: Connection) => onReconnect?.(edge, connection);
 
       handlePointerDown({
         event,
@@ -137,7 +137,7 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
         setState: store.setState,
         isValidConnection,
         edgeUpdaterType: handleType,
-        onEdgeUpdateEnd: _onEdgeUpdateEnd,
+        onReconnectEnd: _onReconnectEnd,
       });
     };
 
@@ -216,26 +216,26 @@ export default (EdgeComponent: ComponentType<EdgeProps>) => {
             interactionWidth={interactionWidth}
           />
         )}
-        {isUpdatable && (
+        {isReconnectable && (
           <>
-            {(isUpdatable === 'source' || isUpdatable === true) && (
+            {(isReconnectable === 'source' || isReconnectable === true) && (
               <EdgeAnchor
                 position={sourcePosition}
                 centerX={sourceX}
                 centerY={sourceY}
-                radius={edgeUpdaterRadius}
+                radius={reconnectRadius}
                 onMouseDown={onEdgeUpdaterSourceMouseDown}
                 onMouseEnter={onEdgeUpdaterMouseEnter}
                 onMouseOut={onEdgeUpdaterMouseOut}
                 type="source"
               />
             )}
-            {(isUpdatable === 'target' || isUpdatable === true) && (
+            {(isReconnectable === 'target' || isReconnectable === true) && (
               <EdgeAnchor
                 position={targetPosition}
                 centerX={targetX}
                 centerY={targetY}
-                radius={edgeUpdaterRadius}
+                radius={reconnectRadius}
                 onMouseDown={onEdgeUpdaterTargetMouseDown}
                 onMouseEnter={onEdgeUpdaterMouseEnter}
                 onMouseOut={onEdgeUpdaterMouseOut}

--- a/packages/core/src/components/Handle/handler.ts
+++ b/packages/core/src/components/Handle/handler.ts
@@ -25,7 +25,7 @@ export function handlePointerDown({
   setState,
   isValidConnection,
   edgeUpdaterType,
-  onEdgeUpdateEnd,
+  onReconnectEnd,
 }: {
   event: ReactMouseEvent | ReactTouchEvent;
   handleId: string | null;
@@ -36,7 +36,7 @@ export function handlePointerDown({
   setState: StoreApi<ReactFlowState>['setState'];
   isValidConnection: ValidConnectionFunc;
   edgeUpdaterType?: HandleType;
-  onEdgeUpdateEnd?: (evt: MouseEvent | TouchEvent) => void;
+  onReconnectEnd?: (evt: MouseEvent | TouchEvent) => void;
 }): void {
   // when react-flow is used inside a shadow root we can't use document
   const doc = getHostForElement(event.target as HTMLElement);
@@ -169,7 +169,7 @@ export function handlePointerDown({
     getState().onConnectEnd?.(event);
 
     if (edgeUpdaterType) {
-      onEdgeUpdateEnd?.(event);
+      onReconnectEnd?.(event);
     }
 
     resetRecentHandle(prevActiveHandle);

--- a/packages/core/src/container/EdgeRenderer/index.tsx
+++ b/packages/core/src/container/EdgeRenderer/index.tsx
@@ -18,14 +18,14 @@ type EdgeRendererProps = Pick<
   | 'onEdgeDoubleClick'
   | 'defaultMarkerColor'
   | 'onlyRenderVisibleElements'
-  | 'onEdgeUpdate'
   | 'onEdgeContextMenu'
   | 'onEdgeMouseEnter'
   | 'onEdgeMouseMove'
   | 'onEdgeMouseLeave'
-  | 'onEdgeUpdateStart'
-  | 'onEdgeUpdateEnd'
-  | 'edgeUpdaterRadius'
+  | 'onReconnect'
+  | 'onReconnectStart'
+  | 'onReconnectEnd'
+  | 'reconnectRadius'
   | 'noPanClassName'
   | 'elevateEdgesOnSelect'
   | 'rfId'
@@ -55,16 +55,16 @@ const EdgeRenderer = ({
   rfId,
   edgeTypes,
   noPanClassName,
-  onEdgeUpdate,
   onEdgeContextMenu,
   onEdgeMouseEnter,
   onEdgeMouseMove,
   onEdgeMouseLeave,
   onEdgeClick,
-  edgeUpdaterRadius,
   onEdgeDoubleClick,
-  onEdgeUpdateStart,
-  onEdgeUpdateEnd,
+  onReconnect,
+  onReconnectStart,
+  onReconnectEnd,
+  reconnectRadius,
   children,
   disableKeyboardA11y,
 }: EdgeRendererProps) => {
@@ -114,9 +114,10 @@ const EdgeRenderer = ({
               const sourcePosition = sourceHandle?.position || Position.Bottom;
               const targetPosition = targetHandle?.position || Position.Top;
               const isFocusable = !!(edge.focusable || (edgesFocusable && typeof edge.focusable === 'undefined'));
-              const isUpdatable =
-                typeof onEdgeUpdate !== 'undefined' &&
-                (edge.updatable || (edgesUpdatable && typeof edge.updatable === 'undefined'));
+              const edgeReconnectable = edge.reconnectable || edge.updatable;
+              const isReconnectable =
+                typeof onReconnect !== 'undefined' &&
+                (edgeReconnectable || (edgesUpdatable && typeof edgeReconnectable === 'undefined'));
 
               if (!sourceHandle || !targetHandle) {
                 onError?.('008', errorMessages['error008'](sourceHandle, edge));
@@ -163,20 +164,20 @@ const EdgeRenderer = ({
                   sourcePosition={sourcePosition}
                   targetPosition={targetPosition}
                   elementsSelectable={elementsSelectable}
-                  onEdgeUpdate={onEdgeUpdate}
                   onContextMenu={onEdgeContextMenu}
                   onMouseEnter={onEdgeMouseEnter}
                   onMouseMove={onEdgeMouseMove}
                   onMouseLeave={onEdgeMouseLeave}
                   onClick={onEdgeClick}
-                  edgeUpdaterRadius={edgeUpdaterRadius}
                   onEdgeDoubleClick={onEdgeDoubleClick}
-                  onEdgeUpdateStart={onEdgeUpdateStart}
-                  onEdgeUpdateEnd={onEdgeUpdateEnd}
+                  onReconnect={onReconnect}
+                  onReconnectStart={onReconnectStart}
+                  onReconnectEnd={onReconnectEnd}
+                  reconnectRadius={reconnectRadius}
                   rfId={rfId}
                   ariaLabel={edge.ariaLabel}
                   isFocusable={isFocusable}
-                  isUpdatable={isUpdatable}
+                  isReconnectable={isReconnectable}
                   pathOptions={'pathOptions' in edge ? edge.pathOptions : undefined}
                   interactionWidth={edge.interactionWidth}
                   disableKeyboardA11y={disableKeyboardA11y}

--- a/packages/core/src/container/GraphView/index.tsx
+++ b/packages/core/src/container/GraphView/index.tsx
@@ -11,7 +11,18 @@ import { createNodeTypes } from '../NodeRenderer/utils';
 import { createEdgeTypes } from '../EdgeRenderer/utils';
 import type { ReactFlowProps } from '../../types';
 
-export type GraphViewProps = Omit<ReactFlowProps, 'onSelectionChange' | 'nodes' | 'edges' | 'nodeTypes' | 'edgeTypes'> &
+export type GraphViewProps = Omit<
+  ReactFlowProps,
+  | 'onSelectionChange'
+  | 'nodes'
+  | 'edges'
+  | 'nodeTypes'
+  | 'edgeTypes'
+  | 'onEdgeUpdate'
+  | 'onEdgeUpdateStart'
+  | 'onEdgeUpdateEnd'
+  | 'edgeUpdaterRadius'
+> &
   Required<
     Pick<
       ReactFlowProps,
@@ -90,14 +101,14 @@ const GraphView = ({
   onPaneMouseLeave,
   onPaneScroll,
   onPaneContextMenu,
-  onEdgeUpdate,
   onEdgeContextMenu,
   onEdgeMouseEnter,
   onEdgeMouseMove,
   onEdgeMouseLeave,
-  edgeUpdaterRadius,
-  onEdgeUpdateStart,
-  onEdgeUpdateEnd,
+  onReconnect,
+  onReconnectStart,
+  onReconnectEnd,
+  reconnectRadius,
   noDragClassName,
   noWheelClassName,
   noPanClassName,
@@ -156,15 +167,15 @@ const GraphView = ({
           edgeTypes={edgeTypesWrapped}
           onEdgeClick={onEdgeClick}
           onEdgeDoubleClick={onEdgeDoubleClick}
-          onEdgeUpdate={onEdgeUpdate}
           onlyRenderVisibleElements={onlyRenderVisibleElements}
           onEdgeContextMenu={onEdgeContextMenu}
           onEdgeMouseEnter={onEdgeMouseEnter}
           onEdgeMouseMove={onEdgeMouseMove}
           onEdgeMouseLeave={onEdgeMouseLeave}
-          onEdgeUpdateStart={onEdgeUpdateStart}
-          onEdgeUpdateEnd={onEdgeUpdateEnd}
-          edgeUpdaterRadius={edgeUpdaterRadius}
+          onReconnect={onReconnect}
+          onReconnectStart={onReconnectStart}
+          onReconnectEnd={onReconnectEnd}
+          reconnectRadius={reconnectRadius}
           defaultMarkerColor={defaultMarkerColor}
           noPanClassName={noPanClassName}
           elevateEdgesOnSelect={!!elevateEdgesOnSelect}

--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -126,14 +126,18 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
       onPaneScroll,
       onPaneContextMenu,
       children,
-      onEdgeUpdate,
       onEdgeContextMenu,
       onEdgeDoubleClick,
       onEdgeMouseEnter,
       onEdgeMouseMove,
       onEdgeMouseLeave,
+      onEdgeUpdate,
       onEdgeUpdateStart,
       onEdgeUpdateEnd,
+      onReconnect,
+      onReconnectStart,
+      onReconnectEnd,
+      reconnectRadius = 10,
       edgeUpdaterRadius = 10,
       onNodesChange,
       onEdgesChange,
@@ -221,15 +225,15 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             onSelectionContextMenu={onSelectionContextMenu}
             onSelectionStart={onSelectionStart}
             onSelectionEnd={onSelectionEnd}
-            onEdgeUpdate={onEdgeUpdate}
             onEdgeContextMenu={onEdgeContextMenu}
             onEdgeDoubleClick={onEdgeDoubleClick}
             onEdgeMouseEnter={onEdgeMouseEnter}
             onEdgeMouseMove={onEdgeMouseMove}
             onEdgeMouseLeave={onEdgeMouseLeave}
-            onEdgeUpdateStart={onEdgeUpdateStart}
-            onEdgeUpdateEnd={onEdgeUpdateEnd}
-            edgeUpdaterRadius={edgeUpdaterRadius}
+            onReconnect={onReconnect ?? onEdgeUpdate}
+            onReconnectStart={onReconnectStart ?? onEdgeUpdateStart}
+            onReconnectEnd={onReconnectEnd ?? onEdgeUpdateEnd}
+            reconnectRadius={reconnectRadius ?? edgeUpdaterRadius}
             defaultMarkerColor={defaultMarkerColor}
             noDragClassName={noDragClassName}
             noWheelClassName={noWheelClassName}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   getIncomers,
   getConnectedEdges,
   updateEdge,
+  reconnectEdge,
   getTransformForBounds,
   getViewportForBounds,
   getRectOfNodes,

--- a/packages/core/src/types/component-props.ts
+++ b/packages/core/src/types/component-props.ts
@@ -56,14 +56,26 @@ export type ReactFlowProps = Omit<HTMLAttributes<HTMLDivElement>, 'onError'> & {
   onNodeDrag?: NodeDragHandler;
   onNodeDragStop?: NodeDragHandler;
   onEdgeClick?: (event: ReactMouseEvent, node: Edge) => void;
+  /**
+   * @deprecated Use `onReconnect` instead
+   */
   onEdgeUpdate?: OnEdgeUpdateFunc;
+  /**
+   * @deprecated Use `onReconnectStart` instead
+   */
+  onEdgeUpdateStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
+  /**
+   * @deprecated Use `onReconnectEnd` instead
+   */
+  onEdgeUpdateEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;
+  onReconnect?: OnEdgeUpdateFunc;
+  onReconnectStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
+  onReconnectEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;
   onEdgeContextMenu?: EdgeMouseHandler;
   onEdgeMouseEnter?: EdgeMouseHandler;
   onEdgeMouseMove?: EdgeMouseHandler;
   onEdgeMouseLeave?: EdgeMouseHandler;
   onEdgeDoubleClick?: EdgeMouseHandler;
-  onEdgeUpdateStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
-  onEdgeUpdateEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;
   onNodesChange?: OnNodesChange;
   onEdgesChange?: OnEdgesChange;
   onNodesDelete?: OnNodesDelete;
@@ -130,7 +142,11 @@ export type ReactFlowProps = Omit<HTMLAttributes<HTMLDivElement>, 'onError'> & {
   panOnScrollSpeed?: number;
   panOnScrollMode?: PanOnScrollMode;
   zoomOnDoubleClick?: boolean;
+  /**
+   * @deprecated Use `reconnectRadius` instead
+   */
   edgeUpdaterRadius?: number;
+  reconnectRadius?: number;
   noDragClassName?: string;
   noWheelClassName?: string;
   noPanClassName?: string;

--- a/packages/core/src/types/edges.ts
+++ b/packages/core/src/types/edges.ts
@@ -36,7 +36,11 @@ type DefaultEdge<T = any> = {
   ariaLabel?: string;
   interactionWidth?: number;
   focusable?: boolean;
+  /**
+   * @deprecated Use `reconnectable` instead
+   */
   updatable?: EdgeUpdatable;
+  reconnectable?: boolean | HandleType;
 } & EdgeLabelOptions;
 
 export type EdgeUpdatable = boolean | HandleType;
@@ -81,17 +85,17 @@ export type WrapEdgeProps<T = any> = Omit<Edge<T>, 'sourceHandle' | 'targetHandl
   sourcePosition: Position;
   targetPosition: Position;
   elementsSelectable?: boolean;
-  onEdgeUpdate?: OnEdgeUpdateFunc;
+  onReconnect?: OnEdgeUpdateFunc;
+  onReconnectStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
+  onReconnectEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;
   onContextMenu?: EdgeMouseHandler;
   onMouseEnter?: EdgeMouseHandler;
   onMouseMove?: EdgeMouseHandler;
   onMouseLeave?: EdgeMouseHandler;
-  edgeUpdaterRadius?: number;
-  onEdgeUpdateStart?: (event: ReactMouseEvent, edge: Edge, handleType: HandleType) => void;
-  onEdgeUpdateEnd?: (event: MouseEvent | TouchEvent, edge: Edge, handleType: HandleType) => void;
+  reconnectRadius?: number;
   rfId?: string;
   isFocusable: boolean;
-  isUpdatable: EdgeUpdatable;
+  isReconnectable: EdgeUpdatable;
   pathOptions?: BezierPathOptions | SmoothStepPathOptions;
   disableKeyboardA11y?: boolean;
 };

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -290,6 +290,10 @@ export type SelectionRect = Rect & {
 
 export type OnError = (id: string, message: string) => void;
 
-export interface UpdateEdgeOptions {
+export type UpdateEdgeOptions = {
   shouldReplaceId?: boolean;
-}
+};
+
+export type ReconnectEdgeOptions = {
+  shouldReplaceId?: boolean;
+};

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -14,6 +14,7 @@ import {
   NodeOrigin,
   UpdateEdgeOptions,
   Viewport,
+  ReconnectEdgeOptions,
 } from '../types';
 import { errorMessages } from '../contants';
 
@@ -95,11 +96,11 @@ export const addEdge = (edgeParams: Edge | Connection, edges: Edge[]): Edge[] =>
   return edges.concat(edge);
 };
 
-export const updateEdge = (
+export const reconnectEdge = (
   oldEdge: Edge,
   newConnection: Connection,
   edges: Edge[],
-  options: UpdateEdgeOptions = { shouldReplaceId: true }
+  options: ReconnectEdgeOptions = { shouldReplaceId: true }
 ): Edge[] => {
   const { id: oldEdgeId, ...rest } = oldEdge;
 
@@ -128,6 +129,23 @@ export const updateEdge = (
   } as Edge;
 
   return edges.filter((e) => e.id !== oldEdgeId).concat(edge);
+};
+
+/**
+ *
+ * @deprecated Use `reconnectEdge` instead.
+ */
+export const updateEdge = (
+  oldEdge: Edge,
+  newConnection: Connection,
+  edges: Edge[],
+  options: UpdateEdgeOptions = { shouldReplaceId: true }
+): Edge[] => {
+  console.warn(
+    '[DEPRECATED] `updateEdge` is deprecated. Instead use `reconnectEdge` https://reactflow.dev/api-reference/utils/reconnect-edge'
+  );
+
+  return reconnectEdge(oldEdge, newConnection, edges, options);
 };
 
 export const pointToRendererPoint = (

--- a/packages/minimap/CHANGELOG.md
+++ b/packages/minimap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/minimap
 
+## 11.7.14
+
+### Patch Changes
+
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+
 ## 11.7.13
 
 ### Patch Changes

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/minimap",
-  "version": "11.7.13",
+  "version": "11.7.14",
   "description": "Minimap component for React Flow.",
   "keywords": [
     "react",

--- a/packages/node-resizer/CHANGELOG.md
+++ b/packages/node-resizer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-resizer
 
+## 2.2.14
+
+### Patch Changes
+
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+
 ## 2.2.13
 
 ### Patch Changes

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-resizer",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "description": "A helper component for resizing nodes.",
   "keywords": [
     "react",

--- a/packages/node-toolbar/CHANGELOG.md
+++ b/packages/node-toolbar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reactflow/node-toolbar
 
+## 1.3.14
+
+### Patch Changes
+
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+
 ## 1.3.13
 
 ### Patch Changes

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactflow/node-toolbar",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "A toolbar component for React Flow that can be attached to a node.",
   "keywords": [
     "react",

--- a/packages/reactflow/CHANGELOG.md
+++ b/packages/reactflow/CHANGELOG.md
@@ -1,5 +1,30 @@
 # reactflow
 
+## 11.11.4
+
+This release adds some deprecation warnings and introduces new function and attribute names for "edge update" which is now called "edge reconnect": 
+
+`updateEdge` => `reconnectEdge`
+`onEdgeUpdateStart` => `onReconnectStart`
+`onEdgeUpdate` => `onReconnect`
+`onEdgeUpdateEnd` => `onReconnectEnd`
+`edgeUpdaterRadius` => `reconnectRadius`
+`edge.updatable` => `edge.reconnectable`
+
+We changed the term, because we think it's more clear what it does and is better to distinguish from the new `updateEdge` and `updateEdgeData` helpers in React Flow 12.
+
+### Patch Changes
+
+- [#4389](https://github.com/xyflow/xyflow/pull/4389) [`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211) - rename updateEdge to reconectEdge
+- [#4387](https://github.com/xyflow/xyflow/pull/4387) [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9) - abort drag when multiple touches are detected
+- Updated dependencies [[`092b2ecb`](https://github.com/xyflow/xyflow/commit/092b2ecbc45aa829e590acb094c7ef75d752d211), [`280a64ee`](https://github.com/xyflow/xyflow/commit/280a64ee1652e36366ea0e0ad6a56a41c6c5f7b9)]:
+  - @reactflow/core@11.11.4
+  - @reactflow/background@11.3.14
+  - @reactflow/controls@11.2.14
+  - @reactflow/minimap@11.7.14
+  - @reactflow/node-resizer@2.2.14
+  - @reactflow/node-toolbar@1.3.14
+
 ## 11.11.3
 
 ### Patch Changes

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactflow",
-  "version": "11.11.3",
+  "version": "11.11.4",
   "description": "A highly customizable React library for building node-based editors and interactive flow charts",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR adds some deprecation warnings and introduces new function and attribute names for "edge update" which is now called "edge reconnect": 

`updateEdge` => `reconnectEdge`
`onEdgeUpdateStart` => `onReconnectStart`
`onEdgeUpdate` => `onReconnect`
`onEdgeUpdateEnd` => `onReconnectEnd`
`edgeUpdaterRadius` => `reconnectRadius`
`edge.updatable` => `edge.reconnectable`

We changed the term, because we think it's more clear what it does and is better to distinguish from the new `updateEdge` and `updateEdgeData` helpers in React Flow 12.

## Patch changes

- abort drag when multiple touches are detected
- rename updateEdge to reconnectEdge and deprecate function and attribute names