### PR TITLE
docs(useNodeConnections): fix docs typo

### DIFF
--- a/packages/react/src/hooks/useNodeConnections.ts
+++ b/packages/react/src/hooks/useNodeConnections.ts
@@ -38,7 +38,7 @@ type UseNodeConnectionsParams = {
  *
  *export default function () {
  *  const connections = useNodeConnections({
- *    type: 'target',
+ *    handleType: 'target',
  *    handleId: 'my-handle',
  *  });
  *


### PR DESCRIPTION
Fixed a docs typo on https://github.com/xyflow/web/commit/fd6c1a86803003eeec140c772f29a40496fd2991 and noticed we had the same issue in here. 