### PR TITLE
Fix node drags remaining active after window blur

### DIFF
--- a/packages/system/src/xydrag/XYDrag.ts
+++ b/packages/system/src/xydrag/XYDrag.ts
@@ -106,6 +106,28 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
   let nodePositionsChanged = false;
   // we store the last drag event to be able to use it in the update function
   let dragEvent: MouseEvent | null = null;
+  let dragCancelWindow: Window | null = null;
+  let dragCancelHandler: (() => void) | null = null;
+
+  function removeWindowBlurDragCancelHandler() {
+    if (dragCancelWindow && dragCancelHandler) {
+      dragCancelWindow.removeEventListener('blur', dragCancelHandler);
+    }
+
+    dragCancelWindow = null;
+    dragCancelHandler = null;
+  }
+
+  function addWindowBlurDragCancelHandler(ownerWindow: Window | null, onCancel: () => void) {
+    if (!ownerWindow) {
+      return;
+    }
+
+    removeWindowBlurDragCancelHandler();
+    dragCancelWindow = ownerWindow;
+    dragCancelHandler = onCancel;
+    ownerWindow.addEventListener('blur', dragCancelHandler);
+  }
 
   // public functions
   function update({
@@ -296,12 +318,30 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
     const d3DragInstance = drag()
       .clickDistance(nodeClickDistance)
       .on('start', (event: UseDragEvent) => {
-        const { domNode, nodeDragThreshold, transform, snapGrid, snapToGrid } = getStoreItems();
-        containerBounds = domNode?.getBoundingClientRect() || null;
+        const { domNode: storeDomNode, nodeDragThreshold, transform, snapGrid, snapToGrid } = getStoreItems();
+        containerBounds = storeDomNode?.getBoundingClientRect() || null;
 
         abortDrag = false;
         nodePositionsChanged = false;
         dragEvent = event.sourceEvent;
+
+        if (event.sourceEvent.type === 'mousedown') {
+          addWindowBlurDragCancelHandler(domNode.ownerDocument.defaultView, () => {
+            const mouseUpEvent = new MouseEvent('mouseup', {
+              view: domNode.ownerDocument.defaultView,
+              bubbles: true,
+              cancelable: true,
+              clientX: dragEvent?.clientX ?? 0,
+              clientY: dragEvent?.clientY ?? 0,
+              screenX: dragEvent?.screenX ?? 0,
+              screenY: dragEvent?.screenY ?? 0,
+            });
+
+            // If window blur prevents d3-drag from seeing mouseup, its window-level listeners stay active.
+            // Dispatch mouseup on the same window so d3 can run its normal cleanup path.
+            domNode.ownerDocument.defaultView?.dispatchEvent(mouseUpEvent);
+          });
+        }
 
         if (nodeDragThreshold === 0) {
           startDrag(event);
@@ -352,6 +392,8 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
         }
       })
       .on('end', (event: UseDragEvent) => {
+        removeWindowBlurDragCancelHandler();
+
         if (!dragStarted || abortDrag) {
           return;
         }
@@ -399,6 +441,7 @@ export function XYDrag<OnNodeDrag extends (e: any, nodes: any, node: any) => voi
   }
 
   function destroy() {
+    removeWindowBlurDragCancelHandler();
     d3Selection?.on('.drag', null);
   }
 

--- a/tests/playwright/e2e/nodes.spec.ts
+++ b/tests/playwright/e2e/nodes.spec.ts
@@ -129,6 +129,36 @@ test.describe('Nodes', () => {
 
       expect(transformBeforeMove).not.toMatch(transformAfterDragHandleMove);
     });
+
+    test('window blur cancels active node drag', async ({ page }) => {
+      const node = page.locator(`.${FRAMEWORK}-flow__node`).first();
+
+      await expect(node).toHaveCSS('visibility', 'visible');
+
+      const nodeBox = await node.boundingBox();
+      const startX = nodeBox!.x + nodeBox!.width / 2;
+      const startY = nodeBox!.y + nodeBox!.height / 2;
+
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      await page.mouse.move(startX + 100, startY + 100);
+
+      const transformAfterMove = await node.evaluate((element) => {
+        return element.style.transform;
+      });
+
+      await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+      // Move the mouse to confirm the node does not keep dragging after blur
+      await page.mouse.move(startX + 250, startY + 250);
+
+      const transformAfterBlurMove = await node.evaluate((element) => {
+        return element.style.transform;
+      });
+
+      expect(transformAfterBlurMove).toBe(transformAfterMove);
+
+      await page.mouse.up();
+    });
   });
 
   test.describe('deleting', () => {


### PR DESCRIPTION
## Problem

When a node drag is active and the window loses focus before mouseup, d3-drag doesn't receive its window `mouseup` event. This can happen when a user starts dragging a node, Alt+Tabs away while holding the mouse button, releases the mouse in another app, and returns to the flow. 

In that state, the node can remain attached to the cursor because the drag session was not finalized.

Reproducing it on Windows, wasn't able to reproduce on macOS:
https://github.com/user-attachments/assets/53b97d44-433e-4beb-832f-b457d8a3841a

## Fix

Add a `window.blur` handler while a mouse node drag gesture is active. On blur, dispatch a `mouseup` event on the flow window so d3-drag runs its normal cleanup path. The existing drag end path then finalizes node dragging.

## Vefification

- Added a e2e test to verify that node doesn't continue following the cursor after `blur` event. 
- Ran React Chromium node tests


