### PR TITLE
chore: add missing type re-export for NodeConnection

### DIFF
--- a/.changeset/fifty-lizards-smash.md
+++ b/.changeset/fifty-lizards-smash.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Export NodeConnection type

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -106,6 +106,7 @@ export {
   type FinalConnectionState,
   type ConnectionInProgress,
   type NoConnection,
+  type NodeConnection,
 } from '@xyflow/system';
 
 // we need this workaround to prevent a duplicate identifier error

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -109,7 +109,8 @@ export {
   type ResizeParams,
   type ResizeParamsWithDirection,
   type ResizeDragEvent,
-  type IsValidConnection
+  type IsValidConnection,
+  type NodeConnection
 } from '@xyflow/system';
 
 // system utils


### PR DESCRIPTION
Missing the NodeConnection type export for the new hook `useNodeConnections`. 

I mainly use React, and doing guesswork on the Svelte part.