### PR TITLE
fix(system): safely handles non-html-element object

### DIFF
--- a/.changeset/brown-pugs-pump.md
+++ b/.changeset/brown-pugs-pump.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Refactor isInputDOMNode so that it handles non-html objects

--- a/packages/system/src/utils/dom.ts
+++ b/packages/system/src/utils/dom.ts
@@ -40,7 +40,7 @@ const inputTags = ['INPUT', 'SELECT', 'TEXTAREA'];
 export function isInputDOMNode(event: KeyboardEvent): boolean {
   // using composed path for handling shadow dom
   const target = (event.composedPath?.()?.[0] || event.target) as HTMLElement;
-  const isInput = inputTags.includes(target?.nodeName) || target?.hasAttribute('contenteditable');
+  const isInput = inputTags.includes(target?.nodeName) || target?.hasAttribute?.('contenteditable');
 
   // when an input field is focused we don't want to trigger deletion or movement of nodes
   return isInput || !!target?.closest('.nokey');


### PR DESCRIPTION
`event.composedPath` and `event.target` do not always return `HTMLElement` object(as their types suggested).

> [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element), and its children, as well as [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document) and [Window](https://developer.mozilla.org/en-US/docs/Web/API/Window), are the most common event targets

This PR prevents exception from being thrown when the object is not an `HTMLElement` (e.g., a `window`).