### PR TITLE
Export MiniMapNode

### DIFF
--- a/.changeset/dry-timers-build.md
+++ b/.changeset/dry-timers-build.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Export MiniMapNode

--- a/.changeset/smooth-stingrays-play.md
+++ b/.changeset/smooth-stingrays-play.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Export MiniMapNode

--- a/packages/react/src/additional-components/MiniMap/index.tsx
+++ b/packages/react/src/additional-components/MiniMap/index.tsx
@@ -1,2 +1,3 @@
 export { MiniMap } from './MiniMap';
+export { MiniMapNode } from './MiniMapNode';
 export * from './types';

--- a/packages/svelte/src/lib/plugins/Minimap/index.ts
+++ b/packages/svelte/src/lib/plugins/Minimap/index.ts
@@ -1,2 +1,3 @@
 export { default as MiniMap } from './Minimap.svelte';
+export { default as MiniMapNode } from './MinimapNode.svelte';
 export * from './types';


### PR DESCRIPTION
It's already possible to use a custom `nodeComponent`, this enables the users to used the original `MiniMapNode` with a custom wrapper