### PR TITLE
fix(css): support old translate css syntax #5460

### DIFF
--- a/.changeset/curly-beds-knock.md
+++ b/.changeset/curly-beds-knock.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Support CSS translate syntax for the resize handle in older versions of Chrome (>104.0.0).

--- a/packages/system/src/styles/node-resizer.css
+++ b/packages/system/src/styles/node-resizer.css
@@ -33,7 +33,7 @@
   border: 1px solid #fff;
   border-radius: 1px;
   background-color: var(--xy-resize-background-color, var(--xy-resize-background-color-default));
-  translate: -50% -50%;
+  transform: translate(-50%, -50%);
 }
 
 .xy-flow__resize-control.handle.left {


### PR DESCRIPTION
In versions of Chrome older than 104, the resize handle is not properly centered because the translate property is used without the transform property. Specifically, the code currently uses translate: -50% -50%; instead of transform: translate(-50%, -50%);.
This causes the resize handle to shift to the side instead of being perfectly centered, affecting user experience and visual consistency on legacy browsers.

[#5460](https://github.com/xyflow/xyflow/issues/5460)