### PR TITLE
types/nodes: Use NodeTypeString for string-extending generics

### DIFF
--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { CSSProperties, SVGAttributes, ReactNode, MouseEvent as ReactMouseEvent, ComponentType } from 'react';
 import type {
   EdgeBase,
@@ -34,8 +33,8 @@ export type EdgeLabelOptions = {
  */
 export type Edge<
   EdgeData extends Record<string, unknown> = Record<string, unknown>,
-  EdgeType extends string | undefined = string | undefined
-> = EdgeBase<EdgeData, EdgeType> &
+  EdgeTypeString extends string | undefined = string | undefined
+> = EdgeBase<EdgeData, EdgeTypeString> &
   EdgeLabelOptions & {
     style?: CSSProperties;
     className?: string;

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -9,8 +9,8 @@ import { NodeTypes } from './general';
  */
 export type Node<
   NodeData extends Record<string, unknown> = Record<string, unknown>,
-  NodeType extends string = string
-> = NodeBase<NodeData, NodeType> & {
+  NodeTypeString extends string = string
+> = NodeBase<NodeData, NodeTypeString> & {
   style?: CSSProperties;
   className?: string;
   resizing?: boolean;

--- a/packages/svelte/src/lib/types/edges.ts
+++ b/packages/svelte/src/lib/types/edges.ts
@@ -15,8 +15,8 @@ import type { Node } from '$lib/types';
  */
 export type Edge<
   EdgeData extends Record<string, unknown> = Record<string, unknown>,
-  EdgeType extends string | undefined = string | undefined
-> = EdgeBase<EdgeData, EdgeType> & {
+  EdgeTypeString extends string | undefined = string | undefined
+> = EdgeBase<EdgeData, EdgeTypeString> & {
   label?: string;
   labelStyle?: string;
   style?: string;

--- a/packages/svelte/src/lib/types/nodes.ts
+++ b/packages/svelte/src/lib/types/nodes.ts
@@ -15,8 +15,8 @@ export type InternalNode<NodeType extends Node = Node> = InternalNodeBase<NodeTy
  */
 export type Node<
   NodeData extends Record<string, unknown> = Record<string, unknown>,
-  NodeType extends string = string
-> = NodeBase<NodeData, NodeType> & {
+  NodeTypeString extends string = string
+> = NodeBase<NodeData, NodeTypeString> & {
   class?: string;
   style?: string;
 };

--- a/packages/system/src/types/edges.ts
+++ b/packages/system/src/types/edges.ts
@@ -2,12 +2,12 @@ import { Position } from './utils';
 
 export type EdgeBase<
   EdgeData extends Record<string, unknown> = Record<string, unknown>,
-  EdgeType extends string | undefined = string | undefined
+  EdgeTypeString extends string | undefined = string | undefined
 > = {
   /** Unique id of an edge */
   id: string;
   /** Type of an edge defined in edgeTypes */
-  type?: EdgeType;
+  type?: EdgeTypeString;
   /** Id of source node */
   source: string;
   /** Id of target node */

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -9,7 +9,7 @@ import { Optional } from '../utils/types';
  */
 export type NodeBase<
   NodeData extends Record<string, unknown> = Record<string, unknown>,
-  NodeType extends string = string
+  NodeTypeString extends string = string
 > = {
   /** Unique id of a node */
   id: string;
@@ -20,7 +20,7 @@ export type NodeBase<
   /** Arbitrary data passed to a node */
   data: NodeData;
   /** Type of node defined in nodeTypes */
-  type?: NodeType;
+  type?: NodeTypeString;
   /** Only relevant for default, source, target nodeType. controls source position
    * @example 'right', 'left', 'top', 'bottom'
    */


### PR DESCRIPTION
This should make it easier to differentiate generic parameters which take a `NodeBase`-/`Node`-based type vs those that take a `string`-based one.