### PR TITLE
Set unique id in connectionLookup to fix multi selection if there are multiple edges between two nodes

### DIFF
--- a/examples/react/src/generic-tests/edges/general.ts
+++ b/examples/react/src/generic-tests/edges/general.ts
@@ -3,6 +3,7 @@ import { MarkerType } from '@xyflow/react';
 export default {
   flowProps: {
     fitView: true,
+    selectionKeyCode: 's',
     multiSelectionKeyCode: 's',
     deleteKeyCode: 'd',
     nodes: [
@@ -177,6 +178,19 @@ export default {
         id: 'subflow-edge-2',
         source: '12-a',
         target: '12-b',
+      },
+      {
+        id: 'multi-edge-1',
+        source: '10',
+        target: '11',
+        label: 'first edge',
+      },
+      {
+        id: 'multi-edge-2',
+        source: '10',
+        target: '11',
+        label: 'second edge',
+        type: 'step',
       },
       // {
       // 	id: 'updatable',

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -514,8 +514,8 @@ export function updateConnectionLookup(connectionLookup: ConnectionLookup, edgeL
     const { source: sourceNode, target: targetNode, sourceHandle = null, targetHandle = null } = edge;
 
     const connection = { edgeId: edge.id, source: sourceNode, target: targetNode, sourceHandle, targetHandle };
-    const sourceKey = `${sourceNode}-${sourceHandle}--${targetNode}-${targetHandle}`;
-    const targetKey = `${targetNode}-${targetHandle}--${sourceNode}-${sourceHandle}`;
+    const sourceKey = `${sourceNode}-${sourceHandle}--${targetNode}-${targetHandle}--${edge.id}`;
+    const targetKey = `${targetNode}-${targetHandle}--${sourceNode}-${sourceHandle}--${edge.id}`;
 
     addConnectionToLookup('source', connection, targetKey, connectionLookup, sourceNode, sourceHandle);
     addConnectionToLookup('target', connection, sourceKey, connectionLookup, targetNode, targetHandle);

--- a/tests/playwright/e2e/edges.spec.ts
+++ b/tests/playwright/e2e/edges.spec.ts
@@ -38,6 +38,32 @@ test.describe('Edges', () => {
       await expect(edge2).toHaveClass(/selected/);
       await expect(edge1).toHaveClass(/selected/);
     });
+
+    test('selecting multiple edges between two nodes by drag selection', async ({ page }) => {
+      const edge1 = page.locator('[data-id="multi-edge-1"]');
+      const edge2 = page.locator('[data-id="multi-edge-2"]');
+
+      await expect(edge1).toBeAttached();
+      await expect(edge2).toBeAttached();
+
+      const edge1Box = await edge1.boundingBox();
+      const edge2Box = await edge2.boundingBox();
+
+      const startX = Math.min(edge1Box!.x, edge2Box!.x) - 250;
+      const startY = Math.min(edge1Box!.y, edge2Box!.y) - 50;
+      const endX = Math.max(edge1Box!.x + edge1Box!.width, edge2Box!.x + edge2Box!.width) + 250;
+      const endY = Math.max(edge1Box!.y + edge1Box!.height, edge2Box!.y + edge2Box!.height) + 50;
+
+      await page.keyboard.down('s');
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      await page.mouse.move(endX, endY);
+      await page.mouse.up();
+      await page.keyboard.up('s');
+
+      await expect(edge1).toHaveClass(/selected/);
+      await expect(edge2).toHaveClass(/selected/);
+    });
   });
 
   test.describe('properties', () => {


### PR DESCRIPTION
Fix for issue https://github.com/xyflow/xyflow/issues/5451
With this change the source and target id should always be unique so no edges get lost in the connectionLookup map.