### PR TITLE
refactor(edges): don't create new object when edge returns early beca…

### DIFF
--- a/.changeset/nine-nails-smoke.md
+++ b/.changeset/nine-nails-smoke.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/react": patch
+---
+
+Return stable reference for edge position when connected node gets deleted
+  

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -60,17 +60,22 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
   const [reconnecting, setReconnecting] = useState<boolean>(false);
   const store = useStoreApi();
 
-  const { zIndex, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition } = useStore(
+  const {
+    zIndex = edge.zIndex,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  } = useStore(
     useCallback(
       (store) => {
         const sourceNode = store.nodeLookup.get(edge.source);
         const targetNode = store.nodeLookup.get(edge.target);
 
         if (!sourceNode || !targetNode) {
-          return {
-            zIndex: edge.zIndex,
-            ...nullPosition,
-          };
+          return nullPosition;
         }
 
         const edgePosition = getEdgePosition({
@@ -93,8 +98,8 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
         });
 
         return {
-          zIndex,
           ...(edgePosition || nullPosition),
+          zIndex,
         };
       },
       [edge.source, edge.target, edge.sourceHandle, edge.targetHandle, edge.selected, edge.zIndex]

--- a/packages/react/src/components/EdgeWrapper/utils.ts
+++ b/packages/react/src/components/EdgeWrapper/utils.ts
@@ -22,4 +22,5 @@ export const nullPosition = {
   targetY: null,
   sourcePosition: null,
   targetPosition: null,
+  zIndex: undefined,
 };


### PR DESCRIPTION
…use connected no was deleted