### PR TITLE
docs(edges): update marker documentation to include formatting info

### DIFF
--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -184,12 +184,12 @@ export type BaseEdgeProps = Omit<SVGAttributes<SVGPathElement>, 'd' | 'path' | '
     path: string;
     /**
      * The id of the SVG marker to use at the start of the edge. This should be defined in a
-     * `<defs>` element in a separate SVG document or element.
+     * `<defs>` element in a separate SVG document or element. Use the format "url(#markerId)" where markerId is the id of your marker definition.
      */
     markerStart?: string;
     /**
      * The id of the SVG marker to use at the end of the edge. This should be defined in a `<defs>`
-     * element in a separate SVG document or element.
+     * element in a separate SVG document or element. Use the format "url(#markerId)" where markerId is the id of your marker definition.
      */
     markerEnd?: string;
   };

--- a/packages/svelte/src/lib/types/edges.ts
+++ b/packages/svelte/src/lib/types/edges.ts
@@ -50,11 +50,15 @@ export type BaseEdgeProps = Pick<
   labelX?: number;
   /** The y coordinate of the label */
   labelY?: number;
-  /** Marker at start of edge
+  /**
+   * The id of the SVG marker to use at the start of the edge. This should be defined in a
+   * `<defs>` element in a separate SVG document or element. Use the format "url(#markerId)" where markerId is the id of your marker definition.
    * @example 'url(#arrow)'
    */
   markerStart?: string;
-  /** Marker at end of edge
+  /**
+   * The id of the SVG marker to use at the end of the edge. This should be defined in a `<defs>`
+   * element in a separate SVG document or element. Use the format "url(#markerId)" where markerId is the id of your marker definition.
    * @example 'url(#arrow)'
    */
   markerEnd?: string;


### PR DESCRIPTION
From this issue in the web repo: https://github.com/xyflow/web/issues/477

I think the best place to update this is inside the api-reference. It seemed too specific to put in the example pages. 