### PR TITLE
perf(react): take Handle off the global store fan-out

### DIFF
--- a/.changeset/handle-off-fanout.md
+++ b/.changeset/handle-off-fanout.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Take `Handle` off the global store connection fan-out. Handles read connection state through a `useStore` selector that ran for every handle on every store emit, so a node-position write still evaluated it once per handle even though the shared idle-state reference bailed the re-render. Connection state now comes from a dedicated channel that only fires during connect gestures, so a node-position write no longer evaluates anything per handle. No behavior change; the gain scales with handle count.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@xyflow/system": "workspace:*",
     "classcat": "^5.0.3",
+    "use-sync-external-store": "^1.2.0",
     "zustand": "^4.4.0"
   },
   "peerDependencies": {
@@ -83,6 +84,7 @@
     "@types/node": "^18.7.16",
     "@types/react": ">=17",
     "@types/react-dom": ">=17",
+    "@types/use-sync-external-store": "^0.0.6",
     "@xyflow/eslint-config": "workspace:*",
     "@xyflow/rollup-config": "workspace:*",
     "@xyflow/tsconfig": "workspace:*",

--- a/packages/react/src/components/Handle/index.tsx
+++ b/packages/react/src/components/Handle/index.tsx
@@ -4,9 +4,11 @@ import {
   type TouchEvent as ReactTouchEvent,
   type ForwardedRef,
   memo,
+  useCallback,
 } from 'react';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import {
   errorMessages,
   Position,
@@ -23,7 +25,7 @@ import {
   Optional,
 } from '@xyflow/system';
 
-import { useStore, useStoreApi } from '../../hooks/useStore';
+import { useStoreApi } from '../../hooks/useStore';
 import { useNodeId } from '../../contexts/NodeIdContext';
 import { useHandleConfig } from '../../contexts/HandleConfigContext';
 import { type ReactFlowState } from '../../types';
@@ -39,18 +41,21 @@ export type HandleProps = HandlePropsSystem &
     onConnect?: OnConnect;
   };
 
-const selector = (s: ReactFlowState) => ({
-  connectOnClick: s.connectOnClick,
-  noPanClassName: s.noPanClassName,
-  rfId: s.rfId,
-});
+type ConnectingState = {
+  connectingFrom: boolean;
+  connectingTo: boolean;
+  clickConnecting: boolean;
+  isPossibleEndHandle: boolean;
+  connectionInProcess: boolean;
+  clickConnectionInProcess: boolean;
+  valid: boolean | null;
+};
 
 /*
- * While no connection is in progress every handle has this same state, so we return a
- * shared reference rather than allocating + shallow-comparing one per handle on every
- * store update. `isPossibleEndHandle` matches what the selector computes when idle.
+ * While no connection is in progress every handle has this same state, so we return a shared
+ * reference rather than allocating one per handle. `isPossibleEndHandle` matches the idle branch.
  */
-const idleConnectingState = {
+const idleConnectingState: ConnectingState = {
   connectingFrom: false,
   connectingTo: false,
   clickConnecting: false,
@@ -60,30 +65,34 @@ const idleConnectingState = {
   valid: false,
 };
 
-const connectingSelector =
-  (nodeId: string | null, handleId: string | null, type: HandleType) => (state: ReactFlowState) => {
-    const { connectionClickStartHandle: clickHandle, connectionMode, connection } = state;
-    const { fromHandle, toHandle, isValid } = connection;
+function computeConnectingState(
+  state: ReactFlowState,
+  nodeId: string | null,
+  handleId: string | null,
+  type: HandleType
+): ConnectingState {
+  const { connectionClickStartHandle: clickHandle, connectionMode, connection } = state;
+  const { fromHandle, toHandle, isValid } = connection;
 
-    if (!fromHandle && !clickHandle) {
-      return idleConnectingState;
-    }
+  if (!fromHandle && !clickHandle) {
+    return idleConnectingState;
+  }
 
-    const connectingTo = toHandle?.nodeId === nodeId && toHandle?.id === handleId && toHandle?.type === type;
+  const connectingTo = toHandle?.nodeId === nodeId && toHandle?.id === handleId && toHandle?.type === type;
 
-    return {
-      connectingFrom: fromHandle?.nodeId === nodeId && fromHandle?.id === handleId && fromHandle?.type === type,
-      connectingTo,
-      clickConnecting: clickHandle?.nodeId === nodeId && clickHandle?.id === handleId && clickHandle?.type === type,
-      isPossibleEndHandle:
-        connectionMode === ConnectionMode.Strict
-          ? fromHandle?.type !== type
-          : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id,
-      connectionInProcess: !!fromHandle,
-      clickConnectionInProcess: !!clickHandle,
-      valid: connectingTo && isValid,
-    };
+  return {
+    connectingFrom: fromHandle?.nodeId === nodeId && fromHandle?.id === handleId && fromHandle?.type === type,
+    connectingTo,
+    clickConnecting: clickHandle?.nodeId === nodeId && clickHandle?.id === handleId && clickHandle?.type === type,
+    isPossibleEndHandle:
+      connectionMode === ConnectionMode.Strict
+        ? fromHandle?.type !== type
+        : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id,
+    connectionInProcess: !!fromHandle,
+    clickConnectionInProcess: !!clickHandle,
+    valid: connectingTo && isValid,
   };
+}
 
 function HandleComponent(
   {
@@ -108,6 +117,17 @@ function HandleComponent(
   const store = useStoreApi();
   const nodeId = useNodeId();
   const { connectOnClick, noPanClassName, rfId } = useHandleConfig();
+
+  // connection state from a dedicated channel, so a node-position write never wakes the handle.
+  // shim variant, not react's useSyncExternalStore, so the react >=17 peer range keeps working.
+  const subscribeConnection = useCallback(
+    (onChange: () => void) => store.getState().subscribeConnection(onChange),
+    [store]
+  );
+  const selectConnecting = useCallback(
+    (state: ReactFlowState) => computeConnectingState(state, nodeId, handleId, type),
+    [nodeId, handleId, type]
+  );
   const {
     connectingFrom,
     connectingTo,
@@ -116,7 +136,7 @@ function HandleComponent(
     connectionInProcess,
     clickConnectionInProcess,
     valid,
-  } = useStore(connectingSelector(nodeId, handleId, type), shallow);
+  } = useSyncExternalStoreWithSelector(subscribeConnection, store.getState, store.getState, selectConnecting, shallow);
   if (!nodeId) {
     store.getState().onError?.('010', errorMessages['error010']());
   }
@@ -201,7 +221,7 @@ function HandleComponent(
 
     if (!connectionClickStartHandle) {
       onClickConnectStart?.(event.nativeEvent, { nodeId, handleId, handleType: type });
-      store.setState({ connectionClickStartHandle: { nodeId, type, id: handleId } });
+      store.getState().setConnectionClickStartHandle({ nodeId, type, id: handleId });
       return;
     }
 
@@ -233,7 +253,7 @@ function HandleComponent(
     connectionClone.toPosition = connectionClone.toHandle ? connectionClone.toHandle.position : null;
     onClickConnectEnd?.(event as unknown as MouseEvent, connectionClone as FinalConnectionState);
 
-    store.setState({ connectionClickStartHandle: null });
+    store.getState().setConnectionClickStartHandle(null);
   };
 
   return (

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -53,6 +53,19 @@ const createStore = ({
   zIndexMode?: ZIndexMode;
 }) =>
   createWithEqualityFn<ReactFlowState>((set, get) => {
+    // Connection channel: connection state changes only during connect gestures, so handles
+    // subscribe here instead of the global store and a node drag never wakes them.
+    const connectionListeners = new Set<() => void>();
+    function notifyConnection() {
+      for (const listener of connectionListeners) listener();
+    }
+    function subscribeConnection(listener: () => void) {
+      connectionListeners.add(listener);
+      return () => {
+        connectionListeners.delete(listener);
+      };
+    }
+
     async function resolveFitView() {
       const { nodeLookup, panZoom, fitViewOptions, fitViewResolver, width, height, minZoom, maxZoom } = get();
 
@@ -442,12 +455,22 @@ const createStore = ({
         set({
           connection: { ...initialConnection },
         });
+        notifyConnection();
       },
       updateConnection: (connection) => {
         set({ connection });
+        notifyConnection();
+      },
+      setConnectionClickStartHandle: (connectionClickStartHandle) => {
+        set({ connectionClickStartHandle });
+        notifyConnection();
       },
 
-      reset: () => set({ ...getInitialState() }),
+      reset: () => {
+        set({ ...getInitialState() });
+        notifyConnection();
+      },
+      subscribeConnection,
     };
   }, Object.is);
 

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -175,7 +175,13 @@ export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   setNodeExtent: (nodeExtent: CoordinateExtent) => void;
   cancelConnection: () => void;
   updateConnection: UpdateConnection<InternalNode<NodeType>>;
+  /** Set the click-to-connect start handle and wake the connection channel. */
+  setConnectionClickStartHandle: (
+    handle: (Pick<Handle, 'nodeId' | 'id'> & Required<Pick<Handle, 'type'>>) | null
+  ) => void;
   reset: () => void;
+  /** Subscribe to connection-state changes only, bypassing the global store fan-out. */
+  subscribeConnection: (listener: () => void) => () => void;
   triggerNodeChanges: (changes: NodeChange<NodeType>[]) => void;
   triggerEdgeChanges: (changes: EdgeChange<EdgeType>[]) => void;
   panBy: PanBy;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       react-dom:
         specifier: '>=17'
         version: 18.3.1(react@18.3.1)
+      use-sync-external-store:
+        specifier: ^1.2.0
+        version: 1.6.0(react@18.3.1)
       zustand:
         specifier: ^4.4.0
         version: 4.5.7(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)
@@ -227,6 +230,9 @@ importers:
       '@types/react-dom':
         specifier: '>=17'
         version: 18.3.7(@types/react@18.3.29)
+      '@types/use-sync-external-store':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@xyflow/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config


### PR DESCRIPTION
### What this does

`Handle` already reads its static config (connectOnClick / noPanClassName / rfId) from a shared
context, and the connection selector early-returns a shared idle reference, so handles do not
re-render on a node drag. But they still subscribe to the global store for connection state, so the
selector is evaluated once per handle on every store emit (each node-position write), and that
per-emit evaluation times the handle count is the remaining fan-out.

This moves connection state to a dedicated channel. It is notified only by the connect-gesture
mutations (`updateConnection` / `cancelConnection` / `setConnectionClickStartHandle` / `reset`), and
handles read it via `useSyncExternalStore` with the same shallow-deduped, idle-shared snapshot. A
node-position write no longer evaluates anything per handle, while a connection drag still re-renders
only the handles whose own flags change. `set()` is kept on every mutation, so every other useStore
consumer is unaffected.

No breaking change, no opt-in. The gain scales with handle count.

### React 17 compatibility

Handles read the channel through `useSyncExternalStoreWithSelector` from
`use-sync-external-store/shim/with-selector`, not React's built-in `useSyncExternalStore`. The
built-in only ships from React 18, and `@xyflow/react` still lists `react` `>=17` as a peer
dependency, so importing it directly would break on 17. The shim uses React's native hook when it is
present (18) and falls back to its own implementation on 17. Its selector variant also gives the
shallow-deduped, referentially stable snapshot, so the handle does not need a hand-rolled cache. This
adds `use-sync-external-store` as a direct dependency, which was already in the tree through zustand.

### Measured impact

Bench scene: 1000 nodes, 4 handles each (3 target + 1 source), so 4000 handles. One node is dragged
while the rest stay put. Compared against current `main`, which already has the shared static-config
context and the idle-state reference, headless Chromium driven through Playwright, both rebuilt from
the same bench.

- Main-thread JavaScript per drag at native CPU speed (Chrome `ScriptDuration`): main ~70 ms, this
  branch ~51 ms, about 28% less. That removed work is the 4000 idle selector evaluations plus the
  store's per-subscriber iteration that the channel no longer runs on a node drag.
- Under 4x CPU throttle the saved work shows up as frame time: mean drag frame ~12.7 ms on main
  versus ~9.5 ms on this branch, about 25% faster.
- At native CPU speed on a fast desktop the isolated wall clock frame time is the same on both (about
  8.3 ms): the saved work still fits inside the frame budget there, so the win is headroom.

This is a clean net win, and it scales with handle count: the channel removes a fixed per-handle cost
from every node-drag frame, so the bigger the graph the more it saves.

DevTools Performance traces of about one second of continuous node dragging on the bench. The
difference is concentrated in Scripting (yellow), which is where the per-handle selectors run: on
`main` the selector still runs for all 4000 handles on every drag frame, while on this branch the
per-handle evaluation is off the node-drag path.

| Before (`main`, idle-ref): Scripting 242 ms | After (channel): Scripting 174 ms, ~28% less |
| :--: | :--: |
| <img width="380" alt="Before (main idle-ref): DevTools Performance of a node drag, Scripting 242 ms" src="https://github.com/user-attachments/assets/a85ad0d8-08f2-4114-81e0-e20bbdd46bc7" /> | <img width="380" alt="After (channel): DevTools Performance of the same node drag, Scripting 174 ms" src="https://github.com/user-attachments/assets/68189498-cb94-4efa-96e1-a89007cb82d5" /> |

### Verification

- `tsc` and eslint clean.
- e2e on the rebased branch: `interaction` 21/21 (includes drag-connect creating an edge) and
  `draghandle` 3/3.
- Connection channel: starting a connection adds `connectingfrom` to the source handle through the
  channel (no `useStore`), verified in a real browser on the bench; cancelling clears it.
- Wake-completeness: every store mutation of connection state (updateConnection / cancelConnection /
  setConnectionClickStartHandle / reset) notifies the channel, so no handle goes stale.
