### PR TITLE
Control background pattern translation with offset

### DIFF
--- a/packages/react/src/additional-components/Background/Background.tsx
+++ b/packages/react/src/additional-components/Background/Background.tsx
@@ -70,7 +70,7 @@ function BackgroundComponent({
         patternTransform={`translate(-${scaledOffset[0]},-${scaledOffset[1]})`}
       >
         {isDots ? (
-          <DotPattern radius={scaledSize} className={patternClassName} />
+          <DotPattern radius={scaledSize / 2} className={patternClassName} />
         ) : (
           <LinePattern
             dimensions={patternDimensions}

--- a/packages/react/src/additional-components/Background/Background.tsx
+++ b/packages/react/src/additional-components/Background/Background.tsx
@@ -24,7 +24,7 @@ function BackgroundComponent({
   // only used for lines and cross
   size,
   lineWidth = 1,
-  offset = 2,
+  offset = 0,
   color,
   bgColor,
   style,
@@ -39,12 +39,10 @@ function BackgroundComponent({
   const gapXY: [number, number] = Array.isArray(gap) ? gap : [gap, gap];
   const scaledGap: [number, number] = [gapXY[0] * transform[2] || 1, gapXY[1] * transform[2] || 1];
   const scaledSize = patternSize * transform[2];
+  const offsetXY: [number, number] = Array.isArray(offset) ? offset : [offset, offset];
+  const scaledOffset: [number, number] = [offsetXY[0] * transform[2] || 1, offsetXY[1] * transform[2] || 1]
 
   const patternDimensions: [number, number] = isCross ? [scaledSize, scaledSize] : scaledGap;
-
-  const patternOffset = isDots
-    ? [scaledSize / offset, scaledSize / offset]
-    : [patternDimensions[0] / offset, patternDimensions[1] / offset];
 
   const _patternId = `${patternId}${id ? id : ''}`;
 
@@ -69,10 +67,10 @@ function BackgroundComponent({
         width={scaledGap[0]}
         height={scaledGap[1]}
         patternUnits="userSpaceOnUse"
-        patternTransform={`translate(-${patternOffset[0]},-${patternOffset[1]})`}
+        patternTransform={`translate(-${scaledOffset[0]},-${scaledOffset[1]})`}
       >
         {isDots ? (
-          <DotPattern radius={scaledSize / offset} className={patternClassName} />
+          <DotPattern radius={scaledSize} className={patternClassName} />
         ) : (
           <LinePattern
             dimensions={patternDimensions}

--- a/packages/react/src/additional-components/Background/types.ts
+++ b/packages/react/src/additional-components/Background/types.ts
@@ -21,7 +21,7 @@ export type BackgroundProps = {
   /** Size of a single pattern element */
   size?: number;
   /** Offset of the pattern */
-  offset?: number;
+  offset?: number | [number, number];
   /** Line width of the Line pattern */
   lineWidth?: number;
   /** Variant of the pattern


### PR DESCRIPTION
First of all, thank you so much to the xyflow team for maintaining this incredible library - it really is a joy to develop with!

I recently discovered a peculiarity with the `offset` prop on the `Background` component. I made a [discussion post](https://github.com/xyflow/xyflow/discussions/4472) about it, but no one has answered my question, which is about a pretty niche feature anyways, so I went ahead with proposing the code changes that make sense to me. 

The documentation regarding the `offset` prop doesn't say anything about the intended purpose/use of this prop. To me, offset makes sense as "translation" or "shift" or similar. And indeed the code has something to do with translation:


```
        patternTransform={`translate(-${patternOffset[0]},-${patternOffset[1]})`}
```

However, the offset seems to also have some effect on the pattern dimensions:
```
  {isDots ? (
          <DotPattern radius={scaledSize / offset} className={patternClassName} />
        ) : 
```

I don't really understand what this is doing. If you are using dots for the background, then changing the offset factor affects the size of the dots, which is strange. If you are using the lines variant, however, then the offset does in fact translate the pattern (as expected). What makes more sense to me, and what I'm proposing here, is to use the offset only for translation, and get rid of its effect on size. 

Please let me know if this doesn't make sense, or if there is some purpose behind the offset prop that I'm missing. My particular use case for this involves the snapGrid feature, and trying to get nodes to align in a specific way with the Background (hence the need to translate it).

*Note that a side effect of merging this change is that react flow projects using the dots background will have different sized dots than before (because the offset was 2 by default, and use to affect the dot size).