### PR TITLE
feat: get connections from handleId without specifying handleType

### DIFF
--- a/.changeset/six-pandas-lay.md
+++ b/.changeset/six-pandas-lay.md
@@ -1,0 +1,7 @@
+---
+"@xyflow/react": patch
+"@xyflow/svelte": patch
+"@xyflow/system": patch
+---
+
+Adds a `nodeId-handleId` key to `connectionLookup` so that `useNodeConnections` can now filter by `handleId` alone.

--- a/packages/react/src/hooks/useNodeConnections.ts
+++ b/packages/react/src/hooks/useNodeConnections.ts
@@ -18,7 +18,7 @@ type UseNodeConnectionsParams = {
   id?: string;
   /** What type of handle connections do you want to observe? */
   handleType?: HandleType;
-  /** Filter by handle id (this is only needed if the node has multiple handles of the same type). */
+  /** Filter by handle id. When used without `handleType`, returns connections for that handle regardless of type. */
   handleId?: string;
   /** Gets called when a connection is established. */
   onConnect?: (connections: HandleConnection[]) => void;
@@ -67,7 +67,7 @@ export function useNodeConnections({
   const connections = useStore(
     (state) =>
       state.connectionLookup.get(
-        `${currentNodeId}${handleType ? (handleId ? `-${handleType}-${handleId}` : `-${handleType}`) : ''}`
+        `${currentNodeId}${handleType ? (handleId ? `-${handleType}-${handleId}` : `-${handleType}`) : handleId ? `-${handleId}` : ''}`
       ),
     areConnectionMapsEqual
   );

--- a/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
@@ -28,7 +28,7 @@ const initialConnections: NodeConnection[] = [];
  * @public
  * @param param.id - node id - optional if called inside a custom node
  * @param param.handleType - filter by handle type 'source' or 'target'
- * @param param.handleId - filter by handle id (this is only needed if the node has multiple handles of the same type)
+ * @param param.handleId - filter by handle id. When used without `handleType`, returns connections for that handle regardless of type.
  * @param param.onConnect - gets called when a connection is established
  * @param param.onDisconnect - gets called when a connection is removed
  * @returns An array with connections
@@ -58,7 +58,7 @@ export function useNodeConnections({
     const prevConnections = connectionMaps.next;
     const nextConnections =
       connectionLookup.get(
-        `${nodeId}${handleType ? (handleId ? `-${handleType}-${handleId}` : `-${handleType}`) : ''}`
+        `${nodeId}${handleType ? (handleId ? `-${handleType}-${handleId}` : `-${handleType}`) : handleId ? `-${handleId}` : ''}`
       ) ?? new Map();
     if (!areConnectionMapsEqual(nextConnections, prevConnections)) {
       connectionMaps = {

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -545,7 +545,7 @@ export async function panBy({
 
 /**
  * this function adds the connection to the connectionLookup
- * at the following keys: nodeId-type-handleId, nodeId-type and nodeId
+ * at the following keys: nodeId-type-handleId, nodeId-handleId, nodeId-type and nodeId
  * @param type type of the connection
  * @param connection connection that should be added to the lookup
  * @param connectionKey at which key the connection should be added
@@ -563,7 +563,7 @@ function addConnectionToLookup(
 ) {
   /*
    * We add the connection to the connectionLookup at the following keys
-   * 1. nodeId, 2. nodeId-type, 3. nodeId-type-handleId
+   * 1. nodeId, 2. nodeId-type, 3. nodeId-type-handleId, 4. nodeId-handleId
    * If the key already exists, we add the connection to the existing map
    */
   let key = nodeId;
@@ -578,6 +578,10 @@ function addConnectionToLookup(
     key = `${nodeId}-${type}-${handleId}`;
     const handleMap = connectionLookup.get(key) || new Map();
     connectionLookup.set(key, handleMap.set(connectionKey, connection));
+
+    key = `${nodeId}-${handleId}`;
+    const handleOnlyMap = connectionLookup.get(key) || new Map();
+    connectionLookup.set(key, handleOnlyMap.set(connectionKey, connection));
   }
 }
 


### PR DESCRIPTION
Added a `nodeId-handleId` key to `connectionLookup` so that useNodeConnections can now filter by handleId alone.