### PR TITLE
chore(NA): adds explicit browser, node and default exports resolution

### DIFF
--- a/.changeset/famous-lobsters-ring.md
+++ b/.changeset/famous-lobsters-ring.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/system': patch
+'@xyflow/react': patch
+---
+
+Splits exports field in package.json to support an explicit resolution for browser, node and default to resolve issues with webpack esm module resolution.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,10 +29,17 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/umd/index.js",
-      "module": "./dist/esm/index.js"
+      "node": {
+        "types": "./dist/esm/index.d.ts",
+        "module": "./dist/esm/index.js",
+        "require": "./dist/umd/index.js",
+        "import": "./dist/esm/index.mjs"
+      },
+      "browser": {
+        "import": "./dist/esm/index.js",
+        "require": "./dist/umd/index.js"
+      },
+      "default": "./dist/esm/index.js"
     },
     "./dist/base.css": "./dist/base.css",
     "./dist/style.css": "./dist/style.css"

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -20,10 +20,17 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/umd/index.js",
-      "module": "./dist/esm/index.js"
+      "node": {
+        "types": "./dist/esm/index.d.ts",
+        "module": "./dist/esm/index.js",
+        "require": "./dist/umd/index.js",
+        "import": "./dist/esm/index.mjs"
+      },
+      "browser": {
+        "import": "./dist/esm/index.js",
+        "require": "./dist/umd/index.js"
+      },
+      "default": "./dist/esm/index.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
This PR follows up on what was done at https://github.com/xyflow/xyflow/pull/4755.

Even having into account the changes in the previous PR, webpack v5 still resolves `@xyflow/react/dist/esm/index.mjs` which then tries to resolve `react/jsx-runtime` within (and in that case it loaded from a .mjs which needs to be `react/jsx-runtime.js`).

The changes I'm proposing introduces a more explicit split in the resolution without room for wrong resolves going further.

\cc @peterkogo @moklick 