### PR TITLE
Fix incorrect d3 event unbinding format

### DIFF
--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -394,7 +394,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
   }
 
   function destroy() {
-    d3Selection?.on('.drag', null);
+    d3Selection?.on('drag', null);
   }
 
   return {


### PR DESCRIPTION
## Issue Description
In the destroy method, an incorrect d3 event unbinding format `.on('.drag', null)` was used, causing the following error during execution:
```
TypeError: Cannot read properties of undefined (reading 'name')
```
The .on() method of d3-selection should use 'drag' instead of '.drag' to reference the drag event.

## Fix
Changed `d3Selection?.on('.drag', null)` to the correct syntax `d3Selection?.on('drag', null).`