### PR TITLE
Improve TSDoc comments for `BaseEdgeProps`

### DIFF
--- a/.changeset/eighty-foxes-add.md
+++ b/.changeset/eighty-foxes-add.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Improve TSDoc comments for `BaseEdgeProps`

--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -148,7 +148,7 @@ export type EdgeProps<EdgeType extends Edge = Edge> = Pick<
  * @public
  * @expand
  */
-export type BaseEdgeProps = Omit<SVGAttributes<SVGPathElement>, 'd' | 'path'> &
+export type BaseEdgeProps = Omit<SVGAttributes<SVGPathElement>, 'd' | 'path' | 'markerStart' | 'markerEnd'> &
   EdgeLabelOptions & {
     /**
      * The width of the invisible area around the edge that the user can interact with. This is
@@ -166,6 +166,16 @@ export type BaseEdgeProps = Omit<SVGAttributes<SVGPathElement>, 'd' | 'path'> &
      * be used to generate this string for you.
      */
     path: string;
+    /**
+     * The id of the SVG marker to use at the start of the edge. This should be defined in a
+     * `<defs>` element in a separate SVG document or element.
+     */
+    markerStart?: string;
+    /**
+     * The id of the SVG marker to use at the end of the edge. This should be defined in a `<defs>`
+     * element in a separate SVG document or element.
+     */
+    markerEnd?: string;
   };
 
 /**


### PR DESCRIPTION
added description for markerStart/markerEnd like currently on reactflow website https://reactflow.dev/api-reference/components/base-edge#marker-start