### PR TITLE
Update nodes.ts to allow strong NodeType

### DIFF
--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -9,7 +9,7 @@ import { Optional } from '../utils/types';
  */
 export type NodeBase<
   NodeData extends Record<string, unknown> = Record<string, unknown>,
-  NodeType extends string = string
+  NodeType extends string | undefined = string | undefined
 > = {
   /** Unique id of a node */
   id: string;
@@ -20,7 +20,7 @@ export type NodeBase<
   /** Arbitrary data passed to a node */
   data: NodeData;
   /** Type of node defined in nodeTypes */
-  type?: NodeType;
+  type: NodeType;
   /** Only relevant for default, source, target nodeType. controls source position
    * @example 'right', 'left', 'top', 'bottom'
    */


### PR DESCRIPTION
## Changes

Issue: `NodeType` in `NodeBase` always resolves to be potentially undefined.

Solution: Update the `NodeBase` type to have a stronger `NodeType` field that can be undefined only if you don't specify it.

## Use case

Current behaviour
![image](https://github.com/user-attachments/assets/d5ce59eb-40dd-4238-8f94-d8be7073cc75)

Desired behaviour
![image](https://github.com/user-attachments/assets/1faa3ba4-80f9-4eec-93a4-16fb48005678)

This also now works for union types:
![image](https://github.com/user-attachments/assets/dea03f42-ec79-4ff8-ba42-0b82ffc5cd12)


### Version info

I consider this type issue a bug, but you probably want to link it to a minor version update to not shock people if the type suddenly change. Up to you though :) 