### PR TITLE
fix(react): stop firing onPaneClick when a connection drag ends on the pane background

### DIFF
--- a/.changeset/pane-click-after-connection-drag.md
+++ b/.changeset/pane-click-after-connection-drag.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Stop firing `onPaneClick` when a connection drag ends on the pane background

--- a/examples/react/src/generic-tests/pane/connection-drag.ts
+++ b/examples/react/src/generic-tests/pane/connection-drag.ts
@@ -1,0 +1,35 @@
+// Fixture for tests covering https://github.com/xyflow/xyflow/issues/5757
+// Ending a connection drag on the pane background must NOT trigger `onPaneClick`.
+
+export default {
+  flowProps: {
+    minZoom: 0.25,
+    maxZoom: 4,
+    fitView: true,
+    nodes: [
+      {
+        id: 'source',
+        position: { x: 0, y: 0 },
+        data: { label: 'source' },
+      },
+      {
+        id: 'target',
+        position: { x: 200, y: 200 },
+        data: { label: 'target' },
+      },
+    ],
+    edges: [
+      {
+        id: 'first-edge',
+        source: 'source',
+        target: 'target',
+      },
+    ],
+    onPaneClick: () => {
+      // Record each pane click on the window so a Playwright test can assert
+      // that drag-end of a connection does not synthesise a spurious click.
+      const w = window as unknown as { __paneClicks?: number };
+      w.__paneClicks = (w.__paneClicks ?? 0) + 1;
+    },
+  },
+} satisfies FlowConfig;

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -105,15 +105,28 @@ export function Pane({
   // Used to prevent click events when the user lets go of the selectionKey during a selection
   const selectionInProgress = useRef<boolean>(false);
 
+  // Used to suppress the click that the browser synthesises from the
+  // mousedown/mouseup pair at the end of a connection drag. By the time the
+  // click reaches the pane the store's `connection.inProgress` has already
+  // been reset to `false` in `XYHandle.onPointerUp`, so checking the flag
+  // directly inside `onClick` is too late. Mirror the flag in a ref that is
+  // latched whenever a connection is in progress and consumed on the next
+  // pane click (#5757).
+  const connectionEndedSinceLastClick = useRef<boolean>(false);
+  if (connectionInProgress) {
+    connectionEndedSinceLastClick.current = true;
+  }
+
   // Used for auto pan when approaching the edges of the container during selection
   const position = useRef<XYPosition>({ x: 0, y: 0 });
   const autoPanStarted = useRef<boolean>(false);
 
   const onClick = (event: ReactMouseEvent) => {
     // We prevent click events when the user let go of the selectionKey during a selection
-    // We also prevent click events when a connection is in progress
-    if (selectionInProgress.current || connectionInProgress) {
+    // We also prevent click events when a connection has just ended (#5757)
+    if (selectionInProgress.current || connectionInProgress || connectionEndedSinceLastClick.current) {
       selectionInProgress.current = false;
+      connectionEndedSinceLastClick.current = false;
       return;
     }
 

--- a/tests/playwright/e2e/pane.spec.ts
+++ b/tests/playwright/e2e/pane.spec.ts
@@ -130,6 +130,63 @@ test.describe('Pane default', () => {
   });
 });
 
+// https://github.com/xyflow/xyflow/issues/5757 — `onPaneClick` was being fired
+// when the user ended a connection drag on the pane background (or close to but
+// not exactly on top of) a handle. The click event that the browser synthesises
+// from the mousedown/mouseup pair leaks to the pane's `onClick` handler because
+// `connectionInProgress` has already been reset to `false` by the time the
+// handler runs, so the early-return inside the handler doesn't fire.
+test.describe('Pane connection drag', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/generic/pane/connection-drag');
+    await page.waitForSelector('[data-id="first-edge"]', { timeout: 5000 });
+    await page.evaluate(() => {
+      (window as unknown as { __paneClicks?: number }).__paneClicks = 0;
+    });
+  });
+
+  test('dragging a connection onto the pane background does not fire onPaneClick', async ({ page }) => {
+    const sourceHandle = page.locator(`[data-id="source"] .${FRAMEWORK}-flow__handle.source`);
+    const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+
+    await expect(sourceHandle).toBeAttached();
+    await expect(pane).toBeAttached();
+
+    const paneBox = await pane.boundingBox();
+    if (!paneBox) throw new Error('pane has no bounding box');
+
+    // Drag from the source handle to an empty area in the bottom-right
+    // quadrant of the pane. The empty area is far from both nodes so the
+    // pointer ends up on the pane background, which is exactly the case the
+    // reporter's video shows.
+    await sourceHandle.hover();
+    await page.mouse.down();
+    await page.mouse.move(paneBox.x + paneBox.width - 40, paneBox.y + paneBox.height - 40, { steps: 20 });
+    await page.mouse.up();
+
+    // Give React a tick to flush the click event that the browser synthesises
+    // from the mousedown/mouseup pair.
+    await page.waitForTimeout(50);
+
+    const paneClicks = await page.evaluate(() => (window as unknown as { __paneClicks?: number }).__paneClicks);
+    expect(paneClicks).toBe(0);
+  });
+
+  test('a real click on the pane background still fires onPaneClick', async ({ page }) => {
+    const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+    await expect(pane).toBeAttached();
+
+    const paneBox = await pane.boundingBox();
+    if (!paneBox) throw new Error('pane has no bounding box');
+
+    await page.mouse.click(paneBox.x + paneBox.width - 40, paneBox.y + paneBox.height - 40);
+    await page.waitForTimeout(50);
+
+    const paneClicks = await page.evaluate(() => (window as unknown as { __paneClicks?: number }).__paneClicks);
+    expect(paneClicks).toBe(1);
+  });
+});
+
 test.describe('Pane non-default', () => {
   test.beforeEach(async ({ page }) => {
     // Go to the starting url before each test.


### PR DESCRIPTION
## What

Drop a new connection drag on the pane background (or end up next to a handle but not directly on top of it) and `onPaneClick` fires unexpectedly. The reporter's video on #5757 shows the symptom — every "miss" of a handle is read by the host app as a deliberate click on empty space.

After this PR, `onPaneClick` is correctly suppressed for the click event that the browser synthesises from the mousedown/mouseup pair at the end of a connection drag. Real pane clicks are unaffected.

Closes #5757.

## Why / root cause

The Pane's `onClick` already has an early-return for this case:

```tsx
const onClick = (event: ReactMouseEvent) => {
  if (selectionInProgress.current || connectionInProgress) {
    selectionInProgress.current = false;
    return;
  }
  onPaneClick?.(event);
  ...
};
```

The flag the early-return reads is `connection.inProgress` from the store. The problem is the order in which the browser dispatches the events at the end of a connection drag:

1. `mouseup` fires
2. `XYHandle.onPointerUp` runs synchronously, calls `cancelConnection()`, and `store.connection.inProgress` is set to `false`
3. React re-renders Pane; the new render closes over `connectionInProgress = false`
4. The browser then dispatches the synthesised `click` to the pane (common ancestor of the handle that received `mousedown` and the pane that received `mouseup`)
5. `onClick` runs and reads `false`, the early-return doesn't fire, `onPaneClick` is called

By the time `onClick` runs, the store has already forgotten that a connection ended. The check has to remember "a connection ended during this exact pointer interaction" instead of "a connection is in progress right now."

The fix mirrors the in-progress state into a ref (`connectionEndedSinceLastClick`) that is latched whenever the store reports `inProgress: true` and consumed by `onClick`. The ref survives the synchronous reset between `mouseup` and the synthesised `click`, but a subsequent independent click clears the ref and behaves normally — `onPaneClick` fires as before.

The set-side mutation lives directly in the render body (idempotent — only ever sets `true`); the reset lives in `onClick`. This mirrors the existing `selectionInProgress` pattern in the same file.

## Tests added

`tests/playwright/e2e/pane.spec.ts` gains a new `Pane connection drag` describe block backed by a new fixture at `examples/react/src/generic-tests/pane/connection-drag.ts`. The fixture exposes `onPaneClick` and counts invocations on `window.__paneClicks`. Two cases:

1. **`dragging a connection onto the pane background does not fire onPaneClick`** — the bug case. Hover the source handle, `mouse.down`, `mouse.move` to an empty corner, `mouse.up`. Without this PR, `window.__paneClicks === 1`; with it, `=== 0`.
2. **`a real click on the pane background still fires onPaneClick`** — negative regression. A plain `page.mouse.click` on the same empty corner must still result in `window.__paneClicks === 1`. Guards the fix against being too aggressive.

Verified the red-baseline -> fix -> green-baseline loop locally:

- Before the fix: case 1 fails with `Expected: 0 Received: 1`, case 2 passes.
- After the fix: all 10 tests in `pane.spec.ts` pass on chromium, including the existing `autoPanOnConnect` and `autoPanOnNodeDrag` tests that touch overlapping pointer-event paths.

## Repro

`/tests/generic/pane/connection-drag` (the new fixture) is the simplest in-repo repro. Existing repro from #5757:

```tsx
const onPaneClick = useCallback((evt) => {
  console.log('on pane click', evt);
}, []);

<ReactFlow nodes={...} edges={...} onPaneClick={onPaneClick} />
```

Drag a new connection from a handle, release on the pane background, watch the console.

## Validation

```bash
pnpm build                                                                          # @xyflow/react patches cleanly
pnpm --filter=playwright run test:react -- --project=chromium pane.spec.ts          # 10/10 passing
pnpm --filter=playwright run test:react -- --project=chromium edges.spec.ts         # 16/16 passing (no regression on edge interactions)
```

Changeset added as a `patch` bump on `@xyflow/react`.

## Notes

This patch covers `@xyflow/react`. The Svelte equivalent has the same shape (the connection lifecycle lives in `@xyflow/system`), but the Svelte pane handlers live in a separate file and follow a slightly different reactivity model. Left out of this PR to keep the diff scoped to the case the reporter filmed; can ship a sibling Svelte PR on request.