### PR TITLE
fix: compare `nodeStrokeWidth` with `number`, not with `string`

### DIFF
--- a/.changeset/rotten-news-deliver.md
+++ b/.changeset/rotten-news-deliver.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+fix: compare `nodeStrokeWidth` with `number`, not with `string`

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -143,7 +143,7 @@ function MiniMapComponent<NodeType extends Node = Node>({
             typeof maskStrokeWidth === 'number' ? maskStrokeWidth * viewScale : undefined,
           '--xy-minimap-node-background-color-props': typeof nodeColor === 'string' ? nodeColor : undefined,
           '--xy-minimap-node-stroke-color-props': typeof nodeStrokeColor === 'string' ? nodeStrokeColor : undefined,
-          '--xy-minimap-node-stroke-width-props': typeof nodeStrokeWidth === 'string' ? nodeStrokeWidth : undefined,
+          '--xy-minimap-node-stroke-width-props': typeof nodeStrokeWidth === 'number' ? nodeStrokeWidth : undefined,
         } as CSSProperties
       }
       className={cc(['react-flow__minimap', className])}


### PR DESCRIPTION
his ts type is `number`, i think this comparison was a mistake