### PR TITLE
feat(types): accepts readonly arrays in props

### DIFF
--- a/packages/react/src/components/ReactFlowProvider/index.tsx
+++ b/packages/react/src/components/ReactFlowProvider/index.tsx
@@ -7,10 +7,10 @@ import type { Node, Edge } from '../../types';
 import { NodeOrigin } from '@xyflow/system';
 
 export type ReactFlowProviderProps = {
-  initialNodes?: Node[];
-  initialEdges?: Edge[];
-  defaultNodes?: Node[];
-  defaultEdges?: Edge[];
+  initialNodes?: readonly Node[];
+  initialEdges?: readonly Edge[];
+  defaultNodes?: readonly Node[];
+  defaultEdges?: readonly Edge[];
   initialWidth?: number;
   initialHeight?: number;
   fitView?: boolean;

--- a/packages/react/src/container/ReactFlow/Wrapper.tsx
+++ b/packages/react/src/container/ReactFlow/Wrapper.tsx
@@ -17,10 +17,10 @@ export function Wrapper({
   nodeOrigin,
 }: {
   children: ReactNode;
-  nodes?: Node[];
-  edges?: Edge[];
-  defaultNodes?: Node[];
-  defaultEdges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
+  defaultNodes?: readonly Node[];
+  defaultEdges?: readonly Edge[];
   width?: number;
   height?: number;
   fitView?: boolean;

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -31,10 +31,10 @@ const createStore = ({
   fitView,
   nodeOrigin,
 }: {
-  nodes?: Node[];
-  edges?: Edge[];
-  defaultNodes?: Node[];
-  defaultEdges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
+  defaultNodes?: readonly Node[];
+  defaultEdges?: readonly Edge[];
   width?: number;
   height?: number;
   fitView?: boolean;
@@ -43,7 +43,7 @@ const createStore = ({
   createWithEqualityFn<ReactFlowState>(
     (set, get) => ({
       ...getInitialState({ nodes, edges, width, height, fitView, nodeOrigin, defaultNodes, defaultEdges }),
-      setNodes: (nodes: Node[]) => {
+      setNodes: (nodes: readonly Node[]) => {
         const { nodeLookup, parentLookup, nodeOrigin, elevateNodesOnSelect } = get();
         // setNodes() is called exclusively in response to user actions:
         // - either when the `<ReactFlow nodes>` prop is updated in the controlled ReactFlow setup,
@@ -55,14 +55,14 @@ const createStore = ({
 
         set({ nodes });
       },
-      setEdges: (edges: Edge[]) => {
+      setEdges: (edges: readonly Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
         updateConnectionLookup(connectionLookup, edgeLookup, edges);
 
         set({ edges });
       },
-      setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => {
+      setDefaultNodesAndEdges: (nodes?: readonly Node[], edges?: readonly Edge[]) => {
         if (nodes) {
           const { setNodes } = get();
           setNodes(nodes);

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -23,10 +23,10 @@ const getInitialState = ({
   fitView,
   nodeOrigin,
 }: {
-  nodes?: Node[];
-  edges?: Edge[];
-  defaultNodes?: Node[];
-  defaultEdges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
+  defaultNodes?: readonly Node[];
+  defaultEdges?: readonly Edge[];
   width?: number;
   height?: number;
   fitView?: boolean;

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -63,7 +63,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    *  }
    * ];
    */
-  nodes?: NodeType[];
+  nodes?: readonly NodeType[];
   /** An array of edges to render in a controlled flow.
    * @example
    * const edges = [
@@ -74,11 +74,11 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    *  }
    * ];
    */
-  edges?: EdgeType[];
+  edges?: readonly EdgeType[];
   /** The initial nodes to render in an uncontrolled flow. */
-  defaultNodes?: NodeType[];
+  defaultNodes?: readonly NodeType[];
   /** The initial edges to render in an uncontrolled flow. */
-  defaultEdges?: EdgeType[];
+  defaultEdges?: readonly EdgeType[];
   /** Defaults to be applied to all new edges that are added to the flow.
    *
    * Properties on a new edge will override these defaults if they exist.
@@ -180,7 +180,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   onSelectionDragStop?: SelectionDragHandler<NodeType>;
   onSelectionStart?: (event: ReactMouseEvent) => void;
   onSelectionEnd?: (event: ReactMouseEvent) => void;
-  onSelectionContextMenu?: (event: ReactMouseEvent, nodes: NodeType[]) => void;
+  onSelectionContextMenu?: (event: ReactMouseEvent, nodes: readonly NodeType[]) => void;
   /** When a connection line is completed and two nodes are connected by the user, this event fires with the new connection.
    *
    * You can use the addEdge utility to convert the connection to a complete edge.
@@ -353,7 +353,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    * @example [0, 2] // allows panning with the left and right mouse buttons
    * [0, 1, 2, 3, 4] // allows panning with all mouse buttons
    */
-  panOnDrag?: boolean | number[];
+  panOnDrag?: boolean | readonly number[];
   /** Minimum zoom level
    * @default 0.5
    */

--- a/packages/react/src/types/general.ts
+++ b/packages/react/src/types/general.ts
@@ -52,13 +52,13 @@ export type EdgeTypes = Record<
 >;
 
 export type UnselectNodesAndEdgesParams = {
-  nodes?: Node[];
-  edges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
 };
 
 export type OnSelectionChangeParams = {
-  nodes: Node[];
-  edges: Edge[];
+  nodes: readonly Node[];
+  edges: readonly Edge[];
 };
 
 export type OnSelectionChangeFunc = (params: OnSelectionChangeParams) => void;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -52,10 +52,10 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
   width: number;
   height: number;
   transform: Transform;
-  nodes: NodeType[];
+  nodes: readonly NodeType[];
   nodeLookup: NodeLookup<InternalNode<NodeType>>;
   parentLookup: ParentLookup<InternalNode<NodeType>>;
-  edges: Edge[];
+  edges: readonly Edge[];
   edgeLookup: EdgeLookup<EdgeType>;
   connectionLookup: ConnectionLookup;
   onNodesChange: OnNodesChange<NodeType> | null;
@@ -149,9 +149,9 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
 };
 
 export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
-  setNodes: (nodes: NodeType[]) => void;
-  setEdges: (edges: EdgeType[]) => void;
-  setDefaultNodesAndEdges: (nodes?: NodeType[], edges?: EdgeType[]) => void;
+  setNodes: (nodes: readonly NodeType[]) => void;
+  setEdges: (edges: readonly EdgeType[]) => void;
+  setDefaultNodesAndEdges: (nodes?: readonly NodeType[], edges?: readonly EdgeType[]) => void;
   updateNodeInternals: (updates: Map<string, InternalNodeUpdate>) => void;
   updateNodePositions: UpdateNodePositions;
   resetSelectedElements: () => void;

--- a/packages/react/src/utils/changes.ts
+++ b/packages/react/src/utils/changes.ts
@@ -14,7 +14,7 @@ import type { Node, Edge, InternalNode } from '../types';
 // This function applies changes to nodes or edges that are triggered by React Flow internally.
 // When you drag a node for example, React Flow will send a position change update.
 // This function then applies the changes and returns the updated elements.
-function applyChanges(changes: any[], elements: any[]): any[] {
+function applyChanges(changes: readonly any[], elements: readonly any[]): any[] {
   const updatedElements: any[] = [];
   // By storing a map of changes for each element, we can a quick lookup as we
   // iterate over the elements array!
@@ -139,7 +139,7 @@ function applyChange(change: any, element: any): any {
  */
 export function applyNodeChanges<NodeType extends Node = Node>(
   changes: NodeChange<NodeType>[],
-  nodes: NodeType[]
+  nodes: readonly NodeType[]
 ): NodeType[] {
   return applyChanges(changes, nodes) as NodeType[];
 }
@@ -165,8 +165,8 @@ export function applyNodeChanges<NodeType extends Node = Node>(
     );
  */
 export function applyEdgeChanges<EdgeType extends Edge = Edge>(
-  changes: EdgeChange<EdgeType>[],
-  edges: EdgeType[]
+  changes: readonly EdgeChange<EdgeType>[],
+  edges: readonly EdgeType[]
 ): EdgeType[] {
   return applyChanges(changes, edges) as EdgeType[];
 }

--- a/packages/svelte/src/lib/components/NodeSelection/NodeSelection.svelte
+++ b/packages/svelte/src/lib/components/NodeSelection/NodeSelection.svelte
@@ -12,8 +12,8 @@
 
   const dispatch = createEventDispatcher<
     NodeEventMap & {
-      selectioncontextmenu: { nodes: Node[]; event: MouseEvent | TouchEvent };
-      selectionclick: { nodes: Node[]; event: MouseEvent | TouchEvent };
+      selectioncontextmenu: { nodes: readonly Node[]; event: MouseEvent | TouchEvent };
+      selectionclick: { nodes: readonly Node[]; event: MouseEvent | TouchEvent };
     }
   >();
 

--- a/packages/svelte/src/lib/hooks/useSvelteFlow.ts
+++ b/packages/svelte/src/lib/hooks/useSvelteFlow.ts
@@ -60,7 +60,7 @@ export function useSvelteFlow(): {
    *
    * @returns nodes array
    */
-  getNodes: (ids?: string[]) => Node[];
+  getNodes: (ids?: readonly string[]) => readonly Node[];
   /**
    * Returns an edge by id.
    *
@@ -73,7 +73,7 @@ export function useSvelteFlow(): {
    *
    * @returns edges array
    */
-  getEdges: (ids?: string[]) => Edge[];
+  getEdges: (ids?: readonly string[]) => readonly Edge[];
   /**
    * Sets the current zoom level.
    *
@@ -509,10 +509,10 @@ export function useSvelteFlow(): {
     viewport
   };
 }
-function getElements(lookup: Map<string, InternalNode>, ids: string[]): Node[];
-function getElements(lookup: Map<string, Edge>, ids: string[]): Edge[];
+function getElements(lookup: Map<string, InternalNode>, ids: readonly string[]): Node[];
+function getElements(lookup: Map<string, Edge>, ids: readonly string[]): Edge[];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getElements(lookup: Map<string, any>, ids: string[]): any[] {
+function getElements(lookup: Map<string, any>, ids: readonly string[]): any[] {
   const result = [];
 
   for (const id of ids) {

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -39,8 +39,8 @@ export function createStore({
   fitView: fitViewOnCreate,
   nodeOrigin
 }: {
-  nodes?: Node[];
-  edges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
   width?: number;
   height?: number;
   fitView?: boolean;
@@ -237,7 +237,7 @@ export function createStore({
     }
   }
 
-  function resetSelectedElements(elements: Node[] | Edge[]) {
+  function resetSelectedElements(elements: readonly Node[] | readonly Edge[]) {
     let elementsChanged = false;
     elements.forEach((element) => {
       if (element.selected) {
@@ -252,7 +252,7 @@ export function createStore({
     get(store.panZoom)?.setClickDistance(distance);
   }
 
-  function unselectNodesAndEdges(params?: { nodes?: Node[]; edges?: Edge[] }) {
+  function unselectNodesAndEdges(params?: { nodes?: readonly Node[]; edges?: readonly Edge[] }) {
     const resetNodes = resetSelectedElements(params?.nodes || get(store.nodes));
     if (resetNodes) store.nodes.set(get(store.nodes));
 

--- a/packages/svelte/src/lib/store/initial-store.ts
+++ b/packages/svelte/src/lib/store/initial-store.ts
@@ -77,8 +77,8 @@ export const getInitialStore = ({
   fitView,
   nodeOrigin
 }: {
-  nodes?: Node[];
-  edges?: Edge[];
+  nodes?: readonly Node[];
+  edges?: readonly Edge[];
   width?: number;
   height?: number;
   fitView?: boolean;

--- a/packages/svelte/src/lib/store/types.ts
+++ b/packages/svelte/src/lib/store/types.ts
@@ -14,8 +14,8 @@ import type { getInitialStore } from './initial-store';
 import type { Node, Edge, NodeTypes, EdgeTypes, FitViewOptions } from '$lib/types';
 
 export type SvelteFlowStoreActions = {
-  syncNodeStores: (nodesStore: Writable<Node[]>) => void;
-  syncEdgeStores: (edgeStore: Writable<Edge[]>) => void;
+  syncNodeStores: (nodesStore: Writable<readonly Node[]>) => void;
+  syncEdgeStores: (edgeStore: Writable<readonly Edge[]>) => void;
   syncViewport: (viewportStore?: Writable<Viewport>) => void;
   setNodeTypes: (nodeTypes: NodeTypes) => void;
   setEdgeTypes: (edgeTypes: EdgeTypes) => void;
@@ -29,7 +29,7 @@ export type SvelteFlowStoreActions = {
   fitView: (options?: FitViewOptions) => Promise<boolean>;
   updateNodePositions: UpdateNodePositions;
   updateNodeInternals: (updates: Map<string, InternalNodeUpdate>) => void;
-  unselectNodesAndEdges: (params?: { nodes?: Node[]; edges?: Edge[] }) => void;
+  unselectNodesAndEdges: (params?: { nodes?: readonly Node[]; edges?: readonly Edge[] }) => void;
   addSelectedNodes: (ids: string[]) => void;
   addSelectedEdges: (ids: string[]) => void;
   handleNodeSelection: (id: string) => void;

--- a/packages/svelte/src/lib/store/utils.ts
+++ b/packages/svelte/src/lib/store/utils.ts
@@ -24,7 +24,7 @@ import type { DefaultEdgeOptions, DefaultNodeOptions, Edge, InternalNode, Node }
 // made by Svelte Flow (like dragging or selecting a node).
 export function syncNodeStores(
   nodesStore: ReturnType<typeof createNodesStore>,
-  userNodesStore: Writable<Node[]>
+  userNodesStore: Writable<readonly Node[]>
 ) {
   const nodesStoreSetter = nodesStore.set;
   const userNodesStoreSetter = userNodesStore.set;
@@ -39,7 +39,7 @@ export function syncNodeStores(
   let val = initWithUserNodes ? currentUserNodesStore : currentNodesStore;
   nodesStore.set(val);
 
-  const _set = (nds: Node[]) => {
+  const _set = (nds: readonly Node[]) => {
     const updatedNodes = nodesStoreSetter(nds);
     val = updatedNodes;
 
@@ -49,13 +49,14 @@ export function syncNodeStores(
   };
 
   nodesStore.set = userNodesStore.set = _set;
-  nodesStore.update = userNodesStore.update = (fn: (nds: Node[]) => Node[]) => _set(fn(val));
+  nodesStore.update = userNodesStore.update = (fn: (nds: readonly Node[]) => readonly Node[]) =>
+    _set(fn(val));
 }
 
 // same for edges
 export function syncEdgeStores(
   edgesStore: ReturnType<typeof createEdgesStore>,
-  userEdgesStore: Writable<Edge[]>
+  userEdgesStore: Writable<readonly Edge[]>
 ) {
   const nodesStoreSetter = edgesStore.set;
   const userEdgesStoreSetter = userEdgesStore.set;
@@ -63,14 +64,15 @@ export function syncEdgeStores(
   let val = get(userEdgesStore);
   edgesStore.set(val);
 
-  const _set = (eds: Edge[]) => {
+  const _set = (eds: readonly Edge[]) => {
     nodesStoreSetter(eds);
     userEdgesStoreSetter(eds);
     val = eds;
   };
 
   edgesStore.set = userEdgesStore.set = _set;
-  edgesStore.update = userEdgesStore.update = (fn: (nds: Edge[]) => Edge[]) => _set(fn(val));
+  edgesStore.update = userEdgesStore.update = (fn: (nds: readonly Edge[]) => readonly Edge[]) =>
+    _set(fn(val));
 }
 
 // it is possible to pass a viewport store to SvelteFlow for having more control
@@ -128,23 +130,23 @@ export type NodeStoreOptions = {
 // we are creating a custom store for the internals nodes in order to update the zIndex and positionAbsolute.
 // The user only passes in relative positions, so we need to calculate the absolute positions based on the parent nodes.
 export const createNodesStore = (
-  nodes: Node[],
+  nodes: readonly Node[],
   nodeLookup: NodeLookup<InternalNode>,
   parentLookup: ParentLookup<InternalNode>,
   nodeOrigin: NodeOrigin = [0, 0]
 ): {
-  subscribe: (this: void, run: Subscriber<Node[]>) => Unsubscriber;
-  update: (this: void, updater: Updater<Node[]>) => void;
-  set: (this: void, value: Node[]) => Node[];
+  subscribe: (this: void, run: Subscriber<readonly Node[]>) => Unsubscriber;
+  update: (this: void, updater: Updater<readonly Node[]>) => void;
+  set: (this: void, value: readonly Node[]) => readonly Node[];
   setDefaultOptions: (opts: DefaultNodeOptions) => void;
   setOptions: (opts: NodeStoreOptions) => void;
 } => {
-  const { subscribe, set, update } = writable<Node[]>([]);
+  const { subscribe, set, update } = writable<readonly Node[]>([]);
   let value = nodes;
   let defaults = {};
   let elevateNodesOnSelect = true;
 
-  const _set = (nds: Node[]): Node[] => {
+  const _set = (nds: readonly Node[]): readonly Node[] => {
     adoptUserNodes(nds, nodeLookup, parentLookup, {
       elevateNodesOnSelect,
       nodeOrigin,
@@ -159,7 +161,7 @@ export const createNodesStore = (
     return value;
   };
 
-  const _update: typeof update = (fn: (nds: Node[]) => Node[]) => _set(fn(value));
+  const _update: typeof update = (fn: (nds: readonly Node[]) => Node[]) => _set(fn(value));
 
   const setDefaultOptions = (options: DefaultNodeOptions) => {
     defaults = options;
@@ -181,16 +183,16 @@ export const createNodesStore = (
 };
 
 export const createEdgesStore = (
-  edges: Edge[],
+  edges: readonly Edge[],
   connectionLookup: ConnectionLookup,
   edgeLookup: EdgeLookup<Edge>,
   defaultOptions?: DefaultEdgeOptions
-): Writable<Edge[]> & { setDefaultOptions: (opts: DefaultEdgeOptions) => void } => {
-  const { subscribe, set, update } = writable<Edge[]>([]);
+): Writable<readonly Edge[]> & { setDefaultOptions: (opts: DefaultEdgeOptions) => void } => {
+  const { subscribe, set, update } = writable<readonly Edge[]>([]);
   let value = edges;
   let defaults = defaultOptions || {};
 
-  const _set: typeof set = (eds: Edge[]) => {
+  const _set: typeof set = (eds: readonly Edge[]) => {
     const nextEdges = defaults ? eds.map((edge) => ({ ...defaults, ...edge })) : eds;
 
     updateConnectionLookup(connectionLookup, edgeLookup, nextEdges);
@@ -199,7 +201,7 @@ export const createEdgesStore = (
     set(value);
   };
 
-  const _update: typeof update = (fn: (eds: Edge[]) => Edge[]) => _set(fn(value));
+  const _update: typeof update = (fn: (eds: readonly Edge[]) => readonly Edge[]) => _set(fn(value));
 
   const setDefaultOptions = (options: DefaultEdgeOptions) => {
     defaults = options;

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -49,9 +49,13 @@ export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default'
 export type NodeEventMap = {
   nodeclick: { node: Node; event: MouseEvent | TouchEvent };
   nodecontextmenu: { node: Node; event: MouseEvent | TouchEvent };
-  nodedrag: { targetNode: Node | null; nodes: Node[]; event: MouseEvent | TouchEvent };
-  nodedragstart: { targetNode: Node | null; nodes: Node[]; event: MouseEvent | TouchEvent };
-  nodedragstop: { targetNode: Node | null; nodes: Node[]; event: MouseEvent | TouchEvent };
+  nodedrag: { targetNode: Node | null; nodes: readonly Node[]; event: MouseEvent | TouchEvent };
+  nodedragstart: {
+    targetNode: Node | null;
+    nodes: readonly Node[];
+    event: MouseEvent | TouchEvent;
+  };
+  nodedragstop: { targetNode: Node | null; nodes: readonly Node[]; event: MouseEvent | TouchEvent };
   nodemouseenter: { node: Node; event: MouseEvent | TouchEvent };
   nodemouseleave: { node: Node; event: MouseEvent | TouchEvent };
   nodemousemove: { node: Node; event: MouseEvent | TouchEvent };

--- a/packages/system/src/types/panzoom.ts
+++ b/packages/system/src/types/panzoom.ts
@@ -31,7 +31,7 @@ export type PanZoomUpdateOptions = {
   onPaneContextMenu?: (event: MouseEvent) => void;
   preventScrolling: boolean;
   panOnScroll: boolean;
-  panOnDrag: boolean | number[];
+  panOnDrag: boolean | readonly number[];
   panOnScrollMode: PanOnScrollMode;
   panOnScrollSpeed: number;
   userSelectionActive: boolean;

--- a/packages/system/src/utils/edges/general.ts
+++ b/packages/system/src/utils/edges/general.ts
@@ -79,7 +79,7 @@ export function isEdgeVisible({ sourceNode, targetNode, width, height, transform
 const getEdgeId = ({ source, sourceHandle, target, targetHandle }: Connection | EdgeBase): string =>
   `xy-edge__${source}${sourceHandle || ''}-${target}${targetHandle || ''}`;
 
-const connectionExists = (edge: EdgeBase, edges: EdgeBase[]) => {
+const connectionExists = (edge: EdgeBase, edges: readonly EdgeBase[]) => {
   return edges.some(
     (el) =>
       el.source === edge.source &&
@@ -99,8 +99,8 @@ const connectionExists = (edge: EdgeBase, edges: EdgeBase[]) => {
  */
 export const addEdge = <EdgeType extends EdgeBase>(
   edgeParams: EdgeType | Connection,
-  edges: EdgeType[]
-): EdgeType[] => {
+  edges: readonly EdgeType[]
+): readonly EdgeType[] => {
   if (!edgeParams.source || !edgeParams.target) {
     devWarn('006', errorMessages['error006']());
 

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -222,8 +222,8 @@ export const getNodesInside = <NodeType extends NodeBase = NodeBase>(
  * @returns Array of edges that connect any of the given nodes with each other
  */
 export const getConnectedEdges = <NodeType extends NodeBase = NodeBase, EdgeType extends EdgeBase = EdgeBase>(
-  nodes: NodeType[],
-  edges: EdgeType[]
+  nodes: readonly NodeType[],
+  edges: readonly EdgeType[]
 ): EdgeType[] => {
   const nodeIds = new Set();
   nodes.forEach((node) => {
@@ -375,10 +375,10 @@ export async function getElementsToRemove<NodeType extends NodeBase = NodeBase, 
   edges,
   onBeforeDelete,
 }: {
-  nodesToRemove: Partial<NodeType>[];
-  edgesToRemove: Partial<EdgeType>[];
-  nodes: NodeType[];
-  edges: EdgeType[];
+  nodesToRemove: readonly Partial<NodeType>[];
+  edgesToRemove: readonly Partial<EdgeType>[];
+  nodes: readonly NodeType[];
+  edges: readonly EdgeType[];
   onBeforeDelete?: OnBeforeDeleteBase<NodeType, EdgeType>;
 }): Promise<{
   nodes: NodeType[];

--- a/packages/system/src/utils/marker.ts
+++ b/packages/system/src/utils/marker.ts
@@ -18,7 +18,7 @@ export function getMarkerId(marker: EdgeMarkerType | undefined, id?: string | nu
 }
 
 export function createMarkerIds(
-  edges: EdgeBase[],
+  edges: readonly EdgeBase[],
   {
     id,
     defaultColor,

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -54,7 +54,7 @@ type UpdateNodesOptions<NodeType extends NodeBase> = {
 };
 
 export function adoptUserNodes<NodeType extends NodeBase>(
-  nodes: NodeType[],
+  nodes: readonly NodeType[],
   nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
   parentLookup: ParentLookup<InternalNodeBase<NodeType>>,
   options?: UpdateNodesOptions<NodeType>
@@ -364,7 +364,11 @@ export async function panBy({
   return Promise.resolve(transformChanged);
 }
 
-export function updateConnectionLookup(connectionLookup: ConnectionLookup, edgeLookup: EdgeLookup, edges: EdgeBase[]) {
+export function updateConnectionLookup(
+  connectionLookup: ConnectionLookup,
+  edgeLookup: EdgeLookup,
+  edges: readonly EdgeBase[]
+) {
   connectionLookup.clear();
   edgeLookup.clear();
 

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -33,13 +33,13 @@ export type OnDrag = (
   event: MouseEvent,
   dragItems: Map<string, NodeDragItem>,
   node: NodeBase,
-  nodes: NodeBase[]
+  nodes: readonly NodeBase[]
 ) => void;
 
 type StoreItems<OnNodeDrag> = {
-  nodes: NodeBase[];
+  nodes: readonly NodeBase[];
   nodeLookup: Map<string, InternalNodeBase>;
-  edges: EdgeBase[];
+  edges: readonly EdgeBase[];
   nodeExtent: CoordinateExtent;
   snapGrid: SnapGrid;
   snapToGrid: boolean;
@@ -52,7 +52,7 @@ type StoreItems<OnNodeDrag> = {
   selectNodesOnDrag: boolean;
   nodeDragThreshold: number;
   panBy: PanBy;
-  unselectNodesAndEdges: (params?: { nodes?: NodeBase[]; edges?: EdgeBase[] }) => void;
+  unselectNodesAndEdges: (params?: { nodes?: readonly NodeBase[]; edges?: readonly EdgeBase[] }) => void;
   onError?: OnError;
   onNodeDragStart?: OnNodeDrag;
   onNodeDrag?: OnNodeDrag;

--- a/packages/system/src/xypanzoom/eventhandler.ts
+++ b/packages/system/src/xypanzoom/eventhandler.ts
@@ -43,7 +43,7 @@ export type PanZoomStartParams = {
 
 export type PanZoomParams = {
   zoomPanValues: ZoomPanValues;
-  panOnDrag: boolean | number[];
+  panOnDrag: boolean | readonly number[];
   onPaneContextMenu: boolean;
   onTransformChange: OnTransformChange;
   onPanZoom?: OnPanZoom;
@@ -51,7 +51,7 @@ export type PanZoomParams = {
 
 export type PanZoomEndParams = {
   zoomPanValues: ZoomPanValues;
-  panOnDrag: boolean | number[];
+  panOnDrag: boolean | readonly number[];
   panOnScroll: boolean;
   onDraggingChange: (isDragging: boolean) => void;
   onPanZoomEnd?: OnPanZoom;

--- a/packages/system/src/xypanzoom/filter.ts
+++ b/packages/system/src/xypanzoom/filter.ts
@@ -5,7 +5,7 @@ export type FilterParams = {
   zoomActivationKeyPressed: boolean;
   zoomOnScroll: boolean;
   zoomOnPinch: boolean;
-  panOnDrag: boolean | number[];
+  panOnDrag: boolean | readonly number[];
   panOnScroll: boolean;
   zoomOnDoubleClick: boolean;
   userSelectionActive: boolean;

--- a/packages/system/src/xypanzoom/utils.ts
+++ b/packages/system/src/xypanzoom/utils.ts
@@ -18,7 +18,7 @@ export const viewportToTransform = ({ x, y, zoom }: Viewport): ZoomTransform =>
 
 export const isWrappedWithClass = (event: any, className: string | undefined) => event.target.closest(`.${className}`);
 
-export const isRightClickPan = (panOnDrag: boolean | number[], usedButton: number) =>
+export const isRightClickPan = (panOnDrag: boolean | readonly number[], usedButton: number) =>
   usedButton === 2 && Array.isArray(panOnDrag) && panOnDrag.includes(2);
 
 export const getD3Transition = (selection: D3SelectionInstance, duration = 0, onEnd = () => {}) => {


### PR DESCRIPTION
The library never modifies the arrays of nodes and edges given in properties, so we can accept readonly arrays.