### PR TITLE
Fix selection box issue on mobile devices

### DIFF
--- a/.changeset/fuzzy-crews-vanish.md
+++ b/.changeset/fuzzy-crews-vanish.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix selection box issue on mobile devices by adding `touch-action:none`

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -447,3 +447,7 @@ svg.xy-flow__connectionline {
     }
   }
 }
+
+.react-flow__pane {
+  touch-action: none;
+}

--- a/packages/system/src/styles/init.css
+++ b/packages/system/src/styles/init.css
@@ -68,6 +68,7 @@
 
 .xy-flow__pane {
   z-index: 1;
+  touch-action: none;
 
   &.draggable {
     cursor: grab;
@@ -446,8 +447,4 @@ svg.xy-flow__connectionline {
       fill: currentColor;
     }
   }
-}
-
-.react-flow__pane {
-  touch-action: none;
 }


### PR DESCRIPTION
Add touch-action: none to react-flow__pane to prevent default touch behavior from interfering with selection functionality on mobile devices

fix: https://github.com/xyflow/xyflow/issues/5639