### PR TITLE
chore(deps): lower React peer dependency requirements to >=16.12.0

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -58,8 +58,8 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "rollup": {
     "globals": {

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -51,8 +51,8 @@
     "zustand": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,8 +58,8 @@
     "zustand": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",

--- a/packages/minimap/package.json
+++ b/packages/minimap/package.json
@@ -55,8 +55,8 @@
     "zustand": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",

--- a/packages/node-resizer/package.json
+++ b/packages/node-resizer/package.json
@@ -53,8 +53,8 @@
     "zustand": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",

--- a/packages/node-toolbar/package.json
+++ b/packages/node-toolbar/package.json
@@ -45,8 +45,8 @@
     "zustand": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",

--- a/packages/reactflow/package.json
+++ b/packages/reactflow/package.json
@@ -52,8 +52,8 @@
     "@reactflow/node-toolbar": "workspace:*"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   },
   "devDependencies": {
     "@reactflow/eslint-config": "workspace:*",


### PR DESCRIPTION
Practical testing shows that React version 16.12.0 is fully compatible as well. As an open-source project, we should be more lenient with peerDependencies, considering many legacy projects face difficulties with upgrading.