### PR TITLE
fix(react): add @types/react to peer dependencies

### DIFF
--- a/.changeset/react-types-peer-dep.md
+++ b/.changeset/react-types-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Add `@types/react` and `@types/react-dom` as optional peer dependencies so the package resolves React types under pnpm strict mode (`hoist: false`) without forcing JavaScript consumers to install the type packages.

--- a/.changeset/react-types-peer-dep.md
+++ b/.changeset/react-types-peer-dep.md
@@ -2,4 +2,4 @@
 '@xyflow/react': patch
 ---
 
-Add `@types/react` and `@types/react-dom` as optional peer dependencies so the package resolves React types under pnpm strict mode (`hoist: false`) without forcing JavaScript consumers to install the type packages.
+Add `@types/react` and `@types/react-dom` as optional peer dependencies to prevent issues with pnpm strict mode (`hoist: false`)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,8 +66,18 @@
     "zustand": "^4.4.0"
   },
   "peerDependencies": {
+    "@types/react": ">=17",
+    "@types/react-dom": ">=17",
     "react": ">=17",
     "react-dom": ">=17"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^18.7.16",


### PR DESCRIPTION
## Summary
Adds `@types/react` and `@types/react-dom` as optional peer dependencies of `@xyflow/react` so TypeScript can resolve the shipped `.d.ts` types under pnpm strict mode (`hoist: false`).

## Issue
Fixes #5738

## Changes
- `packages/react/package.json`: declare `@types/react` / `@types/react-dom` in `peerDependencies`, marked optional in `peerDependenciesMeta` so JavaScript consumers are not asked to install them.
- Added changeset (patch).

## Why optional
`@types/react` is only needed when the consumer is using TypeScript. Marking the peer deps as optional is the standard pattern across the ecosystem — strict pnpm installs resolve the types correctly, and plain JS consumers don't get a missing peer warning.

## Testing
- `.d.ts` resolution works in a pnpm project configured with `hoist: false` (the reported failure mode).
- No runtime code changes — this is purely a `package.json` metadata fix.