### PR TITLE
feat(smoothstep-edge): add bendPosition parameter to control bend location

### DIFF
--- a/examples/react/src/examples/EdgeRouting/index.tsx
+++ b/examples/react/src/examples/EdgeRouting/index.tsx
@@ -69,6 +69,55 @@ const nodes: Node[] = [
     targetPosition: Position.Bottom,
     style: { background: 'rgba(255,255,255,0.5)' },
   },
+  // Bend Position Examples
+  {
+    id: '9',
+    position: { x: 300, y: 0 },
+    data: { label: 'Source' },
+    sourcePosition: Position.Right,
+    targetPosition: Position.Right,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
+  {
+    id: '10',
+    position: { x: 600, y: 150 },
+    data: { label: 'Target' },
+    sourcePosition: Position.Left,
+    targetPosition: Position.Left,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
+  {
+    id: '11',
+    position: { x: 300, y: 300 },
+    data: { label: 'Source' },
+    sourcePosition: Position.Right,
+    targetPosition: Position.Right,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
+  {
+    id: '12',
+    position: { x: 600, y: 450 },
+    data: { label: 'Target' },
+    sourcePosition: Position.Left,
+    targetPosition: Position.Left,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
+  {
+    id: '13',
+    position: { x: 300, y: 600 },
+    data: { label: 'Source' },
+    sourcePosition: Position.Right,
+    targetPosition: Position.Right,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
+  {
+    id: '14',
+    position: { x: 600, y: 750 },
+    data: { label: 'Target' },
+    sourcePosition: Position.Left,
+    targetPosition: Position.Left,
+    style: { background: 'rgba(255,255,255,0.5)' },
+  },
 ];
 
 const edges: Edge[] = [
@@ -101,6 +150,38 @@ const edges: Edge[] = [
     id: 'e7-8',
     source: '7',
     target: '8',
+  },
+  
+  // Bend Position Examples
+  {
+    id: 'e9-10',
+    source: '9',
+    target: '10',
+    label: 'bendPosition: 0.2',
+    pathOptions: {
+      bendPosition: 0.2,
+    },
+    interactionWidth: 0,
+  },
+  {
+    id: 'e11-12',
+    source: '11',
+    target: '12',
+    label: 'bendPosition: 0.5 (default)',
+    pathOptions: {
+      bendPosition: 0.5,
+    },
+    interactionWidth: 0,
+  },
+  {
+    id: 'e13-14',
+    source: '13',
+    target: '14',
+    label: 'bendPosition: 0.8',
+    pathOptions: {
+      bendPosition: 0.8,
+    },
+    interactionWidth: 0,
   },
 ];
 

--- a/packages/react/src/components/Edges/SmoothStepEdge.tsx
+++ b/packages/react/src/components/Edges/SmoothStepEdge.tsx
@@ -36,6 +36,7 @@ function createSmoothStepEdge(params: { isInternal: boolean }) {
         targetPosition,
         borderRadius: pathOptions?.borderRadius,
         offset: pathOptions?.offset,
+        bendPosition: pathOptions?.bendPosition,
       });
 
       const _id = params.isInternal ? undefined : id;

--- a/packages/svelte/src/lib/components/edges/SmoothStepEdge.svelte
+++ b/packages/svelte/src/lib/components/edges/SmoothStepEdge.svelte
@@ -30,7 +30,8 @@
       sourcePosition,
       targetPosition,
       borderRadius: pathOptions?.borderRadius,
-      offset: pathOptions?.offset
+      offset: pathOptions?.offset,
+      bendPosition: pathOptions?.bendPosition,
     })
   );
 </script>

--- a/packages/system/src/types/edges.ts
+++ b/packages/system/src/types/edges.ts
@@ -45,6 +45,7 @@ export type EdgeBase<
 export type SmoothStepPathOptions = {
   offset?: number;
   borderRadius?: number;
+  bendPosition?: number;
 };
 
 export type StepPathOptions = {


### PR DESCRIPTION
- Added bendPosition parameter to getSmoothStepPath function to control where the bend occurs along smoothstep edges
- Updated React and Svelte SmoothStepEdge components to pass through the new parameter
- Added examples with different bend positions (0.2, 0.5, 0.8)

 The bendPosition parameter accepts values from 0 to 1. e.g., 
- 0 = bend at source position
- 1 = bend at target position
- 0.5 = bend at midpoint (default behavior)

This provides more granular control over smoothstep edge routing, especially useful for layouts where the default midpoint bend may not be desired.

**Example Screenshot**

![Screenshot 2025-07-02 at 8 15 40 PM](https://github.com/user-attachments/assets/1ed6dcff-2d5e-4ec1-b3bd-4d50bea37356)
