### PR TITLE
expose ControlButton props to consumers

### DIFF
--- a/.changeset/afraid-trains-hunt.md
+++ b/.changeset/afraid-trains-hunt.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/svelte': patch
+---
+
+Expose props of Controls

--- a/packages/svelte/src/lib/plugins/Controls/ControlButton.svelte
+++ b/packages/svelte/src/lib/plugins/Controls/ControlButton.svelte
@@ -5,12 +5,12 @@
 
   type $$Props = ControlButtonProps;
 
-  let className: $$Props['class'] = undefined;
-  let bgColor: $$Props['bgColor'] = undefined;
-  let bgColorHover: $$Props['bgColorHover'] = undefined;
-  let color: $$Props['color'] = undefined;
-  let colorHover: $$Props['colorHover'] = undefined;
-  let borderColor: $$Props['borderColor'] = undefined;
+  export let className: $$Props['class'] = undefined;
+  export let bgColor: $$Props['bgColor'] = undefined;
+  export let bgColorHover: $$Props['bgColorHover'] = undefined;
+  export let color: $$Props['color'] = undefined;
+  export let colorHover: $$Props['colorHover'] = undefined;
+  export let borderColor: $$Props['borderColor'] = undefined;
 
   export { className as class };
 </script>


### PR DESCRIPTION
I'm guessing the props accidentally had the export keywords removed.  This probably isn't caught by Typescript or CI because the props are passed in by a spread prop from the parent `Controls.svelte`.

Should just be a band-aid fix until the Svelte 5 release is ready to use the `$props` rune.