### PR TITLE
Change hook used by updateNodeInternals to guarantee ordering vs batched store updates

### DIFF
--- a/packages/react/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/react/src/hooks/useUpdateNodeInternals.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import type { UpdateNodeInternals, InternalNodeUpdate } from '@xyflow/system';
 
 import { useStoreApi } from '../hooks/useStore';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
  * Hook for updating node internals.
@@ -25,6 +26,6 @@ export function useUpdateNodeInternals(): UpdateNodeInternals {
       }
     });
 
-    requestAnimationFrame(() => updateNodeInternals(updates, { triggerFitView: false }));
+  useIsomorphicLayoutEffect(() => updateNodeInternals(updates, { triggerFitView: false }));
   }, []);
 }


### PR DESCRIPTION
Fixes Issue #4976
Under the covers, useReactFlow does batched store updates using batch contexts.
These are applied through a useIsomorphmicLayoutEffect callback.

updateNodeInternals also uses a callback to apply updates.  However, it uses
requestAnimationFrame to trigger the callback, which is a browser callback
unrelated to React, and has no ordering guarantees vs the batched store
updates.

The result is that whether the callback created by updateNodeInternals sees the
latest state or not currently depends on your current monitor refresh rate and
graphics card rendering speed, and other amusing things like whether the window
is covered or not.

This commit changes the hook used for callbacks by updateNodeInternals to be
the same as the hook used to apply batched store updates.  React guarantees
these will happen in the order you set them up, which in turn guarantees the
callback will happen after the batch update completes.
