### PR TITLE
fix getNodeRect loses node origin

### DIFF
--- a/packages/react/src/hooks/useReactFlow.ts
+++ b/packages/react/src/hooks/useReactFlow.ts
@@ -60,6 +60,7 @@ export function useReactFlow<NodeType extends Node = Node, EdgeType extends Edge
         width: nodeToUse.measured?.width ?? nodeToUse.width,
         height: nodeToUse.measured?.height ?? nodeToUse.height,
         data: nodeToUse.data,
+        origin: nodeToUse.origin,
       };
 
       return nodeToRect(nodeWithPosition);

--- a/packages/svelte/src/lib/hooks/useSvelteFlow.ts
+++ b/packages/svelte/src/lib/hooks/useSvelteFlow.ts
@@ -297,7 +297,8 @@ export function useSvelteFlow(): {
       position,
       width: nodeToUse.measured?.width ?? nodeToUse.width,
       height: nodeToUse.measured?.height ?? nodeToUse.height,
-      data: nodeToUse.data
+      data: nodeToUse.data,
+      origin: nodeToUse.origin
     };
 
     return nodeToRect(nodeWithPosition);


### PR DESCRIPTION
Good afternoon, I really like your library and its approach to openness and monetization. I'm using `react-flow` to demo my open source library and came across a bug, which can be demonstrated with an example from the documentation (Intersection example)

To get this bug I changed the description of the second node by adding `origin: [0.5, 0]` and got the wrong `rect` for the changed node:
![issue](https://github.com/user-attachments/assets/a43c1121-d8cc-40f5-9074-5f6b4f79b993)

Digging into the code I found the following bug in the use of `nodeToRect` in the `getNodeRect` function:
`nodeToRect` expects the actual `origin` value when retrieving a node, but `getNodeRect` forgets about this field when creating `nodeWithPosition`.

I fixed this call in what I think is the most non-invasive and correct way and now everything works as expected
`origin: [0.5, 0]`
![fixed](https://github.com/user-attachments/assets/4ea58394-5921-4d6b-be51-d1e43918fbdc)

I have also investigated all other places where `nodeToRect` is used (thx to `grep`) and all of them use correct nodes (actual origin, since they are obtained from the store) so this is the only problem of this kind.
