### PR TITLE
fix(svelte): inverted attribution condition

### DIFF
--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -5,7 +5,7 @@
   let { proOptions, position = 'bottom-right' }: AttributionProps = $props();
 </script>
 
-{#if proOptions?.hideAttribution}
+{#if !proOptions?.hideAttribution}
   <Panel
     {position}
     class="svelte-flow__attribution"


### PR DESCRIPTION
The condition was accidentally inverted in https://github.com/xyflow/xyflow/commit/28e4fad342845a05beac9bcc77eb8a5a14727806#diff-88df6697ff34fa2b48872b0220ca1fb63f6e912ec5fdc76c5f45e18fe4c36075