### PR TITLE
fix: add type error when handleId is used without handleType in useNodeConnections

### DIFF
--- a/.changeset/clean-eyes-sleep.md
+++ b/.changeset/clean-eyes-sleep.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/react": patch
+"@xyflow/svelte": patch
+---
+
+Adds a type error when `handleId` is used without `handleType` in `useNodeConnections`

--- a/.changeset/clean-eyes-sleep.md
+++ b/.changeset/clean-eyes-sleep.md
@@ -1,6 +1,7 @@
 ---
 "@xyflow/react": patch
 "@xyflow/svelte": patch
+"@xyflow/system": patch
 ---
 
 Adds a type error when `handleId` is used without `handleType` in `useNodeConnections`

--- a/packages/react/src/hooks/useNodeConnections.ts
+++ b/packages/react/src/hooks/useNodeConnections.ts
@@ -16,15 +16,19 @@ const error014 = errorMessages['error014']();
 type UseNodeConnectionsParams = {
   /** ID of the node, filled in automatically if used inside custom node. */
   id?: string;
-  /** What type of handle connections do you want to observe? */
-  handleType?: HandleType;
-  /** Filter by handle id (this is only needed if the node has multiple handles of the same type). */
-  handleId?: string;
   /** Gets called when a connection is established. */
   onConnect?: (connections: HandleConnection[]) => void;
   /** Gets called when a connection is removed. */
   onDisconnect?: (connections: HandleConnection[]) => void;
-};
+} & (
+  | {
+      /** What type of handle connections do you want to observe? */
+      handleType: HandleType;
+      /** Filter by handle id (this is only needed if the node has multiple handles of the same type). Requires `handleType` to be set. */
+      handleId?: string;
+    }
+  | { handleType?: HandleType; handleId?: never }
+);
 
 /**
  * This hook returns an array of connections on a specific node, handle type ('source', 'target') or handle ID.

--- a/packages/react/src/hooks/useNodeConnections.ts
+++ b/packages/react/src/hooks/useNodeConnections.ts
@@ -4,31 +4,13 @@ import {
   errorMessages,
   handleConnectionChange,
   type NodeConnection,
-  type HandleType,
-  type HandleConnection,
+  type UseNodeConnectionsParams,
 } from '@xyflow/system';
 
 import { useStore } from './useStore';
 import { useNodeId } from '../contexts/NodeIdContext';
 
 const error014 = errorMessages['error014']();
-
-type UseNodeConnectionsParams = {
-  /** ID of the node, filled in automatically if used inside custom node. */
-  id?: string;
-  /** Gets called when a connection is established. */
-  onConnect?: (connections: HandleConnection[]) => void;
-  /** Gets called when a connection is removed. */
-  onDisconnect?: (connections: HandleConnection[]) => void;
-} & (
-  | {
-      /** What type of handle connections do you want to observe? */
-      handleType: HandleType;
-      /** Filter by handle id (this is only needed if the node has multiple handles of the same type). Requires `handleType` to be set. */
-      handleId?: string;
-    }
-  | { handleType?: HandleType; handleId?: never }
-);
 
 /**
  * This hook returns an array of connections on a specific node, handle type ('source', 'target') or handle ID.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -118,6 +118,7 @@ export {
   type HandleConnection,
   type ZIndexMode,
   type NodeHandle,
+  type UseNodeConnectionsParams,
 } from '@xyflow/system';
 
 // we need this workaround to prevent a duplicate identifier error

--- a/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
@@ -12,11 +12,12 @@ import { getNodeIdContext } from '$lib/store/context';
 
 type UseNodeConnectionsParams = {
   id?: string;
-  handleType?: HandleType;
-  handleId?: string;
   onConnect?: (connections: HandleConnection[]) => void;
   onDisconnect?: (connections: HandleConnection[]) => void;
-};
+} & (
+  | { handleType: HandleType; handleId?: string }
+  | { handleType?: HandleType; handleId?: never }
+);
 
 type ConnectionMap = Map<string, NodeConnection>;
 
@@ -28,7 +29,7 @@ const initialConnections: NodeConnection[] = [];
  * @public
  * @param param.id - node id - optional if called inside a custom node
  * @param param.handleType - filter by handle type 'source' or 'target'
- * @param param.handleId - filter by handle id (this is only needed if the node has multiple handles of the same type)
+ * @param param.handleId - filter by handle id (this is only needed if the node has multiple handles of the same type). Requires `handleType` to be set.
  * @param param.onConnect - gets called when a connection is established
  * @param param.onDisconnect - gets called when a connection is removed
  * @returns An array with connections

--- a/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useNodeConnections.svelte.ts
@@ -3,21 +3,11 @@ import {
   areConnectionMapsEqual,
   handleConnectionChange,
   type NodeConnection,
-  type HandleType,
-  type HandleConnection
+  type UseNodeConnectionsParams
 } from '@xyflow/system';
 
 import { useStore } from '$lib/store';
 import { getNodeIdContext } from '$lib/store/context';
-
-type UseNodeConnectionsParams = {
-  id?: string;
-  onConnect?: (connections: HandleConnection[]) => void;
-  onDisconnect?: (connections: HandleConnection[]) => void;
-} & (
-  | { handleType: HandleType; handleId?: string }
-  | { handleType?: HandleType; handleId?: never }
-);
 
 type ConnectionMap = Map<string, NodeConnection>;
 

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -124,7 +124,8 @@ export {
   type FitBounds,
   type HandleConnection,
   type ZIndexMode,
-  type NodeHandle
+  type NodeHandle,
+  type UseNodeConnectionsParams
 } from '@xyflow/system';
 
 // system utils

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -98,6 +98,23 @@ export type NodeConnection = Connection & {
   edgeId: string;
 };
 
+export type UseNodeConnectionsParams = {
+  /** ID of the node, filled in automatically if used inside custom node. */
+  id?: string;
+  /** Gets called when a connection is established. */
+  onConnect?: (connections: HandleConnection[]) => void;
+  /** Gets called when a connection is removed. */
+  onDisconnect?: (connections: HandleConnection[]) => void;
+} & (
+  | {
+      /** What type of handle connections do you want to observe? */
+      handleType: HandleType;
+      /** Filter by handle id (this is only needed if the node has multiple handles of the same type). Requires `handleType` to be set. */
+      handleId?: string;
+    }
+  | { handleType?: HandleType; handleId?: never }
+);
+
 /**
  * The `ConnectionMode` is used to set the mode of connection between nodes.
  * The `Strict` mode is the default one and only allows source to target edges.


### PR DESCRIPTION
Peter and I chatted, and we decided the best solution to this would be to keep the functionality of useNodeConnections the same and just add a type error to point users in the right direction. 