### PR TITLE
Fix: Include `onViewportChange` in `useEffect` Dependency Array to Prevent Stale References

### DIFF
--- a/packages/react/src/container/ZoomPane/index.tsx
+++ b/packages/react/src/container/ZoomPane/index.tsx
@@ -103,7 +103,7 @@ export function ZoomPane({
         panZoom.current?.destroy();
       };
     }
-  }, []);
+  }, [onViewportChange]);
 
   useEffect(() => {
     panZoom.current?.update({


### PR DESCRIPTION
This merge request fixes the issue where the `onViewportChange` function was not included in the `useEffect` dependency array (inside `ZoomPane`), causing stale references to be used. This caused the viewport to break if a new `onViewportChange` function was passed.

Fixes #4579