### PR TITLE
fix(system,errors): use handle id of matching handle type for errors

### DIFF
--- a/.changeset/short-dingos-return.md
+++ b/.changeset/short-dingos-return.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Use the handle id of the matching handle type when warning about an edge that can't be created due to missing handle ids.

--- a/packages/system/src/constants.ts
+++ b/packages/system/src/constants.ts
@@ -16,7 +16,7 @@ export const errorMessages = {
     { id, sourceHandle, targetHandle }: { id: string; sourceHandle: string | null; targetHandle: string | null }
   ) =>
     `Couldn't create edge for ${handleType} handle id: "${
-      !sourceHandle ? sourceHandle : targetHandle
+      handleType === 'source' ? sourceHandle : targetHandle
     }", edge id: ${id}.`,
   error010: () => 'Handle: No node id found. Make sure to only use a Handle inside a custom Node.',
   error011: (edgeType: string) => `Edge type "${edgeType}" not found. Using fallback type "default".`,


### PR DESCRIPTION
# 🚀 What's changed?

- Use the handle id of the matching handle type when warning about edges that can't be created due to missing handle ids

# 🐛 Fixes

- [x] the warning `e008` always showing `null` as the handle id even if one was passed (although no matching handle was found)