### PR TITLE
Remove unused css variables

### DIFF
--- a/.changeset/humble-pianos-attack.md
+++ b/.changeset/humble-pianos-attack.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/svelte': patch
+---
+
+Remove unused `background-color` CSS variable

--- a/examples/svelte/src/routes/examples/overview/Flow.svelte
+++ b/examples/svelte/src/routes/examples/overview/Flow.svelte
@@ -266,13 +266,7 @@
 	}
 
 	:root {
-		/* --background-color: #ffffdd; */
-		--background-pattern-color: #5050ff;
-
 		--xy-minimap-background-color: red;
 		--xy-minimap-mask-color: rgb(255, 255, 240, 0.6);
-
-		--controls-button-background-color: #ddd;
-		--controls-button-background-color-hover: #ccc;
 	}
 </style>

--- a/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
+++ b/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
@@ -139,22 +139,5 @@
     overflow: hidden;
     position: relative;
     z-index: 0;
-
-    background-color: var(--background-color, var(--background-color-default));
-  }
-
-  :root {
-    --background-color-default: #fff;
-    --background-pattern-color-default: #ddd;
-
-    --minimap-mask-color-default: rgb(240, 240, 240, 0.6);
-    --minimap-mask-stroke-color-default: none;
-    --minimap-mask-stroke-width-default: 1;
-
-    --controls-button-background-color-default: #fefefe;
-    --controls-button-background-color-hover-default: #f4f4f4;
-    --controls-button-color-default: inherit;
-    --controls-button-color-hover-default: inherit;
-    --controls-button-border-color-default: #eee;
   }
 </style>

--- a/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
+++ b/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
@@ -123,7 +123,7 @@
   bind:clientWidth
   style:width={toPxString(width)}
   style:height={toPxString(height)}
-  class={['svelte-flow', 'svelte-flow__container', className, colorMode]}
+  class={['svelte-flow', 'svelte-flow__container', colorMode, className ]}
   data-testid="svelte-flow__wrapper"
   role="application"
   onscroll={wrapperOnScroll}


### PR DESCRIPTION
fixes #5774

**TODO**
We should actually move all of the css into the imported css layer, so we will never run into issues of preventing users from overwriting styles.