### PR TITLE
fix: minimize inline style usage

### DIFF
--- a/packages/svelte/src/lib/components/ConnectionLine/ConnectionLine.svelte
+++ b/packages/svelte/src/lib/components/ConnectionLine/ConnectionLine.svelte
@@ -10,8 +10,8 @@
     getStraightPath
   } from '@xyflow/system';
 
-  export let containerStyle: string = '';
-  export let style: string = '';
+  export let containerStyle: string | undefined = undefined;
+  export let style: string | undefined = undefined;
   export let isCustomComponent: boolean = false;
 
   const { width, height, connection, connectionLineType } = useStore();

--- a/packages/svelte/src/lib/components/EdgeLabel/EdgeLabel.svelte
+++ b/packages/svelte/src/lib/components/EdgeLabel/EdgeLabel.svelte
@@ -18,7 +18,8 @@
   <div
     class="svelte-flow__edge-label"
     style:transform="translate(-50%, -50%) translate({x}px,{y}px)"
-    style={'pointer-events: all;' + style}
+    style:pointer-events="all"
+    {style}
     role="button"
     tabindex="-1"
     on:keyup={() => {}}

--- a/packages/svelte/src/lib/components/NodeSelection/NodeSelection.svelte
+++ b/packages/svelte/src/lib/components/NodeSelection/NodeSelection.svelte
@@ -38,7 +38,9 @@
 {#if $selectionRectMode === 'nodes' && bounds && isNumeric(bounds.x) && isNumeric(bounds.y)}
   <div
     class="selection-wrapper nopan"
-    style="width: {bounds.width}px; height: {bounds.height}px; transform: translate({bounds.x}px, {bounds.y}px)"
+    style:width="{bounds.width}px"
+    style:height="{bounds.height}px"
+    style:transform="translate({bounds.x}px, {bounds.y}px)"
     use:drag={{
       disabled: false,
       store,

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -185,7 +185,9 @@
     style:z-index={zIndex}
     style:transform="translate({positionX}px, {positionY}px)"
     style:visibility={initialized ? 'visible' : 'hidden'}
-    style="{style ?? ''};{inlineStyleDimensions.width}{inlineStyleDimensions.height}"
+    style:width={inlineStyleDimensions.width ?? ''}
+    style:height={inlineStyleDimensions.height ?? ''}
+    {style}
     on:click={onSelectNodeHandler}
     on:mouseenter={(event) => dispatchNodeEvent('nodemouseenter', { node, event })}
     on:mouseleave={(event) => dispatchNodeEvent('nodemouseleave', { node, event })}

--- a/packages/svelte/src/lib/components/NodeWrapper/utils.ts
+++ b/packages/svelte/src/lib/components/NodeWrapper/utils.ts
@@ -13,21 +13,21 @@ export function getNodeInlineStyleDimensions({
   measuredWidth?: number;
   measuredHeight?: number;
 }): {
-  width: string | undefined;
-  height: string | undefined;
+  width: number | undefined;
+  height: number | undefined;
 } {
   if (measuredWidth === undefined && measuredHeight === undefined) {
     const styleWidth = width ?? initialWidth;
     const styleHeight = height ?? initialHeight;
 
     return {
-      width: styleWidth ? `width:${styleWidth}px;` : '',
-      height: styleHeight ? `height:${styleHeight}px;` : ''
+      width: styleWidth,
+      height: styleHeight
     };
   }
 
   return {
-    width: width ? `width:${width}px;` : '',
-    height: height ? `height:${height}px;` : ''
+    width: width,
+    height: height
   };
 }

--- a/packages/svelte/src/lib/container/SvelteFlow/SvelteFlow.svelte
+++ b/packages/svelte/src/lib/container/SvelteFlow/SvelteFlow.svelte
@@ -46,8 +46,8 @@
   export let connectionRadius: $$Props['connectionRadius'] = undefined;
   export let connectionLineType: $$Props['connectionLineType'] = undefined;
   export let connectionMode: $$Props['connectionMode'] = ConnectionMode.Strict;
-  export let connectionLineStyle: $$Props['connectionLineStyle'] = '';
-  export let connectionLineContainerStyle: $$Props['connectionLineContainerStyle'] = '';
+  export let connectionLineStyle: $$Props['connectionLineStyle'] = undefined;
+  export let connectionLineContainerStyle: $$Props['connectionLineContainerStyle'] = undefined;
   export let onMoveStart: $$Props['onMoveStart'] = undefined;
   export let onMove: $$Props['onMove'] = undefined;
   export let onMoveEnd: $$Props['onMoveEnd'] = undefined;

--- a/packages/svelte/src/lib/container/Viewport/Viewport.svelte
+++ b/packages/svelte/src/lib/container/Viewport/Viewport.svelte
@@ -6,7 +6,7 @@
 
 <div
   class="svelte-flow__viewport xyflow__viewport"
-  style="transform: translate({$viewport.x}px, {$viewport.y}px) scale({$viewport.zoom})"
+  style:transform="translate({$viewport.x}px, {$viewport.y}px) scale({$viewport.zoom})"
 >
   <slot />
 </div>

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -103,7 +103,8 @@
 
 <Panel
   {position}
-  style={style + (bgColor ? `;--xy-minimap-background-color-props:${bgColor}` : '')}
+  {style}
+  --xy-minimap-background-color-props={bgColor ? bgColor : ''}
   class={cc(['svelte-flow__minimap', className])}
   data-testid="svelte-flow__minimap"
 >

--- a/packages/svelte/src/lib/plugins/Minimap/MinimapNode.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/MinimapNode.svelte
@@ -24,8 +24,8 @@
   ry={borderRadius}
   {width}
   {height}
-  style={`${color ? `fill: ${color};` : ''}${strokeColor ? `stroke: ${strokeColor};` : ''}${
-    strokeWidth ? `stroke-width: ${strokeWidth};` : ''
-  }`}
+  style:fill={color ? color : ''}
+  style:stroke={strokeColor ? strokeColor : ''}
+  style:stroke-width={strokeWidth ? strokeWidth : ''}
   shape-rendering={shapeRendering}
 />


### PR DESCRIPTION
In some environments, inline styles are not permitted due to security issues (e.g. strict CSP). Some of the current SvelteFlow components set string values to `style` attribute to apply dynamic styles, which makes part of the functionalities not available in these environments.

This commit tries to minimize usage of inline styles by

- Use `style:` directive where possible. These are compiled to setting properties of the CSSOM, which is permitted by CSP.
- For props that can be set to `style` attribute, default to `undefined` instead of empty string to avoid unnecessarily setting the attribute.