### PR TITLE
fix(edges): add `type` property to `EdgeProps`

### DIFF
--- a/.changeset/curly-steaks-check.md
+++ b/.changeset/curly-steaks-check.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Add `type` property to `EdgeProps` to match `NodeProps` behavior

--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -149,7 +149,7 @@ export type EdgeTextProps = Omit<SVGAttributes<SVGElement>, 'x' | 'y'> &
  */
 export type EdgeProps<EdgeType extends Edge = Edge> = Pick<
   EdgeType,
-  'id' | 'animated' | 'data' | 'style' | 'selected' | 'source' | 'target' | 'selectable' | 'deletable'
+  'id' | 'type' | 'animated' | 'data' | 'style' | 'selected' | 'source' | 'target' | 'selectable' | 'deletable'
 > &
   EdgePosition &
   EdgeLabelOptions & {


### PR DESCRIPTION
Adds the `type` property to `EdgeProps` to match `NodeProps` behavior. This allows custom edge components to access their edge type with proper TypeScript support.

The `type` property was already being passed [at runtime in `EdgeWrapper`](https://github.com/xyflow/xyflow/blob/4c2a3030575557b8270575e88fa5366bc6e1b476/packages/react/src/components/EdgeWrapper/index.tsx#L217) but was missing from the TypeScript type definition.