### PR TITLE
fix(svelte): pass ariaLabel to node wrapper

### DIFF
--- a/.changeset/green-dryers-cough.md
+++ b/.changeset/green-dryers-cough.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/svelte': patch
+---
+
+Pass aria label to node dom element

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -291,6 +291,7 @@
     onfocus={focusable ? onFocus : undefined}
     tabIndex={focusable ? 0 : undefined}
     role={node.ariaRole ?? (focusable ? 'group' : undefined)}
+    aria-label={node.ariaLabel}
     aria-roledescription="node"
     aria-describedby={store.disableKeyboardA11y
       ? undefined


### PR DESCRIPTION
## Summary

This PR fixes an issue in `@xyflow/svelte` where the `ariaLabel` property defined on a node was not passed to the rendered DOM element.

### Changes

- Added `aria-label={node.ariaLabel}` to `NodeWrapper.svelte`

### Result

Nodes configured with an `ariaLabel` now correctly render an `aria-label` attribute on the corresponding `.svelte-flow__node` element.

Fixes #5799