### PR TITLE
fix(system): cancel dangling connection line when originating touch is lifted while another touch is active

### DIFF
--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -58,6 +58,7 @@ function onPointerDown(
   const handleType = getHandleType(edgeUpdaterType, handleDomNode);
   const containerBounds = domNode?.getBoundingClientRect();
   let connectionStarted = false;
+  const touchId = 'touches' in event ? event.changedTouches[0]?.identifier : undefined;
 
   if (!containerBounds || !handleType) {
     return;
@@ -196,9 +197,12 @@ function onPointerDown(
   }
 
   function onPointerUp(event: MouseEvent | TouchEvent) {
-    // Prevent multi-touch aborting connection
-    if ('touches' in event && event.touches.length > 0) {
-      return;
+    // Only handle the touch that started the connection
+    if ('changedTouches' in event && touchId !== undefined) {
+      const touch = Array.from(event.changedTouches).find((t) => t.identifier === touchId);
+      if (!touch) {
+        return;
+      }
     }
 
     if (connectionStarted) {

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -197,10 +197,15 @@ function onPointerDown(
   }
 
   function onPointerUp(event: MouseEvent | TouchEvent) {
-    // Only handle the touch that started the connection
     if ('changedTouches' in event && touchId !== undefined) {
-      const touch = Array.from(event.changedTouches).find((t) => t.identifier === touchId);
-      if (!touch) {
+      // ignore if the lifted finger is not the one that started the connection
+      const isOriginatingTouch = Array.from(event.changedTouches).some((t) => t.identifier === touchId);
+      if (!isOriginatingTouch) {
+        return;
+      }
+      // ignore if the originating touch is still active (e.g. second finger tapped and lifted while first is still down)
+      const stillActive = Array.from(event.touches).some((t) => t.identifier === touchId);
+      if (stillActive) {
         return;
       }
     }


### PR DESCRIPTION
### Problem
When dragging a connection line on a touch screen, if a second finger touches anywhere on the canvas while the first finger is dragging, lifting the first finger does not cancel the connection. This leaves the connection line dangling on screen until the second finger is also lifted.

### Root cause:
In onPointerUp, the current guard bails out early if the touchId of the lifted finger doesn't match the one that started the connection.This guard was intended to ignore unrelated touches, but it also ignores the originating touch when other fingers are still on the screen. 

### Fix
Check whether the touchend event contains the originating touch (touchId). If it does, always proceed with cleanup ;do not bail out. Only bail out when the lifted finger is a different, unrelated touch.

Fixes #5712 