### PR TITLE
Fix unneccessary rerenders of edges on viewport resize

### DIFF
--- a/.changeset/tall-kids-lick.md
+++ b/.changeset/tall-kids-lick.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Prevent unnecessary rerenders of edges when resizing the flow.

--- a/packages/react/src/container/EdgeRenderer/index.tsx
+++ b/packages/react/src/container/EdgeRenderer/index.tsx
@@ -31,8 +31,6 @@ type EdgeRendererProps<EdgeType extends Edge = Edge> = Pick<
 };
 
 const selector = (s: ReactFlowState) => ({
-  width: s.width,
-  height: s.height,
   edgesFocusable: s.edgesFocusable,
   edgesReconnectable: s.edgesReconnectable,
   elementsSelectable: s.elementsSelectable,


### PR DESCRIPTION
closes #4867

Second try.

Checked and it works flawlessly with `onlyRenderVisible`. The selector inside `getVisibleEdgeIds` already does everything right.