### PR TITLE
fix(svelte): rename `isConnectable` to `handleConnectable`

### DIFF
--- a/.changeset/curly-llamas-obey.md
+++ b/.changeset/curly-llamas-obey.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/svelte': patch
+---
+
+Rename `isConnectable` prop locally to `isConnectableProp` to avoid naming collision with derived value of `isConnectable` in `<Handle>` component.

--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -21,7 +21,6 @@
   export let type: $$Props['type'] = 'source';
   export let position: $$Props['position'] = Position.Top;
   export let style: $$Props['style'] = undefined;
-  export let isConnectable: $$Props['isConnectable'] = undefined;
   export let isValidConnection: $$Props['isValidConnection'] = undefined;
   export let onconnect: $$Props['onconnect'] = undefined;
   export let ondisconnect: $$Props['ondisconnect'] = undefined;
@@ -29,13 +28,16 @@
   // export let isConnectableStart: $$Props['isConnectableStart'] = undefined;
   // export let isConnectableEnd: $$Props['isConnectableEnd'] = undefined;
 
+  let isConnectableProp: $$Props['isConnectable'] = undefined;
+  export { isConnectableProp as isConnectable }
+
   let className: $$Props['class'] = undefined;
   export { className as class };
 
   $: isTarget = type === 'target';
   const nodeId = getContext<string>('svelteflow__node_id');
   const connectable = getContext<Writable<boolean>>('svelteflow__node_connectable');
-  $: isConnectable = isConnectable !== undefined ? isConnectable : $connectable;
+  $: isConnectable = isConnectableProp !== undefined ? isConnectableProp : $connectable;
 
   $: handleId = id || null;
 


### PR DESCRIPTION
# 🚀 What's changed?

<!--- Tell us what changes this pr contains -->

- Renamed `isConnectable` prop locally to `isConnectableProp` to avoid naming collision with derived var `isConnectable`
	- Apparently naming it the same thing as the prop just causes the cmp to prefer the prop instead of the local variable (Peter would know more about this though)

# 🐛 Fixes

<!--- Tell us what issues this pr fixes (bugfix) -->

- [x] [#4509](https://github.com/xyflow/xyflow/issues/4509)