### PR TITLE
When horizontal, remove the border from all control buttons

### DIFF
--- a/.changeset/serious-jeans-tap.md
+++ b/.changeset/serious-jeans-tap.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Add separators to horizontal control buttons

--- a/packages/system/src/styles/style.css
+++ b/packages/system/src/styles/style.css
@@ -160,6 +160,14 @@
   }
 
   &.horizontal &-button {
-    border-bottom: none;
+    border-right: 1px solid
+      var(
+        --xy-controls-button-border-color-props,
+        var(--xy-controls-button-border-color, var(--xy-controls-button-border-color-default))
+      );
+  }
+
+  &.horizontal &-button:last-child {
+    border-right: none;
   }
 }

--- a/packages/system/src/styles/style.css
+++ b/packages/system/src/styles/style.css
@@ -158,4 +158,8 @@
   &-button:last-child {
     border-bottom: none;
   }
+
+  &.horizontal &-button {
+    border-bottom: none;
+  }
 }

--- a/packages/system/src/styles/style.css
+++ b/packages/system/src/styles/style.css
@@ -160,6 +160,7 @@
   }
 
   &.horizontal &-button {
+    border-bottom: none;
     border-right: 1px solid
       var(
         --xy-controls-button-border-color-props,


### PR DESCRIPTION
I found a small styling issue while creating a Reactflow component in our application. See discussion: https://github.com/xyflow/xyflow/discussions/5152

With the proposed change, horizontal buttons would have no bottom border by default.
<img width="191" alt="image" src="https://github.com/user-attachments/assets/c6eb36c7-8fec-4e3b-8abe-db7c8bf99d54" />

closes #5152
