### PR TITLE
fix(svelte): temporary fix for keyboard shortcuts

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@svelte-put/shortcut": "^3.1.0",
+    "@svelte-put/shortcut": "^3.1.0 <3.1.2",
     "@xyflow/system": "workspace:*",
     "classcat": "^5.0.4"
   },


### PR DESCRIPTION
Exclude problematic version `3.1.2` of `@svelte-put/shortcut` which causes `Shift` and `Backspace` keys to stop working in svelteflow.

fixes: #4891