### PR TITLE
fix(a11y): remove outdated `ariaRoleDescription` field

### DIFF
--- a/examples/react/src/examples/A11y/index.tsx
+++ b/examples/react/src/examples/A11y/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from 'react';
+import { useState } from 'react';
 import {
   ReactFlow,
   MiniMap,
@@ -34,7 +34,6 @@ const initialNodes: Node[] = [
     data: { label: 'Node 3' },
     position: { x: 100, y: 100 },
     className: 'light',
-    ariaRoleDescription: 'custom node role',
     ariaRole: 'button',
   },
   {


### PR DESCRIPTION
Removes the `ariaRoleDescription` field we caught earlier. It's already removed everywhere else. 