### PR TITLE
fix: type error

### DIFF
--- a/packages/react/src/additional-components/Background/types.ts
+++ b/packages/react/src/additional-components/Background/types.ts
@@ -28,7 +28,7 @@ export type BackgroundProps = {
    * @example BackgroundVariant.Lines, BackgroundVariant.Dots, BackgroundVariant.Cross
    * 'lines', 'dots', 'cross'
    */
-  variant?: BackgroundVariant;
+  variant?: 'lines' | 'dots' | 'cross';
   /** Style applied to the container */
   style?: CSSProperties;
 };


### PR DESCRIPTION
fixed: Type '"dots"' is not assignable to type 'BackgroundVariant | undefined'.ts(2322)

example code:         <Background variant='dots' bgColor='#0a0a0a' />