### PR TITLE
perf(react): read shared handle config from context instead of subscribing per handle

### DIFF
--- a/.changeset/handle-config-context.md
+++ b/.changeset/handle-config-context.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Provide the shared handle config (`connectOnClick`, `noPanClassName`, `rfId`) through context instead of subscribing to the store in every `Handle`, so a store update no longer runs a selector once per handle

--- a/packages/react/src/components/Handle/index.tsx
+++ b/packages/react/src/components/Handle/index.tsx
@@ -25,6 +25,7 @@ import {
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
 import { useNodeId } from '../../contexts/NodeIdContext';
+import { useHandleConfig } from '../../contexts/HandleConfigContext';
 import { type ReactFlowState } from '../../types';
 import { fixedForwardRef } from '../../utils';
 import { addEdge } from '../../utils/edges';
@@ -37,12 +38,6 @@ export type HandleProps = HandlePropsSystem &
     /** Callback called when connection is made */
     onConnect?: OnConnect;
   };
-
-const selector = (s: ReactFlowState) => ({
-  connectOnClick: s.connectOnClick,
-  noPanClassName: s.noPanClassName,
-  rfId: s.rfId,
-});
 
 const connectingSelector =
   (nodeId: string | null, handleId: string | null, type: HandleType) => (state: ReactFlowState) => {
@@ -86,7 +81,7 @@ function HandleComponent(
   const isTarget = type === 'target';
   const store = useStoreApi();
   const nodeId = useNodeId();
-  const { connectOnClick, noPanClassName, rfId } = useStore(selector, shallow);
+  const { connectOnClick, noPanClassName, rfId } = useHandleConfig();
   const {
     connectingFrom,
     connectingTo,

--- a/packages/react/src/components/ReactFlowProvider/index.tsx
+++ b/packages/react/src/components/ReactFlowProvider/index.tsx
@@ -3,6 +3,7 @@ import { useState, type ReactNode } from 'react';
 import { Provider } from '../../contexts/StoreContext';
 import { createStore } from '../../store';
 import { BatchProvider } from '../BatchProvider';
+import { HandleConfigProvider } from '../../contexts/HandleConfigContext';
 import type { Node, Edge, FitViewOptions } from '../../types';
 import { CoordinateExtent, NodeOrigin, ZIndexMode } from '@xyflow/system';
 
@@ -121,7 +122,9 @@ export function ReactFlowProvider({
 
   return (
     <Provider value={store}>
-      <BatchProvider>{children}</BatchProvider>
+      <BatchProvider>
+        <HandleConfigProvider>{children}</HandleConfigProvider>
+      </BatchProvider>
     </Provider>
   );
 }

--- a/packages/react/src/contexts/HandleConfigContext.tsx
+++ b/packages/react/src/contexts/HandleConfigContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { shallow } from 'zustand/shallow';
+
+import { useStore } from '../hooks/useStore';
+import type { ReactFlowState } from '../types';
+
+type HandleConfig = {
+  connectOnClick: boolean;
+  noPanClassName: string;
+  rfId: string;
+};
+
+const selector = (s: ReactFlowState): HandleConfig => ({
+  connectOnClick: s.connectOnClick,
+  noPanClassName: s.noPanClassName,
+  rfId: s.rfId,
+});
+
+const HandleConfigContext = createContext<HandleConfig | null>(null);
+
+/*
+ * `connectOnClick`, `noPanClassName` and `rfId` are the same for every handle, so they are
+ * shared through context from a single store subscription.
+ */
+export function HandleConfigProvider({ children }: { children: ReactNode }) {
+  const config = useStore(selector, shallow);
+  return <HandleConfigContext.Provider value={config}>{children}</HandleConfigContext.Provider>;
+}
+
+export function useHandleConfig() {
+  const config = useContext(HandleConfigContext);
+
+  if (!config) {
+    throw new Error('useHandleConfig must be used within a HandleConfigProvider');
+  }
+
+  return config;
+}


### PR DESCRIPTION
While profiling a canvas with many handles I noticed every store update (pan, zoom, drag, selection) runs a selector once per handle. Each `<Handle>` subscribes to the store for `connectOnClick`, `noPanClassName` and `rfId`, but those are flow level config that is identical for every handle, so with N handles that is N selector runs that all return the same thing and bail out.

I moved these three values into a small context provided once near the top of the flow (in `ReactFlowProvider`, so it covers the nodes and any handle a user renders in `children`). A single subscription reads them (with `shallow`, so the reference stays stable) and `Handle` reads them from context, which removes the per-handle subscriptions from the store fan-out.

The behavior is the same. These values are global, so changing one of them already re-rendered every handle before (they all read it). The context value changes only when one of the three actually changes, so handles still re-render exactly then, and not on pan/zoom/drag. The way you set them is unchanged too, they are still `ReactFlow` props synced into the store by `StoreUpdater`.

Before/after on the Stress example (625 nodes / 1250 handles), measuring the synchronous fan-out of a transform `setState`: around 25% faster per update (698us to 523us here).
