### PR TITLE
Enhance/node props

### DIFF
--- a/.changeset/rotten-moons-roll.md
+++ b/.changeset/rotten-moons-roll.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/react': minor
+'@xyflow/svelte': minor
+'@xyflow/system': patch
+---
+
+Narrow properties selected, selectable, deletable, draggable of NodeProps type to be required.

--- a/.changeset/rotten-moons-roll.md
+++ b/.changeset/rotten-moons-roll.md
@@ -1,6 +1,6 @@
 ---
-'@xyflow/react': minor
-'@xyflow/svelte': minor
+'@xyflow/react': patch
+'@xyflow/svelte': patch
 '@xyflow/system': patch
 ---
 

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -202,7 +202,7 @@ export function NodeWrapper<NodeType extends Node>({
           type={nodeType}
           positionAbsoluteX={internals.positionAbsolute.x}
           positionAbsoluteY={internals.positionAbsolute.y}
-          selected={node.selected}
+          selected={node.selected ?? false}
           selectable={isSelectable}
           draggable={isDraggable}
           deletable={node.deletable ?? true}

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -54,7 +54,9 @@
     nodeDragThreshold,
     selectNodesOnDrag,
     handleNodeSelection,
-    updateNodeInternals
+    updateNodeInternals,
+    elementsSelectable,
+    nodesDraggable
   } = store;
 
   let nodeRef: HTMLDivElement;
@@ -194,14 +196,14 @@
       this={nodeComponent}
       {data}
       {id}
-      {selected}
-      {selectable}
-      {deletable}
+      selected={selected ?? false}
+      selectable={selectable ?? $elementsSelectable ?? true}
+      deletable={deletable ?? true}
       {sourcePosition}
       {targetPosition}
       {zIndex}
       {dragging}
-      {draggable}
+      draggable={draggable ?? $nodesDraggable ?? true}
       {dragHandle}
       {parentId}
       type={nodeType}

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -88,20 +88,9 @@ export type InternalNodeBase<NodeType extends NodeBase = NodeBase> = NodeType & 
  */
 export type NodeProps<NodeType extends NodeBase> = Pick<
   NodeType,
-  | 'id'
-  | 'data'
-  | 'width'
-  | 'height'
-  | 'sourcePosition'
-  | 'targetPosition'
-  | 'selected'
-  | 'dragHandle'
-  | 'selectable'
-  | 'deletable'
-  | 'draggable'
-  | 'parentId'
+  'id' | 'data' | 'width' | 'height' | 'sourcePosition' | 'targetPosition' | 'dragHandle' | 'parentId'
 > &
-  Required<Pick<NodeType, 'type' | 'dragging' | 'zIndex'>> & {
+  Required<Pick<NodeType, 'type' | 'dragging' | 'zIndex' | 'selectable' | 'deletable' | 'selected' | 'draggable'>> & {
     /** whether a node is connectable or not */
     isConnectable: boolean;
     /** position absolute x value */


### PR DESCRIPTION
We currently pass undefined to the node for selected, selectable, draggable, deletable. This causes some weird issues down the line like in the [NodeResizer](https://reactflow.dev/examples/nodes/node-resizer) (See "NodeResizer when selected" node shows resizer when selected is undefined because the `NodeResizer` has default value for `isVisible = true`.
Additionally this also complicates things for the user, even though we do know precisely if a node is selected, selectable, draggable or deletable.

I also noticed the current Svelte Flow version is super messy in this regard - I fixed what I could but in the new version everything is so much better!