### PR TITLE
fix(system): ensure auto-pan stops when state changes during drag

### DIFF
--- a/.changeset/serious-ducks-care.md
+++ b/.changeset/serious-ducks-care.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Make it possible to stop autoPanOnDrag by setting it to false

--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -214,7 +214,13 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         return;
       }
 
-      const { transform, panBy, autoPanSpeed } = getStoreItems();
+      const { transform, panBy, autoPanSpeed, autoPanOnNodeDrag } = getStoreItems();
+
+      if (!autoPanOnNodeDrag) {
+        autoPanStarted = false;
+        cancelAnimationFrame(autoPanId);
+        return;
+      }
 
       const [xMovement, yMovement] = calcAutoPan(mousePosition, containerBounds, autoPanSpeed);
 


### PR DESCRIPTION
This PR ensures that auto-panning is disabled if the `autoPanOnNodeDrag` state changes while dragging on the canvas. Currently, if this property is set to `true` before the drag event starts, the auto-panning logic will begin but won't stop until dragging ends.

In my use case, I'd like to stop auto-panning if I detect that a user has dragged a node over a specific area near the canvas edge.

Feel free to close this PR if this behavior is expected.
