### PR TITLE
feat(react): opt-in skipMeasurement to skip the per-node measurement pass

### DIFF
--- a/.changeset/skip-measurement.md
+++ b/.changeset/skip-measurement.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/react': minor
+'@xyflow/svelte': minor
+'@xyflow/system': patch
+---
+
+Add an opt-in `skipMeasurement` flag on nodes. It is honored only while you provide the values it would otherwise measure: real dimensions (`width`/`height` or `measured`) and `handles` (use `handles: []` for a node without handles). While honored the node is never measured (not by the ResizeObserver, on type/handle-position changes, nor by an explicit `updateNodeInternals`), so the per-node measurement pass is skipped entirely on mount and on add; those provided values are authoritative. If the values are missing the flag is ignored and the node is measured normally, so it cannot render broken. Useful for static or read-only nodes whose size the app already knows; the saving scales with the number of handles per node. Opt-in, so the default path is unchanged.

--- a/packages/react/src/components/NodeWrapper/useNodeObserver.ts
+++ b/packages/react/src/components/NodeWrapper/useNodeObserver.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { isSkipMeasurementHonored } from '@xyflow/system';
 
 import type { InternalNode } from '../../types';
 import { useStoreApi } from '../../hooks/useStore';
@@ -27,8 +28,23 @@ export function useNodeObserver({
   const prevTargetPosition = useRef(node.targetPosition);
   const prevType = useRef(nodeType);
   const isInitialized = hasDimensions && !!node.internals.handleBounds;
+  /*
+   * opt-in, honored only once the app has actually provided the values (dimensions + user `handles`);
+   * shared with adoptUserNodes and the Svelte wrapper so all sites agree. Gating on the user-provided
+   * `handles` rather than `internals.handleBounds` is deliberate: a measurement only writes
+   * `internals.handleBounds`, so a node that opts in without providing `handles` keeps measuring
+   * normally instead of getting measured once and then skipping.
+   */
+  const skipMeasurement = isSkipMeasurementHonored(node);
 
   useEffect(() => {
+    if (skipMeasurement) {
+      if (observedNode.current) {
+        resizeObserver?.unobserve(observedNode.current);
+        observedNode.current = null;
+      }
+      return;
+    }
     if (nodeRef.current && !node.hidden && (!isInitialized || observedNode.current !== nodeRef.current)) {
       if (observedNode.current) {
         resizeObserver?.unobserve(observedNode.current);
@@ -36,7 +52,7 @@ export function useNodeObserver({
       resizeObserver?.observe(nodeRef.current);
       observedNode.current = nodeRef.current;
     }
-  }, [isInitialized, node.hidden]);
+  }, [skipMeasurement, isInitialized, node.hidden]);
 
   useEffect(() => {
     return () => {
@@ -48,6 +64,13 @@ export function useNodeObserver({
   }, []);
 
   useEffect(() => {
+    /*
+     * a node that opts in provides its own handles, so the edges follow the data; we must not force a
+     * DOM read here, otherwise the measurement we skipped on mount comes back on every handle change
+     */
+    if (skipMeasurement) {
+      return;
+    }
     if (nodeRef.current) {
       /*
        * when the user programmatically changes the source or handle position, we need to update the internals
@@ -67,7 +90,7 @@ export function useNodeObserver({
           .updateNodeInternals(new Map([[node.id, { id: node.id, nodeElement: nodeRef.current, force: true }]]));
       }
     }
-  }, [node.id, nodeType, node.sourcePosition, node.targetPosition]);
+  }, [skipMeasurement, node.id, nodeType, node.sourcePosition, node.targetPosition]);
 
   return nodeRef;
 }

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -4,6 +4,7 @@
     elementSelectionKeys,
     errorMessages,
     isInputDOMNode,
+    isSkipMeasurementHonored,
     nodeHasDimensions,
     Position,
     getNodesInside
@@ -73,6 +74,9 @@
   let hasDimensions = $derived(nodeHasDimensions(node));
   let hasHandleBounds = $derived(!!node.internals.handleBounds);
   let isInitialized = $derived(hasDimensions && hasHandleBounds);
+  // opt-in, honored only once the app has provided the values (dimensions + user `handles`); shared
+  // predicate with adoptUserNodes and the React wrapper so all sites agree on "honored"
+  let skipMeasurement = $derived(isSkipMeasurementHonored(node));
   let focusable = $derived(_focusable ?? store.nodesFocusable);
 
   function isInParentLookup(id: string) {
@@ -131,7 +135,7 @@
       sourcePosition !== prevSourcePosition ||
       targetPosition !== prevTargetPosition;
 
-    if (doUpdate && nodeRef !== null) {
+    if (!skipMeasurement && doUpdate && nodeRef !== null) {
       requestAnimationFrame(() => {
         if (nodeRef !== null) {
           store.updateNodeInternals(
@@ -157,6 +161,14 @@
 
   $effect(() => {
     /* eslint-disable @typescript-eslint/no-unused-expressions */
+    if (skipMeasurement) {
+      if (prevNodeRef) {
+        resizeObserver?.unobserve(prevNodeRef);
+        prevNodeRef = null;
+      }
+      return;
+    }
+
     if (resizeObserver && (!isInitialized || nodeRef !== prevNodeRef)) {
       prevNodeRef && resizeObserver.unobserve(prevNodeRef);
       nodeRef && resizeObserver.observe(nodeRef);

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -77,6 +77,16 @@ export type NodeBase<
     width?: number;
     height?: number;
   };
+  /**
+   * Opt out of dimension and handle measurement. It is honored only while you provide the values it
+   * would otherwise measure: real dimensions (`width`/`height` or `measured`) and `handles` (use
+   * `handles: []` for a node without handles). While honored the node is never measured (not by the
+   * ResizeObserver, on type/handle-position changes, nor by an explicit `updateNodeInternals`), and
+   * those values are authoritative. If the values are missing (or removed later) the flag is ignored
+   * and the node is measured normally, so it cannot render broken. Set it only when your dimensions
+   * and handles are correct and the node does not resize after mount.
+   */
+  skipMeasurement?: boolean;
 } & (undefined extends NodeType
   ? {
       /** Type of node defined in nodeTypes */

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -369,6 +369,21 @@ export function nodeHasDimensions<NodeType extends NodeBase = NodeBase>(node: No
 }
 
 /**
+ * Whether a node's opt-in `skipMeasurement` should be honored. It is honored only when the values it
+ * would otherwise measure are actually provided: real dimensions (`width`/`height` or `measured`,
+ * not the `initialWidth`/`initialHeight` estimates, which are placeholders until measured) and
+ * `handles` (use `handles: []` for a node without handles). Otherwise the flag is ignored and the
+ * node is measured normally, so it cannot render broken.
+ *
+ * @internal
+ */
+export function isSkipMeasurementHonored<NodeType extends NodeBase = NodeBase>(node: NodeType): boolean {
+  const hasWidth = (node.measured?.width ?? node.width) !== undefined;
+  const hasHeight = (node.measured?.height ?? node.height) !== undefined;
+  return !!node.skipMeasurement && hasWidth && hasHeight && !!node.handles;
+}
+
+/**
  * Convert child position to absolute position
  *
  * @internal

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -25,6 +25,7 @@ import {
   getNodeDimensions,
   isCoordinateExtent,
   isNumeric,
+  isSkipMeasurementHonored,
   nodeToRect,
 } from './general';
 import { getNodePositionWithOrigin } from './graph';
@@ -153,12 +154,21 @@ export function adoptUserNodes<NodeType extends NodeBase>(
       const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : _options.nodeExtent;
       const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
 
+      // skipMeasurement is honored only when the values it replaces are actually provided (dimensions
+      // + handles); otherwise the flag is ignored and the node is measured normally, so we keep the
+      // regular `measured` seeding here too. Shared predicate so all sites agree on "honored".
+      const useProvidedDimensions = isSkipMeasurementHonored(userNode);
+
       internalNode = {
         ..._options.defaults,
         ...userNode,
         measured: {
-          width: userNode.measured?.width,
-          height: userNode.measured?.height,
+          width: useProvidedDimensions
+            ? userNode.width ?? userNode.measured?.width ?? userNode.initialWidth
+            : userNode.measured?.width,
+          height: useProvidedDimensions
+            ? userNode.height ?? userNode.measured?.height ?? userNode.initialHeight
+            : userNode.measured?.height,
         },
         internals: {
           positionAbsolute: clampedPosition,
@@ -423,6 +433,12 @@ export function updateNodeInternals<NodeType extends InternalNodeBase>(
   for (const update of updates.values()) {
     const node = nodeLookup.get(update.id);
     if (!node) {
+      continue;
+    }
+
+    // a node that opts in (with values provided) is authoritative: never measure it from the DOM, not
+    // even via an explicit updateNodeInternals (force), so its provided measured/handleBounds stand
+    if (isSkipMeasurementHonored(node)) {
       continue;
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #5834 (the fitView-on-init fix). Merge that one first.**
> `skipMeasurement` makes nodes initialize synchronously, which in React exposes a pre-existing
> fitView-on-init race: the queued initial `fitView` runs before the container and panZoom are
> ready, so `skipMeasurement` + `fitView` lands at the wrong initial camera. #5834 fixes that and
> should land first; this PR should not ship into a React release ahead of it.
>
> Svelte is not affected: its init fit defers through a `queueMicrotask` until panZoom and the
> container dimensions are ready (verified on a bench).

### What this does

Every node is observed by a ResizeObserver on mount, which forces a synchronous layout per
node (`getDimensions`, plus a `querySelectorAll` + `getBoundingClientRect` per handle) on first
load and on every node add, even when the app already knows the dimensions and handle positions.
More handles per node mean more reads, so the pass is larger on handle-heavy nodes.

Add a per-node `skipMeasurement` flag. It is honored only when you also provide the values it would
otherwise measure: real dimensions (`width`/`height` or `measured`) and `handles` (use `handles: []`
for a node without handles). When honored the node is not observed and those values are authoritative.

- `measured` is seeded from the provided `width`/`height` (preferred, so a resize wins over a stale
  `measured` value) or `measured`, so you do not need to set the internal `measured` field.
  `initialWidth`/`initialHeight` are placeholders until measured and do not count as real dimensions.
- While honored the node is never measured, not even by an explicit `updateNodeInternals`.
- Opt-in because only the app knows a node's size is static, as opposed to content that resizes after
  mount (async images, font swaps, expand/collapse). If the values are missing the flag is ignored and
  the node is measured normally, so it cannot break.

### Cost removed

The avoided measurement scales with nodes times handles-per-node:

| nodes x handles | measurement pass |
|---|---|
| 1600 x 4 | ~10.5 ms |
| 1600 x 16 | ~30.7 ms |

Both fall to zero with the flag. The cost is not the DOM reads on their own (their self-time is
tiny, see the profile below) but the per-node `updateNodeInternals` pass they feed: the node write
plus the store update and re-render it fans out. It grows with node count and handles per node, so
it is biggest for large or handle-heavy graphs.

#### Adding a node (DevTools Performance profile)

Clicking to add one node to a large graph. Without the flag the new node is observed and the
ResizeObserver fires `updateNodeInternals`; with the flag the node is never observed.

<table>
<tr>
<th>without <code>skipMeasurement</code></th>
<th>with <code>skipMeasurement</code></th>
</tr>
<tr>
<td><img width="370" alt="Performance profile of adding a node without skipMeasurement" src="https://github.com/user-attachments/assets/505cec15-c092-4a2d-8f44-ee823e3c972c" /></td>
<td><img width="370" alt="Performance profile of adding a node with skipMeasurement" src="https://github.com/user-attachments/assets/c8c967e0-8407-4356-b03b-901542d7c836" /></td>
</tr>
<tr>
<td><code>updateNodeInternals</code> runs at <b>15.43 ms</b> (self 0.21 ms; the rest is the store update and re-render it fans out). The click-to-paint interaction is <b>~70 ms</b>.</td>
<td>No <code>updateNodeInternals</code> at all. The same add is <b>~45 ms</b>.</td>
</tr>
</table>

### Default path unchanged

The flag is opt-in; without it, behavior is byte-identical. Verified: default-path e2e green; an
opt-in node initializes from provided data with no DOM read; a provided `width` correctly
overrides a stale `measured`.
