### PR TITLE
fix(types): make FinalConnectionState narrowable (#5810)

### DIFF
--- a/.changeset/final-connection-state-types.md
+++ b/.changeset/final-connection-state-types.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/system': patch
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Fix `FinalConnectionState` type so it preserves the discriminated union. Previously `Omit` was applied to the `ConnectionState` union, collapsing both arms and making every field nullable. It now distributes over the union, so fields like `fromHandle`, `from` and `fromNode` keep their non-null types in the connection-in-progress case and can be narrowed correctly.

--- a/.changeset/final-connection-state-types.md
+++ b/.changeset/final-connection-state-types.md
@@ -4,4 +4,4 @@
 '@xyflow/svelte': patch
 ---
 
-Fix `FinalConnectionState` type so it preserves the discriminated union. Previously `Omit` was applied to the `ConnectionState` union, collapsing both arms and making every field nullable. It now distributes over the union, so fields like `fromHandle`, `from` and `fromNode` keep their non-null types in the connection-in-progress case and can be narrowed correctly.
+Fix `FinalConnectionState` type so it preserves the discriminated union. 

--- a/packages/react/src/components/Handle/index.tsx
+++ b/packages/react/src/components/Handle/index.tsx
@@ -19,6 +19,7 @@ import {
   ConnectionMode,
   OnConnect,
   ConnectionState,
+  FinalConnectionState,
   Optional,
 } from '@xyflow/system';
 
@@ -209,7 +210,7 @@ function HandleComponent(
     const connectionClone = structuredClone(connectionState) as Optional<ConnectionState, 'inProgress'>;
     delete connectionClone.inProgress;
     connectionClone.toPosition = connectionClone.toHandle ? connectionClone.toHandle.position : null;
-    onClickConnectEnd?.(event as unknown as MouseEvent, connectionClone);
+    onClickConnectEnd?.(event as unknown as MouseEvent, connectionClone as FinalConnectionState);
 
     store.setState({ connectionClickStartHandle: null });
   };

--- a/packages/svelte/src/lib/components/Handle/Handle.svelte
+++ b/packages/svelte/src/lib/components/Handle/Handle.svelte
@@ -10,6 +10,7 @@
     type HandleConnection,
     type Optional,
     type ConnectionState,
+    type FinalConnectionState,
     type Connection
   } from '@xyflow/system';
 
@@ -185,7 +186,7 @@
     connectionClone.toPosition = connectionClone.toHandle
       ? connectionClone.toHandle.position
       : null;
-    store.onclickconnectend?.(event, connectionClone);
+    store.onclickconnectend?.(event, connectionClone as FinalConnectionState);
 
     store.clickConnectStartHandle = null;
   }

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -369,10 +369,9 @@ export type ConnectionState<NodeType extends InternalNodeBase = InternalNodeBase
   | ConnectionInProgress<NodeType>
   | NoConnection;
 
-export type FinalConnectionState<NodeType extends InternalNodeBase = InternalNodeBase> = Omit<
-  ConnectionState<NodeType>,
-  'inProgress'
->;
+export type FinalConnectionState<NodeType extends InternalNodeBase = InternalNodeBase> =
+  | (Omit<ConnectionInProgress<NodeType>, 'inProgress' | 'toPosition'> & { toPosition: Position | null })
+  | Omit<NoConnection, 'inProgress'>;
 
 export type UpdateConnection<NodeType extends InternalNodeBase = InternalNodeBase> = (
   params: ConnectionState<NodeType>


### PR DESCRIPTION
## Fixes #5810

`FinalConnectionState` was defined as `Omit<ConnectionState, 'inProgress'>`. Since `ConnectionState` is a discriminated union (`ConnectionInProgress | NoConnection`), applying `Omit` to the union collapses both arms into a single object type — so every field (e.g. `fromHandle`, `from`, `fromNode`) became nullable, even though they are always non-null while a connection is in progress.

This distributes the `Omit` over each arm so the discriminated union is preserved and consumers can narrow correctly:

```ts
export type FinalConnectionState<NodeType extends InternalNodeBase = InternalNodeBase> =
  | (Omit<ConnectionInProgress<NodeType>, 'inProgress' | 'toPosition'> & { toPosition: Position | null })
  | Omit<NoConnection, 'inProgress'>;
```

`toPosition` is overridden to `Position | null` because the runtime sets it to `null` on connection end when there is no target handle (see `XYHandle.onPointerUp`), so the in-progress arm of the *final* state must allow it.

### Changes
- `@xyflow/system`: distribute `Omit` across the union in `FinalConnectionState`.
- `@xyflow/react` / `@xyflow/svelte`: assert `FinalConnectionState` at the `onClickConnectEnd` callback boundary, where the final state is built imperatively.

### Verification
- `tsc --noEmit` passes for `@xyflow/system` and `@xyflow/react`.
- `svelte-check` passes for `@xyflow/svelte` (0 errors).

Approach approved by @moklick in #5810.