### PR TITLE
Fix unnecessary rerenders of edges in viewport

### DIFF
--- a/.changeset/young-insects-cry.md
+++ b/.changeset/young-insects-cry.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Prevent unnecessary rerenders of edges.

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -17,6 +17,7 @@ import type { Edge, EdgeWrapperProps } from '../../types';
 
 export function EdgeWrapper<EdgeType extends Edge = Edge>({
   id,
+  edge,
   edgesFocusable,
   edgesReconnectable,
   elementsSelectable,
@@ -36,7 +37,6 @@ export function EdgeWrapper<EdgeType extends Edge = Edge>({
   onError,
   disableKeyboardA11y,
 }: EdgeWrapperProps<EdgeType>): JSX.Element | null {
-  let edge = useStore((s) => s.edgeLookup.get(id)!) as EdgeType;
   const defaultEdgeOptions = useStore((s) => s.defaultEdgeOptions);
   edge = defaultEdgeOptions ? { ...defaultEdgeOptions, ...edge } : edge;
 

--- a/packages/react/src/container/EdgeRenderer/index.tsx
+++ b/packages/react/src/container/EdgeRenderer/index.tsx
@@ -2,7 +2,7 @@ import { memo, ReactNode } from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { useStore } from '../../hooks/useStore';
-import { useVisibleEdgeIds } from '../../hooks/useVisibleEdgeIds';
+import { useVisibleEdges } from '../../hooks/useVisibleEdges';
 import MarkerDefinitions from './MarkerDefinitions';
 import { GraphViewProps } from '../GraphView';
 import { EdgeWrapper } from '../../components/EdgeWrapper';
@@ -31,8 +31,6 @@ type EdgeRendererProps<EdgeType extends Edge = Edge> = Pick<
 };
 
 const selector = (s: ReactFlowState) => ({
-  width: s.width,
-  height: s.height,
   edgesFocusable: s.edgesFocusable,
   edgesReconnectable: s.edgesReconnectable,
   elementsSelectable: s.elementsSelectable,
@@ -59,17 +57,18 @@ function EdgeRendererComponent<EdgeType extends Edge = Edge>({
   disableKeyboardA11y,
 }: EdgeRendererProps<EdgeType>) {
   const { edgesFocusable, edgesReconnectable, elementsSelectable, onError } = useStore(selector, shallow);
-  const edgeIds = useVisibleEdgeIds(onlyRenderVisibleElements);
+  const edges = useVisibleEdges<EdgeType>(onlyRenderVisibleElements);
 
   return (
     <div className="react-flow__edges">
       <MarkerDefinitions defaultColor={defaultMarkerColor} rfId={rfId} />
 
-      {edgeIds.map((id) => {
+      {edges.map((edge) => {
         return (
           <EdgeWrapper<EdgeType>
-            key={id}
-            id={id}
+            key={edge.id}
+            id={edge.id}
+            edge={edge}
             edgesFocusable={edgesFocusable}
             edgesReconnectable={edgesReconnectable}
             elementsSelectable={elementsSelectable}

--- a/packages/react/src/hooks/useVisibleEdges.ts
+++ b/packages/react/src/hooks/useVisibleEdges.ts
@@ -3,7 +3,7 @@ import { shallow } from 'zustand/shallow';
 import { isEdgeVisible } from '@xyflow/system';
 
 import { useStore } from './useStore';
-import { type ReactFlowState } from '../types';
+import { Edge, type ReactFlowState } from '../types';
 
 /**
  * Hook for getting the visible edge ids from the store.
@@ -12,15 +12,15 @@ import { type ReactFlowState } from '../types';
  * @param onlyRenderVisible
  * @returns array with visible edge ids
  */
-export function useVisibleEdgeIds(onlyRenderVisible: boolean): string[] {
-  const edgeIds = useStore(
+export function useVisibleEdges<T extends Edge>(onlyRenderVisible: boolean): T[] {
+  return useStore(
     useCallback(
       (s: ReactFlowState) => {
         if (!onlyRenderVisible) {
-          return s.edges.map((edge) => edge.id);
+          return s.edges as T[];
         }
 
-        const visibleEdgeIds = [];
+        const visibleEdges = [];
 
         if (s.width && s.height) {
           for (const edge of s.edges) {
@@ -38,17 +38,15 @@ export function useVisibleEdgeIds(onlyRenderVisible: boolean): string[] {
                 transform: s.transform,
               })
             ) {
-              visibleEdgeIds.push(edge.id);
+              visibleEdges.push(edge as T);
             }
           }
         }
 
-        return visibleEdgeIds;
+        return visibleEdges;
       },
       [onlyRenderVisible]
     ),
     shallow
   );
-
-  return edgeIds;
 }

--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -67,6 +67,7 @@ export type EdgeMouseHandler<EdgeType extends Edge = Edge> = (event: ReactMouseE
 
 export type EdgeWrapperProps<EdgeType extends Edge = Edge> = {
   id: string;
+  edge: EdgeType;
   edgesFocusable: boolean;
   edgesReconnectable: boolean;
   elementsSelectable: boolean;


### PR DESCRIPTION
closes #4867.

Remove unused references to viewport dimensions in state selector for EdgeRenderer.

Instead of determining visibleEdgeIds first and then looking up the edge in the edgeWrapper, we just return the visibleEdges right away. Why were we even doing this? 