### PR TITLE
Fix visual artifacts around handles when zoomed out

### DIFF
--- a/packages/system/src/styles/style.css
+++ b/packages/system/src/styles/style.css
@@ -113,7 +113,7 @@
   width: 6px;
   height: 6px;
   background-color: var(--xy-handle-background-color, var(--xy-handle-background-color-default));
-  border: 1px solid var(--xy-handle-border-color, var(--xy-handle-border-color-default));
+  outline: 1px solid var(--xy-handle-border-color, var(--xy-handle-border-color-default));
   border-radius: 100%;
 }
 


### PR DESCRIPTION
Hello, I noticed there was some visual artifacts around the handles when zoomed out, it seems that some pixel of the black background of the handles can be seen outside of the border due to some precision error both in chrome and firefox
This is easily fixed by using an outline instead of a border :)

<img width="734" height="439" alt="Screenshot_20250902_134310" src="https://github.com/user-attachments/assets/2c4c3c5e-a2be-4c8c-98ca-d2eb971b0b55" />
