### PR TITLE
Option to intersection on certain input percentage. Issue #4406

### DIFF
--- a/packages/react/src/hooks/useReactFlow.ts
+++ b/packages/react/src/hooks/useReactFlow.ts
@@ -172,7 +172,7 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
 
         return { deletedNodes: matchingNodes, deletedEdges: matchingEdges };
       },
-      getIntersectingNodes: (nodeOrRect, partially = true, nodes) => {
+      getIntersectingNodes: (nodeOrRect, partially = true, nodes, inputPercentOverlap) => {
         const isRect = isRectObject(nodeOrRect);
         const nodeRect = isRect ? nodeOrRect : getNodeRect(nodeOrRect);
         const hasNodesOption = nodes !== undefined;
@@ -190,8 +190,16 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
 
           const currNodeRect = nodeToRect(hasNodesOption ? n : internalNode!);
           const overlappingArea = getOverlappingArea(currNodeRect, nodeRect);
+          const overlappingPercentage = overlappingArea / (nodeRect.width * nodeRect.height);
           const partiallyVisible = partially && overlappingArea > 0;
 
+          if (inputPercentOverlap) {
+            if (inputPercentOverlap > 100 || inputPercentOverlap < 0) {
+              return partiallyVisible || overlappingArea >= nodeRect.width * nodeRect.height;
+            }
+            const inputPercentToFraction = inputPercentOverlap / 100;
+            return overlappingPercentage >= inputPercentToFraction;
+          }
           return partiallyVisible || overlappingArea >= nodeRect.width * nodeRect.height;
         }) as NodeType[];
       },

--- a/packages/react/src/types/instance.ts
+++ b/packages/react/src/types/instance.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+import type { Edge, InternalNode, Node, ViewportHelperFunctions } from '.';
 import type { Rect, Viewport } from '@xyflow/system';
-import type { Node, Edge, ViewportHelperFunctions, InternalNode } from '.';
 
 export type ReactFlowJsonObject<NodeType extends Node = Node, EdgeType extends Edge = Edge> = {
   nodes: NodeType[];
@@ -101,7 +101,8 @@ export type GeneralHelpers<NodeType extends Node = Node, EdgeType extends Edge =
   getIntersectingNodes: (
     node: NodeType | { id: Node['id'] } | Rect,
     partially?: boolean,
-    nodes?: NodeType[]
+    nodes?: NodeType[],
+    inputPercentOverlap?: number
   ) => NodeType[];
   /**
    * Checks if the given node or rect intersects with the passed rect.


### PR DESCRIPTION
Issue #4406 
Added option through which user can define percentage area overlap.

```js
getIntersectingNodes: (nodeOrRect, partially = true, nodes, inputPercentOverlap)
```