### PR TITLE
Keep handle interactive when `isConnectableEnd` is false

### DIFF
--- a/examples/svelte/src/components/Header/Header.svelte
+++ b/examples/svelte/src/components/Header/Header.svelte
@@ -21,6 +21,7 @@
 		'node-toolbar',
 		'node-resizer',
 		'overview',
+		'self-attach',
 		'stress',
 		'subflows',
 		'two-way-viewport',

--- a/examples/svelte/src/routes/examples/self-attach/+page.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import {
+		SvelteFlow,
+		Controls,
+		Background,
+		BackgroundVariant,
+		MiniMap,
+		type Node,
+		type NodeTypes
+	} from '@xyflow/svelte';
+
+	import '@xyflow/svelte/dist/style.css';
+
+	import DebugNode from './DebugNode.svelte';
+
+	const nodeTypes: NodeTypes = {
+		debug: DebugNode
+	};
+
+	let nodes = $state.raw<Node[]>([
+		{
+			id: 'debug',
+			type: 'debug',
+			position: {
+				x: 0,
+				y: 0
+			},
+			data: {}
+		}
+	]);
+</script>
+
+<SvelteFlow {nodeTypes} bind:nodes fitView minZoom={0.2} onlyRenderVisibleElements>
+	<Controls />
+	<Background variant={BackgroundVariant.Lines} />
+	<MiniMap />
+</SvelteFlow>

--- a/examples/svelte/src/routes/examples/self-attach/+page.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/+page.svelte
@@ -11,19 +11,50 @@
 
 	import '@xyflow/svelte/dist/style.css';
 
-	import DebugNode from './DebugNode.svelte';
+	import ConnectableStart from './ConnectableStart.svelte';
+	import ConnectableEnd from './ConnectableEnd.svelte';
+	import UnconnectableTarget from './UnconnectableTarget.svelte';
 
 	const nodeTypes: NodeTypes = {
-		debug: DebugNode
+		start: ConnectableStart,
+		end: ConnectableEnd,
+		unconnectable: UnconnectableTarget
 	};
 
 	let nodes = $state.raw<Node[]>([
 		{
-			id: 'debug',
-			type: 'debug',
+			id: 'start-1',
+			type: 'start',
 			position: {
 				x: 0,
 				y: 0
+			},
+			data: {}
+		},
+		{
+			id: 'start-2',
+			type: 'start',
+			position: {
+				x: -50,
+				y: -50
+			},
+			data: {}
+		},
+		{
+			id: 'second',
+			type: 'end',
+			position: {
+				x: 50,
+				y: 50
+			},
+			data: {}
+		},
+		{
+			id: 'unconnectable-1',
+			type: 'unconnectable',
+			position: {
+				x: 150,
+				y: -50
 			},
 			data: {}
 		}

--- a/examples/svelte/src/routes/examples/self-attach/ConnectableEnd.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/ConnectableEnd.svelte
@@ -6,14 +6,12 @@
 	rest;
 </script>
 
-<div style:margin-bottom="10px">
-	x:{Math.round(positionAbsoluteX)} y:{Math.round(positionAbsoluteY)}
-</div>
+<div style:margin-bottom="10px">End</div>
 
 <Handle
-	type="source"
+	type="target"
 	position={Position.Bottom}
 	isConnectable
-	isConnectableStart
-	isConnectableEnd={false}
+	isConnectableStart={false}
+	isConnectableEnd
 />

--- a/examples/svelte/src/routes/examples/self-attach/ConnectableStart.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/ConnectableStart.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	let { id, positionAbsoluteX, positionAbsoluteY, ...rest }: NodeProps = $props();
+
+	rest;
+</script>
+
+<div style:margin-bottom="10px">Start</div>
+
+<Handle
+	type="source"
+	position={Position.Bottom}
+	isConnectable
+	isConnectableStart
+	isConnectableEnd={false}
+/>

--- a/examples/svelte/src/routes/examples/self-attach/DebugNode.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/DebugNode.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	let { id, positionAbsoluteX, positionAbsoluteY, ...rest }: NodeProps = $props();
+
+	rest;
+</script>
+
+<div style:margin-bottom="10px">
+	x:{Math.round(positionAbsoluteX)} y:{Math.round(positionAbsoluteY)}
+</div>
+
+<Handle
+	type="source"
+	position={Position.Bottom}
+	isConnectable
+	isConnectableStart
+	isConnectableEnd={false}
+/>

--- a/examples/svelte/src/routes/examples/self-attach/UnconnectableTarget.svelte
+++ b/examples/svelte/src/routes/examples/self-attach/UnconnectableTarget.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	let { id, positionAbsoluteX, positionAbsoluteY, ...rest }: NodeProps = $props();
+
+	rest;
+</script>
+
+<div style:margin-bottom="10px">Unconnectable</div>
+
+<Handle
+	type="target"
+	position={Position.Bottom}
+	isConnectable
+	isConnectableStart={false}
+	isConnectableEnd={false}
+/>

--- a/packages/react/src/components/Handle/index.tsx
+++ b/packages/react/src/components/Handle/index.tsx
@@ -243,7 +243,9 @@ function HandleComponent(
           connectionindicator:
             isConnectable &&
             (!connectionInProcess || isPossibleEndHandle) &&
-            (connectionInProcess || clickConnectionInProcess ? isConnectableEnd : isConnectableStart),
+            (connectionInProcess || clickConnectionInProcess
+              ? isConnectableEnd || clickConnecting
+              : isConnectableStart),
         },
       ])}
       onMouseDown={onPointerDown}

--- a/packages/react/src/components/Handle/index.tsx
+++ b/packages/react/src/components/Handle/index.tsx
@@ -4,6 +4,7 @@ import {
   type TouchEvent as ReactTouchEvent,
   type ForwardedRef,
   memo,
+  useRef,
 } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
@@ -99,6 +100,8 @@ function HandleComponent(
     store.getState().onError?.('010', errorMessages['error010']());
   }
 
+  const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+
   const onConnectExtended = (params: Connection) => {
     const { defaultEdgeOptions, onConnect: onConnectAction, hasDefaultEdges } = store.getState();
 
@@ -126,6 +129,16 @@ function HandleComponent(
       ((isMouseTriggered && (event as ReactMouseEvent<HTMLDivElement>).button === 0) || !isMouseTriggered)
     ) {
       const currentStore = store.getState();
+
+      pointerDownPos.current = isMouseTriggered
+        ? {
+            x: (event as ReactMouseEvent<HTMLDivElement>).clientX,
+            y: (event as ReactMouseEvent<HTMLDivElement>).clientY,
+          }
+        : {
+            x: (event as ReactTouchEvent<HTMLDivElement>).touches[0].clientX,
+            y: (event as ReactTouchEvent<HTMLDivElement>).touches[0].clientY,
+          };
 
       XYHandle.onPointerDown(event.nativeEvent, {
         handleDomNode: event.currentTarget,
@@ -171,7 +184,17 @@ function HandleComponent(
       rfId: flowId,
       nodeLookup,
       connection: connectionState,
+      connectionDragThreshold,
     } = store.getState();
+
+    if (pointerDownPos.current) {
+      const dx = event.clientX - pointerDownPos.current.x;
+      const dy = event.clientY - pointerDownPos.current.y;
+      pointerDownPos.current = null;
+      if (dx * dx + dy * dy > connectionDragThreshold * connectionDragThreshold) {
+        return;
+      }
+    }
 
     if (!nodeId || (!connectionClickStartHandle && !isConnectableStart)) {
       return;

--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -68,6 +68,13 @@
     }
   });
 
+  let isClickConnectSource = $derived(
+    store.clickConnectStartHandle !== null &&
+      store.clickConnectStartHandle.nodeId === nodeId &&
+      store.clickConnectStartHandle.type === type &&
+      store.clickConnectStartHandle.id === handleId
+  );
+
   let [connectionInProgress, connectingFrom, connectingTo, isPossibleTargetHandle, valid] =
     $derived.by(() => {
       if (!store.connection.inProgress) {
@@ -112,7 +119,11 @@
   function onpointerdown(event: MouseEvent | TouchEvent) {
     const isMouseTriggered = isMouseEvent(event);
 
-    if (event.currentTarget && ((isMouseTriggered && event.button === 0) || !isMouseTriggered)) {
+    if (
+      isConnectableStart &&
+      event.currentTarget &&
+      ((isMouseTriggered && event.button === 0) || !isMouseTriggered)
+    ) {
       XYHandle.onPointerDown(event, {
         handleId,
         nodeId,
@@ -218,7 +229,9 @@ The Handle component is the part of a node that can be used to connect nodes.
   class:connectable={isConnectable}
   class:connectionindicator={isConnectable &&
     (!connectionInProgress || isPossibleTargetHandle) &&
-    (connectionInProgress || store.clickConnectStartHandle ? isConnectableEnd : isConnectableStart)}
+    (connectionInProgress || store.clickConnectStartHandle
+      ? isConnectableEnd || isClickConnectSource
+      : isConnectableStart)}
   onmousedown={onpointerdown}
   ontouchstart={onpointerdown}
   onclick={store.clickConnect ? onclick : undefined}

--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -48,6 +48,7 @@
   let ariaLabelConfig = $derived(store.ariaLabelConfig);
 
   let prevConnections: Map<string, HandleConnection> | null = null;
+  let pointerDownPos: { x: number; y: number } | null = null;
   $effect.pre(() => {
     if (onconnect || ondisconnect) {
       // connectionLookup is not reactive, so we use edges to get notified about updates
@@ -124,6 +125,13 @@
       event.currentTarget &&
       ((isMouseTriggered && event.button === 0) || !isMouseTriggered)
     ) {
+      pointerDownPos = isMouseTriggered
+        ? { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY }
+        : {
+            x: (event as TouchEvent).touches[0].clientX,
+            y: (event as TouchEvent).touches[0].clientY
+          };
+
       XYHandle.onPointerDown(event, {
         handleId,
         nodeId,
@@ -153,6 +161,16 @@
   }
 
   function onclick(event: MouseEvent) {
+    if (pointerDownPos) {
+      const dx = event.clientX - pointerDownPos.x;
+      const dy = event.clientY - pointerDownPos.y;
+      const threshold = store.connectionDragThreshold;
+      pointerDownPos = null;
+      if (dx * dx + dy * dy > threshold * threshold) {
+        return;
+      }
+    }
+
     if (!nodeId || (!store.clickConnectStartHandle && !isConnectableStart)) {
       return;
     }


### PR DESCRIPTION
## Summary

- Fix handle with `isConnectableEnd={false}` becoming permanently unusable after a connection starts and ends on the same handle
- Add missing `isConnectableStart` guard in Svelte Handle's `onpointerdown` for React parity

## Problem

When a handle has `isConnectableEnd={false}` and a user drags a connection that starts and ends on that same handle:

1. The drag cancels, then `click` fires on the same element
2. `clickConnectStartHandle` gets set to this handle
3. The `connectionindicator` class ternary switches to evaluate `isConnectableEnd` (which is `false`)
4. Handle loses `pointer-events: all` from CSS and becomes permanently unclickable
5. `clickConnectStartHandle` can only be cleared via click on a handle, but this handle is now dead

## Fix

The `connectionindicator` class now stays `true` for the click-connect source handle, so it retains `pointer-events: all` even when `isConnectableEnd={false}`.

**Svelte:** Added `isClickConnectSource` derived value used in `connectionindicator` expression.
**React:** Reused existing `clickConnecting` selector in `connectionindicator` expression (same bug existed).

Also added `isConnectableStart` check in Svelte's `onpointerdown` since React already had this guard.