### PR TITLE
Update absolute positions before initial fitView

### DIFF
--- a/.changeset/curly-cows-repeat.md
+++ b/.changeset/curly-cows-repeat.md
@@ -4,4 +4,4 @@
 '@xyflow/react': patch
 ---
 
-Fix initial fitView not working correctly for nodeOrigin other than [0,0]
+Fix initial `fitView` not working correctly for `nodeOrigin` other than [0,0]

--- a/.changeset/curly-cows-repeat.md
+++ b/.changeset/curly-cows-repeat.md
@@ -4,4 +4,4 @@
 '@xyflow/react': patch
 ---
 
-Fix fitView not working correctly for nodeOrigin other than [0,0]
+Fix initial fitView not working correctly for nodeOrigin other than [0,0]

--- a/.changeset/curly-cows-repeat.md
+++ b/.changeset/curly-cows-repeat.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/svelte': patch
+'@xyflow/system': patch
+'@xyflow/react': patch
+---
+
+Fix fitView not working correctly for nodeOrigin other than [0,0]

--- a/.changeset/cyan-frogs-lick.md
+++ b/.changeset/cyan-frogs-lick.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/svelte': patch
+'@xyflow/react': patch
+---
+
+Improve fitView to resepct any clamped node positions based on nodeExtent

--- a/.changeset/cyan-frogs-lick.md
+++ b/.changeset/cyan-frogs-lick.md
@@ -3,4 +3,4 @@
 '@xyflow/react': patch
 ---
 
-Improve fitView to resepct any clamped node positions based on nodeExtent
+Improve `fitView` to respect clamped node positions based on `nodeExtent`

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -19,7 +19,8 @@ import {
   type UpdateConnection,
   type ConnectionState,
   type NodeOrigin,
-  getFitViewNodes
+  getFitViewNodes,
+  updateAbsolutePositions
 } from '@xyflow/system';
 
 import type { EdgeTypes, NodeTypes, Node, Edge, FitViewOptions } from '$lib/types';
@@ -96,6 +97,7 @@ export function createStore({
 
   function updateNodeInternals(updates: Map<string, InternalNodeUpdate>) {
     const nodeLookup = get(store.nodeLookup);
+    const parentLookup = get(store.parentLookup);
     const { changes, updatedInternals } = updateNodeInternalsSystem(
       updates,
       nodeLookup,
@@ -107,6 +109,8 @@ export function createStore({
     if (!updatedInternals) {
       return;
     }
+
+    updateAbsolutePositions(nodeLookup, parentLookup, { nodeOrigin, nodeExtent });
 
     if (!get(store.fitViewOnInitDone) && get(store.fitViewOnInit)) {
       const fitViewOptions = get(store.fitViewOptions);

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -61,11 +61,14 @@ export function updateAbsolutePositions<NodeType extends NodeBase>(
 ) {
   const _options = mergeObjects(defaultOptions, options);
   for (const node of nodeLookup.values()) {
-    if (!node.parentId) {
-      continue;
+    if (node.parentId) {
+      updateChildNode(node, nodeLookup, parentLookup, _options);
+    } else {
+      const positionWithOrigin = getNodePositionWithOrigin(node, _options.nodeOrigin);
+      const extent = isCoordinateExtent(node.extent) ? node.extent : _options.nodeExtent;
+      const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(node));
+      node.internals.positionAbsolute = clampedPosition;
     }
-
-    updateChildNode(node, nodeLookup, parentLookup, _options);
   }
 }
 


### PR DESCRIPTION
Currently initial fitView is broken for nodeOrigins other than [0,0] (!!!)

A nice side effect of this is that fitView now also respects any clamped positions based on extent.