### PR TITLE
Fix/handle snapping

### DIFF
--- a/.changeset/chilly-dogs-mix.md
+++ b/.changeset/chilly-dogs-mix.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/system': patch
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Fix connection snapping for handles larger than connectionRadius

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -157,8 +157,8 @@ function onPointerDown(
       ...previousConnection,
       isValid,
       to:
-        closestHandle && isValid
-          ? rendererPointToPoint({ x: closestHandle.x, y: closestHandle.y }, transform)
+        result.toHandle && isValid
+          ? rendererPointToPoint({ x: result.toHandle.x, y: result.toHandle.y }, transform)
           : position,
       toHandle: result.toHandle,
       toPosition: isValid && result.toHandle ? result.toHandle.position : oppositePosition[fromHandle.position],
@@ -295,7 +295,7 @@ function isValidHandle(
 
     result.isValid = isValid && isValidConnection(connection);
 
-    result.toHandle = getHandle(handleNodeId, handleType, handleId, nodeLookup, connectionMode, false);
+    result.toHandle = getHandle(handleNodeId, handleType, handleId, nodeLookup, connectionMode, true);
   }
 
   return result;


### PR DESCRIPTION
@closes #5264 

@moklick I can't see any downside to this - but am I missing something with the reason why we did not put the absolute position into the result before?

Otherwise we could also just add an additional field to 'result' if both are required.