### PR TITLE
perf(react): only create an XYDrag instance for draggable nodes

### DIFF
--- a/.changeset/drag-instance-draggable-only.md
+++ b/.changeset/drag-instance-draggable-only.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Only create an `XYDrag` instance for draggable nodes. A non-draggable node no longer allocates one on mount, so static and read-only graphs pay nothing for drag setup (the saving scales with the number of non-draggable nodes). Draggable nodes are unaffected.

--- a/packages/react/src/container/GraphView/index.tsx
+++ b/packages/react/src/container/GraphView/index.tsx
@@ -105,6 +105,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
   rfId,
   viewport,
   onViewportChange,
+  nodesDraggable,
 }: GraphViewProps<NodeType, EdgeType>) {
   useNodeOrEdgeTypesWarning(nodeTypes);
   useNodeOrEdgeTypesWarning(edgeTypes);
@@ -194,6 +195,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
           disableKeyboardA11y={disableKeyboardA11y}
           nodeExtent={nodeExtent}
           rfId={rfId}
+          nodesDraggable={nodesDraggable}
         />
         <div className="react-flow__viewport-portal" />
       </Viewport>

--- a/packages/react/src/container/NodeRenderer/index.tsx
+++ b/packages/react/src/container/NodeRenderer/index.tsx
@@ -25,10 +25,10 @@ export type NodeRendererProps<NodeType extends Node> = Pick<
   | 'nodeExtent'
   | 'nodeTypes'
   | 'nodeClickDistance'
+  | 'nodesDraggable'
 >;
 
 const selector = (s: ReactFlowState) => ({
-  nodesDraggable: s.nodesDraggable,
   nodesConnectable: s.nodesConnectable,
   nodesFocusable: s.nodesFocusable,
   elementsSelectable: s.elementsSelectable,
@@ -36,7 +36,7 @@ const selector = (s: ReactFlowState) => ({
 });
 
 function NodeRendererComponent<NodeType extends Node>(props: NodeRendererProps<NodeType>) {
-  const { nodesDraggable, nodesConnectable, nodesFocusable, elementsSelectable, onError } = useStore(selector, shallow);
+  const { nodesConnectable, nodesFocusable, elementsSelectable, onError } = useStore(selector, shallow);
   const nodeIds = useVisibleNodeIds(props.onlyRenderVisibleElements);
   const resizeObserver = useResizeObserver();
 
@@ -85,7 +85,7 @@ function NodeRendererComponent<NodeType extends Node>(props: NodeRendererProps<N
             rfId={props.rfId}
             disableKeyboardA11y={props.disableKeyboardA11y}
             resizeObserver={resizeObserver}
-            nodesDraggable={nodesDraggable}
+            nodesDraggable={props.nodesDraggable ?? true}
             nodesConnectable={nodesConnectable}
             nodesFocusable={nodesFocusable}
             elementsSelectable={elementsSelectable}

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -316,6 +316,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
           nodeExtent={nodeExtent}
           viewport={viewport}
           onViewportChange={onViewportChange}
+          nodesDraggable={nodesDraggable}
         />
         <SelectionListener<NodeType, EdgeType> onSelectionChange={onSelectionChange} />
         {children}

--- a/packages/react/src/hooks/useDrag.ts
+++ b/packages/react/src/hooks/useDrag.ts
@@ -33,6 +33,10 @@ export function useDrag({
   const xyDrag = useRef<XYDragInstance>();
 
   useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
     xyDrag.current = XYDrag({
       getStoreItems: () => store.getState(),
       onNodeMouseDown: (id: string) => {
@@ -49,7 +53,12 @@ export function useDrag({
         setDragging(false);
       },
     });
-  }, []);
+
+    return () => {
+      xyDrag.current?.destroy();
+      xyDrag.current = undefined;
+    };
+  }, [disabled, store, nodeRef]);
 
   useEffect(() => {
     if (disabled || !nodeRef.current || !xyDrag.current) {
@@ -64,10 +73,6 @@ export function useDrag({
       nodeId,
       nodeClickDistance,
     });
-
-    return () => {
-      xyDrag.current?.destroy();
-    };
   }, [noDragClassName, handleSelector, disabled, isSelectable, nodeRef, nodeId, nodeClickDistance]);
 
   return dragging;


### PR DESCRIPTION
### What this does

`useDrag` (per node) built an `XYDrag` instance for every node on mount, including
non-draggable ones. The `.update()` that attaches the d3-drag listeners was already gated on
`!disabled`, but the instance itself was always constructed. This gates creation on `!disabled`
too, so a non-draggable node never allocates one.

The win is mount and init cost, not the drag hot path: read-only or mostly-static canvases, and
the non-draggable nodes in any graph, no longer build an `XYDrag` (and attach d3-drag listeners)
they will never use. The saving scales with the number of non-draggable nodes.

The create effect now owns the instance lifecycle: create when draggable, destroy on unmount or
when draggability toggles off. The update effect just reconfigures in place. `update()` re-binds
via `selection.call(drag)`, and d3 replaces the `.drag`-namespaced listeners rather than stacking
them, so the previous per-prop-change destroy and rebuild was redundant.

### No behavior change

Draggable nodes still drag. Non-draggable nodes still don't move and stay click-selectable.
Marquee and box-select (handled in `Pane` / `UserSelection`, not `useDrag`) and selection-box
drag (`NodesSelection`, which already gates on `disabled: !shouldRender`) are unaffected.

### Verification

`tsc` and eslint clean. e2e drag suite green (24/24): `draghandle.cy.ts` covers the
`handleSelector` reconfiguration path; `interaction.cy.ts` covers drag, the draggable toggle,
non-draggable nodes, selection, and connection.
