### PR TITLE
Always allow releasing keys

### DIFF
--- a/packages/react/src/hooks/useKeyPress.ts
+++ b/packages/react/src/hooks/useKeyPress.ts
@@ -106,13 +106,6 @@ export function useKeyPress(
       };
 
       const upHandler = (event: KeyboardEvent) => {
-        const preventAction =
-          (!modifierPressed.current || (modifierPressed.current && !options.actInsideInputWithModifier)) &&
-          isInputDOMNode(event);
-
-        if (preventAction) {
-          return false;
-        }
         const keyOrCode = useKeyOrCode(event.code, keysToWatch);
 
         if (isMatchingKey(keyCodes, pressedKeys.current, true)) {


### PR DESCRIPTION
Wow you have some complex keypress handling code! 😅 

### What happened to me

I bring up a node search bar when `/` is pressed. The XYFlow keydown handler first registers that `/` has been pressed. Then we jump to the node search bar. Then the XYFlow keyup handler runs. The keyup handler sees that we are now inside an input, so it returns early. Leaving `/` forever pressed in the eyes of XYFlow.

### About the fix

This is a niche case and I'm probably the only one hurt. But the fix is so simple. Why would we ignore a key getting released because of being inside an input or whatever the modifier keys are doing? If it's released it's released.

Thanks for considering this!