### PR TITLE
Pass through NodeType to connectionLineComponent ReactFlow prop

### DIFF
--- a/.changeset/happy-hats-lay.md
+++ b/.changeset/happy-hats-lay.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': minor
+---
+
+Pass `NodeType` type argument from `ReactFlowProps` to `connectionLineComponent` property.

--- a/packages/react/src/components/ConnectionLine/index.tsx
+++ b/packages/react/src/components/ConnectionLine/index.tsx
@@ -11,12 +11,12 @@ import {
 
 import { useStore } from '../../hooks/useStore';
 import { getSimpleBezierPath } from '../Edges/SimpleBezierEdge';
-import type { ConnectionLineComponent, ReactFlowState } from '../../types';
+import type { ConnectionLineComponent, Node, ReactFlowState } from '../../types';
 import { useConnection } from '../../hooks/useConnection';
 
-type ConnectionLineWrapperProps = {
+type ConnectionLineWrapperProps<NodeType extends Node = Node> = {
   type: ConnectionLineType;
-  component?: ConnectionLineComponent;
+  component?: ConnectionLineComponent<NodeType>;
   containerStyle?: CSSProperties;
   style?: CSSProperties;
 };
@@ -29,7 +29,7 @@ const selector = (s: ReactFlowState) => ({
   height: s.height,
 });
 
-export function ConnectionLineWrapper({ containerStyle, style, type, component }: ConnectionLineWrapperProps) {
+export function ConnectionLineWrapper<NodeType extends Node = Node>({ containerStyle, style, type, component }: ConnectionLineWrapperProps<NodeType>) {
   const { nodesConnectable, width, height, isValid, inProgress } = useStore(selector, shallow);
   const renderConnection = !!(width && nodesConnectable && inProgress);
 
@@ -51,15 +51,15 @@ export function ConnectionLineWrapper({ containerStyle, style, type, component }
   );
 }
 
-type ConnectionLineProps = {
+type ConnectionLineProps<NodeType extends Node = Node> = {
   type: ConnectionLineType;
   style?: CSSProperties;
-  CustomComponent?: ConnectionLineComponent;
+  CustomComponent?: ConnectionLineComponent<NodeType>;
   isValid: boolean | null;
 };
 
-const ConnectionLine = ({ style, type = ConnectionLineType.Bezier, CustomComponent, isValid }: ConnectionLineProps) => {
-  const { inProgress, from, fromNode, fromHandle, fromPosition, to, toNode, toHandle, toPosition } = useConnection();
+const ConnectionLine = <NodeType extends Node = Node> ({ style, type = ConnectionLineType.Bezier, CustomComponent, isValid }: ConnectionLineProps<NodeType>) => {
+  const { inProgress, from, fromNode, fromHandle, fromPosition, to, toNode, toHandle, toPosition } = useConnection<NodeType>();
 
   if (!inProgress) {
     return;

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -259,7 +259,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   /** Styles to be applied to the connection line */
   connectionLineStyle?: CSSProperties;
   /** React Component to be used as a connection line */
-  connectionLineComponent?: ConnectionLineComponent;
+  connectionLineComponent?: ConnectionLineComponent<NodeType>;
   /** Styles to be applied to the container of the connection line */
   connectionLineContainerStyle?: CSSProperties;
   /** 'strict' connection mode will only allow you to connect source handles to target handles.


### PR DESCRIPTION
## Summary
The `connectionLineComponent` attribute in `ReactFlowProps` is of type `ConnectionLineComponent` which is a generic type that takes a `NodeType` as a type argument.

The `NodeType` of the `ReactFlowProps` is not getting passed through to the `ConnectionLineComponent`, though. This PR fixes that.

## Testing
Successfully ran `pnpm build` and `pnpm dev` locally without errors. Also ran `pnpm test:react` and all tests pass except one (but I think it may be flakey - see below).

Small note for the xyflow team: I ran into a few issues running `pnpm test:react`. First, I had trouble running the tests at all because the correct playwright binaries were not installed by default. To install the correct binaries I had to do:

```
cd tests/playwright
pnpm exec playwright install --with-deps
```

I think this is possibly because the version of playwright is different in the root `package.json` than it is in the `package.json` within `tests/playwright`.

The other issue was that it seems like there is a flakey or bad unit test:

```
  ✘  75 [firefox] › pane.spec.ts:87:9 › Pane default › autoPan › autoPanOnNodeDrag (1.9s)
```

I can't seem to get this test to pass locally, but it seems definitely unrelated to my changes.