### PR TITLE
Add 'group' to `BuiltInNode` type definition

### DIFF
--- a/examples/svelte/src/routes/examples/overview/CustomNode.svelte
+++ b/examples/svelte/src/routes/examples/overview/CustomNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Handle, Position, type BuiltInNode, type NodeProps } from '@xyflow/svelte';
+	import { Handle, Position, type LabeledBuiltInNode, type NodeProps } from '@xyflow/svelte';
 
-	type $$Props = NodeProps<BuiltInNode>;
+	type $$Props = NodeProps<LabeledBuiltInNode>;
 	$$restProps;
 
 	export let data: { label: string } = { label: 'Node' };

--- a/examples/svelte/src/routes/examples/overview/CustomNodeDragHandle.svelte
+++ b/examples/svelte/src/routes/examples/overview/CustomNodeDragHandle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { BuiltInNode, NodeProps } from '@xyflow/svelte';
+	import type { LabeledBuiltInNode, NodeProps } from '@xyflow/svelte';
 
-	type $$Props = NodeProps<BuiltInNode>;
+	type $$Props = NodeProps<LabeledBuiltInNode>;
 	$$restProps;
 
 	export let data: { label: string } = { label: 'Node' };

--- a/packages/react/src/components/Nodes/DefaultNode.tsx
+++ b/packages/react/src/components/Nodes/DefaultNode.tsx
@@ -1,14 +1,14 @@
 import { Position } from '@xyflow/system';
 
 import { Handle } from '../../components/Handle';
-import type { BuiltInNode, NodeProps } from '../../types/nodes';
+import type { LabeledBuiltInNode, NodeProps } from '../../types/nodes';
 
 export function DefaultNode({
   data,
   isConnectable,
   targetPosition = Position.Top,
   sourcePosition = Position.Bottom,
-}: NodeProps<BuiltInNode>) {
+}: NodeProps<LabeledBuiltInNode>) {
   return (
     <>
       <Handle type="target" position={targetPosition} isConnectable={isConnectable} />

--- a/packages/react/src/components/Nodes/InputNode.tsx
+++ b/packages/react/src/components/Nodes/InputNode.tsx
@@ -1,9 +1,9 @@
 import { Position } from '@xyflow/system';
 
 import { Handle } from '../../components/Handle';
-import type { BuiltInNode, NodeProps } from '../../types/nodes';
+import type { LabeledBuiltInNode, NodeProps } from '../../types/nodes';
 
-export function InputNode({ data, isConnectable, sourcePosition = Position.Bottom }: NodeProps<BuiltInNode>) {
+export function InputNode({ data, isConnectable, sourcePosition = Position.Bottom }: NodeProps<LabeledBuiltInNode>) {
   return (
     <>
       {data?.label}

--- a/packages/react/src/components/Nodes/OutputNode.tsx
+++ b/packages/react/src/components/Nodes/OutputNode.tsx
@@ -1,9 +1,9 @@
 import { Position } from '@xyflow/system';
 
 import { Handle } from '../../components/Handle';
-import type { BuiltInNode, NodeProps } from '../../types/nodes';
+import type { LabeledBuiltInNode, NodeProps } from '../../types/nodes';
 
-export function OutputNode({ data, isConnectable, targetPosition = Position.Top }: NodeProps<BuiltInNode>) {
+export function OutputNode({ data, isConnectable, targetPosition = Position.Top }: NodeProps<LabeledBuiltInNode>) {
   return (
     <>
       <Handle type="target" position={targetPosition} isConnectable={isConnectable} />

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -56,6 +56,8 @@ export type NodeWrapperProps<NodeType extends Node> = {
   nodeClickDistance?: number;
 };
 
-export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default' | 'group'>;
+export type LabeledBuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default'>;
+export type GroupNode = Node<Record<string, never>, 'group'>;
+export type BuiltInNode = LabeledBuiltInNode | GroupNode;
 
 export type NodeProps<NodeType extends Node = Node> = NodePropsBase<NodeType>;

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -56,6 +56,6 @@ export type NodeWrapperProps<NodeType extends Node> = {
   nodeClickDistance?: number;
 };
 
-export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default'>;
+export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default' | 'group'>;
 
 export type NodeProps<NodeType extends Node = Node> = NodePropsBase<NodeType>;

--- a/packages/svelte/src/lib/components/nodes/DefaultNode.svelte
+++ b/packages/svelte/src/lib/components/nodes/DefaultNode.svelte
@@ -2,9 +2,9 @@
   import { Position } from '@xyflow/system';
 
   import { Handle } from '$lib/components/Handle';
-  import type { NodeProps } from '$lib/types';
+  import type { LabeledBuiltInNode, NodeProps } from '$lib/types';
 
-  interface $$Props extends NodeProps {}
+  type $$Props = NodeProps<LabeledBuiltInNode>;
 
   export let data: $$Props['data'] = { label: 'Node' };
   export let targetPosition: $$Props['targetPosition'] = undefined;

--- a/packages/svelte/src/lib/components/nodes/InputNode.svelte
+++ b/packages/svelte/src/lib/components/nodes/InputNode.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Position } from '@xyflow/system';
-  import type { NodeProps } from '$lib/types';
+  import type { LabeledBuiltInNode, NodeProps } from '$lib/types';
 
   import { Handle } from '$lib/components/Handle';
 
-  interface $$Props extends NodeProps {}
+  type $$Props = NodeProps<LabeledBuiltInNode>;
 
   export let data: $$Props['data'] = { label: 'Node' };
   export let sourcePosition: $$Props['sourcePosition'] = undefined;

--- a/packages/svelte/src/lib/components/nodes/OutputNode.svelte
+++ b/packages/svelte/src/lib/components/nodes/OutputNode.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Position } from '@xyflow/system';
-  import type { NodeProps } from '$lib/types';
+  import type { LabeledBuiltInNode, NodeProps } from '$lib/types';
 
   import { Handle } from '$lib/components/Handle';
 
-  interface $$Props extends NodeProps {}
+  type $$Props = NodeProps<LabeledBuiltInNode>;
 
   export let data: $$Props['data'] = { label: 'Node' };
   export let targetPosition: $$Props['targetPosition'] = undefined;

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -51,6 +51,8 @@ export type {
   Node,
   NodeTypes,
   DefaultNodeOptions,
+  LabeledBuiltInNode,
+  GroupNode,
   BuiltInNode,
   NodeProps,
   InternalNode

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -44,7 +44,7 @@ export type NodeTypes = Record<
 
 export type DefaultNodeOptions = Partial<Omit<Node, 'id'>>;
 
-export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default'>;
+export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default' | 'group'>;
 
 export type NodeEventMap = {
   nodeclick: { node: Node; event: MouseEvent | TouchEvent };

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -44,7 +44,9 @@ export type NodeTypes = Record<
 
 export type DefaultNodeOptions = Partial<Omit<Node, 'id'>>;
 
-export type BuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default' | 'group'>;
+export type LabeledBuiltInNode = Node<{ label: string }, 'input' | 'output' | 'default'>;
+export type GroupNode = Node<Record<string, never>, 'group'>;
+export type BuiltInNode = LabeledBuiltInNode | GroupNode;
 
 export type NodeEventMap = {
   nodeclick: { node: Node; event: MouseEvent | TouchEvent };


### PR DESCRIPTION
As is, the 'group' node type is used in internal utilities for the built-in node types
https://github.com/xyflow/xyflow/blob/616d2665235447e0280368228ac64b987afecba0/packages/react/src/components/NodeWrapper/utils.tsx#L16-L21 

and is indeed a supported built-in node per https://reactflow.dev/learn/layouting/sub-flows and https://reactflow.dev/examples/layout/sub-flows, and simply renders the node without any handles. As such, it should seemingly be part  of the type definition for `BuiltInNode`.