### PR TITLE
fix(react,svelte): calculate viewport dimensions inside of fitView action

### DIFF
--- a/.changeset/smart-insects-tease.md
+++ b/.changeset/smart-insects-tease.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Calculate viewport dimensions in fitView instead of using stored dimensions. Fixes [#4652](https://github.com/xyflow/xyflow/issues/4652)

--- a/packages/react/src/hooks/useViewportHelper.ts
+++ b/packages/react/src/hooks/useViewportHelper.ts
@@ -6,6 +6,7 @@ import {
   fitView,
   type XYPosition,
   rendererPointToPoint,
+  getDimensions,
 } from '@xyflow/system';
 
 import { useStoreApi } from '../hooks/useStore';
@@ -64,8 +65,10 @@ const useViewportHelper = (): ViewportHelperFunctions => {
         return { x, y, zoom };
       },
       fitView: (options) => {
-        const { nodeLookup, width, height, minZoom, maxZoom, panZoom } = store.getState();
+        const { nodeLookup, minZoom, maxZoom, panZoom, domNode } = store.getState();
         const fitViewNodes = getFitViewNodes(nodeLookup, options);
+
+        const { width, height } = getDimensions(domNode!);
 
         return panZoom
           ? fitView(

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -19,7 +19,8 @@ import {
   type UpdateConnection,
   type ConnectionState,
   type NodeOrigin,
-  getFitViewNodes
+  getFitViewNodes,
+  getDimensions
 } from '@xyflow/system';
 
 import type { EdgeTypes, NodeTypes, Node, Edge, FitViewOptions } from '$lib/types';
@@ -152,18 +153,21 @@ export function createStore({
 
   function fitView(options?: FitViewOptions) {
     const panZoom = get(store.panZoom);
+    const domNode = get(store.domNode);
 
-    if (!panZoom) {
+    if (!panZoom || !domNode) {
       return Promise.resolve(false);
     }
+
+    const { width, height } = getDimensions(domNode);
 
     const fitViewNodes = getFitViewNodes(get(store.nodeLookup), options);
 
     return fitViewSystem(
       {
         nodes: fitViewNodes,
-        width: get(store.width),
-        height: get(store.height),
+        width,
+        height,
         minZoom: get(store.minZoom),
         maxZoom: get(store.maxZoom),
         panZoom


### PR DESCRIPTION
# 🚀 What's changed?

<!--- Tell us what changes this pr contains -->

- Calculate viewport dimensions for fitView in the action itself instead of using the stored viewport dimensions
	- When using stored dimensions, the dimensions update happens too late because it's based on an effect that has to run first; if we just grab the dimensions directly from the `domNode` element we don't run into the issue of using stale dimensions when the size of the viewport has changed

# 🐛 Fixes

<!--- Tell us what issues this pr fixes (bugfix) -->

- [x] [#4652](https://github.com/xyflow/xyflow/issues/4652)