### PR TITLE
perf(react): subscribe nodes and edges per id instead of through the global store

### DIFF
--- a/.changeset/granular-node-updates.md
+++ b/.changeset/granular-node-updates.md
@@ -1,0 +1,13 @@
+---
+'@xyflow/react': minor
+'@xyflow/system': patch
+---
+
+Make single-node updates scale to large graphs. Node components subscribe to their own
+node instead of the global store, so changing one node out of thousands no longer re-runs
+every node's selector. Edges re-path through a per-edge channel when an endpoint node
+moves, so a single-node move re-renders only the edges that touch it. `setNodes` also
+reconciles structurally unchanged arrays (flat or nested) in place, recomputing only the
+moved nodes and their cascaded children (no `nodeLookup` clone/clear/rebuild).
+
+Behaviour is unchanged for existing apps: same props, same `onNodesChange` flow.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@xyflow/system": "workspace:*",
     "classcat": "^5.0.3",
+    "use-sync-external-store": "^1.2.0",
     "zustand": "^4.4.0"
   },
   "peerDependencies": {
@@ -83,6 +84,7 @@
     "@types/node": "^18.7.16",
     "@types/react": ">=17",
     "@types/react-dom": ">=17",
+    "@types/use-sync-external-store": "^0.0.6",
     "@xyflow/eslint-config": "workspace:*",
     "@xyflow/rollup-config": "workspace:*",
     "@xyflow/tsconfig": "workspace:*",

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, type KeyboardEvent, useCallback, JSX, memo } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
 import {
@@ -13,7 +14,16 @@ import { useStoreApi, useStore } from '../../hooks/useStore';
 import { ARIA_EDGE_DESC_KEY } from '../A11yDescriptions';
 import { builtinEdgeTypes, nullPosition } from './utils';
 import { EdgeUpdateAnchors } from './EdgeUpdateAnchors';
-import type { Edge, EdgeWrapperProps } from '../../types';
+import type { Edge, EdgeWrapperProps, ReactFlowState } from '../../types';
+
+// edge config that affects path/zIndex; changes rarely, so a global subscription
+// here costs nothing on node drags (it bails) while the hot endpoint-position
+// dependency is handled by the per-edge subscription below
+const edgeConfigSelector = (s: ReactFlowState) => ({
+  connectionMode: s.connectionMode,
+  elevateEdgesOnSelect: s.elevateEdgesOnSelect,
+  zIndexMode: s.zIndexMode,
+});
 
 function EdgeWrapper<EdgeType extends Edge = Edge>({
   id,
@@ -60,52 +70,45 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
   const [reconnecting, setReconnecting] = useState<boolean>(false);
   const store = useStoreApi();
 
-  const {
-    zIndex = edge.zIndex,
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  } = useStore(
-    useCallback(
-      (store) => {
-        const sourceNode = store.nodeLookup.get(edge.source);
-        const targetNode = store.nodeLookup.get(edge.target);
-
-        if (!sourceNode || !targetNode) {
-          return nullPosition;
-        }
-
-        const edgePosition = getEdgePosition({
-          id,
-          sourceNode,
-          targetNode,
-          sourceHandle: edge.sourceHandle || null,
-          targetHandle: edge.targetHandle || null,
-          connectionMode: store.connectionMode,
-          onError,
-        });
-
-        const zIndex = getElevatedEdgeZIndex({
-          selected: edge.selected,
-          zIndex: edge.zIndex,
-          sourceNode,
-          targetNode,
-          elevateOnSelect: store.elevateEdgesOnSelect,
-          zIndexMode: store.zIndexMode,
-        });
-
-        return {
-          ...(edgePosition || nullPosition),
-          zIndex,
-        };
-      },
-      [edge.source, edge.target, edge.sourceHandle, edge.targetHandle, edge.selected, edge.zIndex]
-    ),
-    shallow
+  // Per-edge subscription: re-render only when this edge's data or one of its endpoint nodes
+  // changes (via the store's incidentEdges map), not on every store emit. This is what lets a
+  // single-node move re-path only its edges.
+  const getEdgeVersion = useCallback(() => store.getState().getEdgeVersion(id), [store, id]);
+  useSyncExternalStore(
+    useCallback((onChange) => store.getState().subscribeEdge(id, onChange), [store, id]),
+    getEdgeVersion,
+    getEdgeVersion
   );
+
+  const { connectionMode, elevateEdgesOnSelect, zIndexMode } = useStore(edgeConfigSelector, shallow);
+
+  // computed fresh from the live nodeLookup on each (subscription-driven) render
+  const { nodeLookup } = store.getState();
+  const sourceNode = nodeLookup.get(edge.source);
+  const targetNode = nodeLookup.get(edge.target);
+
+  const { zIndex, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition } =
+    sourceNode && targetNode
+      ? {
+          ...(getEdgePosition({
+            id,
+            sourceNode,
+            targetNode,
+            sourceHandle: edge.sourceHandle || null,
+            targetHandle: edge.targetHandle || null,
+            connectionMode,
+            onError,
+          }) || nullPosition),
+          zIndex: getElevatedEdgeZIndex({
+            selected: edge.selected,
+            zIndex: edge.zIndex,
+            sourceNode,
+            targetNode,
+            elevateOnSelect: elevateEdgesOnSelect,
+            zIndexMode,
+          }),
+        }
+      : { ...nullPosition, zIndex: edge.zIndex };
 
   const markerStartUrl = useMemo(
     () => (edge.markerStart ? `url('#${getMarkerId(edge.markerStart, rfId)}')` : undefined),

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -1,6 +1,5 @@
 import { type MouseEvent, type KeyboardEvent, memo } from 'react';
 import cc from 'classcat';
-import { shallow } from 'zustand/shallow';
 import {
   elementSelectionKeys,
   errorMessages,
@@ -10,7 +9,8 @@ import {
   getNodesInside,
 } from '@xyflow/system';
 
-import { useStore, useStoreApi } from '../../hooks/useStore';
+import { useStoreApi } from '../../hooks/useStore';
+import { useNode } from '../../hooks/useNode';
 import { Provider } from '../../contexts/NodeIdContext';
 import { ARIA_NODE_DESC_KEY } from '../A11yDescriptions';
 import { useDrag } from '../../hooks/useDrag';
@@ -18,7 +18,7 @@ import { useMoveSelectedNodes } from '../../hooks/useMoveSelectedNodes';
 import { handleNodeClick } from '../Nodes/utils';
 import { arrowKeyDiffs, builtinNodeTypes, getNodeInlineStyleDimensions } from './utils';
 import { useNodeObserver } from './useNodeObserver';
-import type { InternalNode, Node, NodeWrapperProps } from '../../types';
+import type { Node, NodeWrapperProps } from '../../types';
 
 function NodeWrapper<NodeType extends Node>({
   id,
@@ -41,16 +41,7 @@ function NodeWrapper<NodeType extends Node>({
   nodeClickDistance,
   onError,
 }: NodeWrapperProps<NodeType>) {
-  const { node, internals, isParent } = useStore((s) => {
-    const node = s.nodeLookup.get(id)! as InternalNode<NodeType>;
-    const isParent = s.parentLookup.has(id);
-
-    return {
-      node,
-      internals: node.internals,
-      isParent,
-    };
-  }, shallow);
+  const { node, internals, isParent } = useNode<NodeType>(id);
 
   let nodeType = node.type || 'default';
   let NodeComponent = nodeTypes?.[nodeType] || builtinNodeTypes[nodeType];

--- a/packages/react/src/hooks/useNode.ts
+++ b/packages/react/src/hooks/useNode.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+import { useStoreApi } from './useStore';
+import type { InternalNode, Node } from '../types';
+
+/*
+ * Per-node subscription for NodeWrapper: read this node's version from the store's per-node registry
+ * so a single-node change wakes only this node, not every mounted node.
+ */
+
+export type NodeRenderSlice<NodeType extends Node = Node> = {
+  node: InternalNode<NodeType>;
+  internals: InternalNode<NodeType>['internals'];
+  isParent: boolean;
+};
+
+export function useNode<NodeType extends Node = Node>(id: string): NodeRenderSlice<NodeType> {
+  const store = useStoreApi();
+
+  const getVersion = useCallback(() => store.getState().getNodeVersion(id), [store, id]);
+  useSyncExternalStore(
+    useCallback((onChange) => store.getState().subscribeNode(id, onChange), [store, id]),
+    getVersion,
+    getVersion // getServerSnapshot: the version is environment-agnostic, so SSR is safe
+  );
+
+  // NodeWrapper only renders ids present in nodeLookup, so the node is guaranteed here
+  const { nodeLookup, parentLookup } = store.getState();
+  const node = nodeLookup.get(id)! as InternalNode<NodeType>;
+  // cast works around a generic-variance quirk in InternalNode<NodeType>['internals']
+  return { node, internals: node.internals, isParent: parentLookup.has(id) } as NodeRenderSlice<NodeType>;
+}

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -16,7 +16,7 @@ import {
   fitViewport,
   getHandlePosition,
   Position,
-  ZIndexMode
+  ZIndexMode,
 } from '@xyflow/system';
 
 import { applyEdgeChanges, applyNodeChanges, createSelectionChange, getSelectionChanges } from '../utils/changes';
@@ -53,6 +53,205 @@ const createStore = ({
   zIndexMode?: ZIndexMode;
 }) =>
   createWithEqualityFn<ReactFlowState>((set, get) => {
+    /*
+     * Per-node subscription registry. A node subscribes to only its own internalNode (via
+     * `useNode`) instead of the global notify-all store, so a single-node change no longer re-runs
+     * every node's selector, the dominant cost when dragging one node out of thousands.
+     *
+     * Each subscribed node has a version counter that the subscriber reads through `getNodeVersion`.
+     * We bump it when the node's internalNode reference changes or when its parent status
+     * (`parentLookup.has(id)`) flips. The parent-status part matters because a child gaining or
+     * losing `parentId` does not change the parent's own reference, so a plain ref check misses it.
+     */
+    const nodeListeners = new Map<string, Set<() => void>>();
+    const nodeVersions = new Map<string, number>();
+    const prevNodeRef = new Map<string, unknown>();
+    const prevIsParent = new Map<string, boolean>();
+
+    function notifyNode(id: string) {
+      const { nodeLookup, parentLookup } = get();
+      prevNodeRef.set(id, nodeLookup.get(id));
+      prevIsParent.set(id, parentLookup.has(id));
+      nodeVersions.set(id, (nodeVersions.get(id) ?? 0) + 1);
+      const listeners = nodeListeners.get(id);
+      if (listeners) {
+        for (const l of listeners) l();
+      }
+    }
+
+    function subscribeNode(id: string, listener: () => void) {
+      let listeners = nodeListeners.get(id);
+      if (!listeners) {
+        listeners = new Set();
+        nodeListeners.set(id, listeners);
+        // record the current values in the prev maps so the first notify doesn't fire spuriously
+        const { nodeLookup, parentLookup } = get();
+        prevNodeRef.set(id, nodeLookup.get(id));
+        prevIsParent.set(id, parentLookup.has(id));
+        if (!nodeVersions.has(id)) nodeVersions.set(id, 0);
+      }
+      listeners.add(listener);
+      return () => {
+        const listenerSet = nodeListeners.get(id);
+        if (listenerSet) {
+          listenerSet.delete(listener);
+          if (listenerSet.size === 0) {
+            nodeListeners.delete(id);
+            nodeVersions.delete(id);
+            prevNodeRef.delete(id);
+            prevIsParent.delete(id);
+          }
+        }
+      };
+    }
+
+    function getNodeVersion(id: string) {
+      return nodeVersions.get(id) ?? 0;
+    }
+
+    /*
+     * `mayMoveCulledNodes`: the caller took a full-rebuild path that can move nodes the per-node
+     * scan can't see, e.g. a subflow cascade (a parented graph takes the full rebuild under `auto`
+     * zIndexMode, child-before-parent ordering, or a structural change, and a parent move then
+     * cascades to its children) or a nodeExtent re-clamp. Only relevant under
+     * onlyRenderVisibleElements, where such a node may be culled (unmounted) yet still have a
+     * visible incident edge.
+     */
+    function notifyNodes(changedIds?: string[], mayMoveCulledNodes = false) {
+      // O(changed): the caller (incremental adopt / delta write) listed exactly
+      // which nodes changed and guarantees no parent-status flips.
+      if (changedIds) {
+        if (nodeListeners.size > 0) {
+          for (const id of changedIds) {
+            if (nodeListeners.has(id)) notifyNode(id);
+          }
+        }
+        notifyIncidentEdges(changedIds);
+        return;
+      }
+
+      // No change list: scan subscribed nodes, fire on a ref or parent-status change. Removed ids go
+      // to the edge notify but never to notifyNode (their NodeWrapper is unmounting; useNode would
+      // dereference a missing nodeLookup entry).
+      if (nodeListeners.size === 0) {
+        notifyIncidentEdges();
+        return;
+      }
+      const { nodeLookup, parentLookup } = get();
+      const changedForEdges: string[] = [];
+      for (const id of nodeListeners.keys()) {
+        const node = nodeLookup.get(id);
+        if (node === undefined) {
+          changedForEdges.push(id);
+          continue;
+        }
+        if (prevNodeRef.get(id) !== node || prevIsParent.get(id) !== parentLookup.has(id)) {
+          notifyNode(id);
+          changedForEdges.push(id);
+        }
+      }
+      /*
+       * If the caller may have moved culled nodes and some nodes are culled (mounted < total), the
+       * scan above missed any culled-but-moved node, so re-path all mounted edges. Only on-screen
+       * edges are mounted under culling, so this is bounded, and it's paid only by
+       * onlyRenderVisibleElements users on a full-rebuild/extent path. Without culling the scan
+       * already covers every node, so this is skipped entirely.
+       */
+      if (mayMoveCulledNodes && nodeListeners.size < nodeLookup.size) {
+        notifyIncidentEdges();
+      } else {
+        notifyIncidentEdges(changedForEdges);
+      }
+    }
+
+    /*
+     * Per-edge subscription registry, mirroring the per-node one. An edge re-renders
+     * on one of its endpoint nodes moving: the `incidentEdges` map (nodeId -> edge
+     * ids touching it) lets a single-node move re-path only those edges. Edge data
+     * and config changes still come through cheap global useStore selectors in
+     * EdgeWrapper (see there), not this registry.
+     *
+     * We key incident edges by bare nodeId rather than reusing connectionLookup,
+     * which dedupes by handle pair and would collapse parallel edges (same endpoints
+     * and handles) into one entry, missing all but one of them on a node move.
+     */
+    const edgeListeners = new Map<string, Set<() => void>>();
+    const edgeVersions = new Map<string, number>();
+    const incidentEdges = new Map<string, Set<string>>();
+
+    function addIncidentEdge(nodeId: string, edgeId: string) {
+      let edges = incidentEdges.get(nodeId);
+      if (!edges) {
+        edges = new Set();
+        incidentEdges.set(nodeId, edges);
+      }
+      edges.add(edgeId);
+    }
+
+    function rebuildIncidentEdges(edges: Edge[]) {
+      incidentEdges.clear();
+      for (const edge of edges) {
+        addIncidentEdge(edge.source, edge.id);
+        addIncidentEdge(edge.target, edge.id);
+      }
+    }
+
+    function notifyEdge(edgeId: string) {
+      // only bump for a subscribed edge; notifyIncidentEdges fires on incident edges that may be
+      // culled (unmounted) under onlyRenderVisibleElements, and an orphan version entry would leak
+      const listeners = edgeListeners.get(edgeId);
+      if (!listeners) {
+        return;
+      }
+      edgeVersions.set(edgeId, (edgeVersions.get(edgeId) ?? 0) + 1);
+      for (const l of listeners) l();
+    }
+
+    function notifyIncidentEdges(changedNodeIds?: string[]) {
+      if (edgeListeners.size === 0) return;
+      if (!changedNodeIds) {
+        for (const edgeId of edgeListeners.keys()) notifyEdge(edgeId);
+        return;
+      }
+      // dedupe so an edge spanning two changed nodes (or a parallel pair sharing a
+      // moved node) fires once
+      const seen = new Set<string>();
+      for (const nodeId of changedNodeIds) {
+        const edges = incidentEdges.get(nodeId);
+        if (!edges) continue;
+        for (const edgeId of edges) {
+          if (!seen.has(edgeId)) {
+            seen.add(edgeId);
+            notifyEdge(edgeId);
+          }
+        }
+      }
+    }
+
+    function subscribeEdge(id: string, listener: () => void) {
+      let listeners = edgeListeners.get(id);
+      if (!listeners) {
+        listeners = new Set();
+        edgeListeners.set(id, listeners);
+        if (!edgeVersions.has(id)) edgeVersions.set(id, 0);
+      }
+      listeners.add(listener);
+      return () => {
+        const listenerSet = edgeListeners.get(id);
+        if (listenerSet) {
+          listenerSet.delete(listener);
+          if (listenerSet.size === 0) {
+            edgeListeners.delete(id);
+            edgeVersions.delete(id);
+          }
+        }
+      };
+    }
+
+    function getEdgeVersion(id: string) {
+      return edgeVersions.get(id) ?? 0;
+    }
+
     async function resolveFitView() {
       const { nodeLookup, panZoom, fitViewOptions, fitViewResolver, width, height, minZoom, maxZoom } = get();
 
@@ -79,6 +278,10 @@ const createStore = ({
        */
       set({ fitViewResolver: null });
     }
+
+    // seed the incident-edge map from the initial edges so a node measurement that fires before the
+    // first setEdges still re-paths its edges (setEdges rebuilds it on every later change)
+    rebuildIncidentEdges(defaultEdges ?? edges ?? []);
 
     return {
       ...getInitialState({
@@ -116,12 +319,14 @@ const createStore = ({
          * relevant for internal React Flow operations.
          */
 
-        const { nodesInitialized, hasSelectedNodes } = adoptUserNodes(nodes, nodeLookup, parentLookup, {
+        const { nodesInitialized, hasSelectedNodes, changedIds } = adoptUserNodes(nodes, nodeLookup, parentLookup, {
           nodeOrigin,
           nodeExtent,
           elevateNodesOnSelect,
           checkEquality: true,
           zIndexMode,
+          // self-gates via canIncrementalAdopt and falls back to the full rebuild
+          incremental: true,
         });
 
         const nextNodesSelectionActive = nodesSelectionActive && hasSelectedNodes;
@@ -138,11 +343,18 @@ const createStore = ({
         } else {
           set({ nodes, nodesInitialized, nodesSelectionActive: nextNodesSelectionActive });
         }
+
+        // a full rebuild (changedIds === undefined, e.g. a structural change, or a parented graph
+        // under `auto` zIndexMode or child-before-parent ordering) may have moved culled nodes in
+        // its parent cascade, so flag it and let visible edges to those nodes still re-path under
+        // onlyRenderVisibleElements.
+        notifyNodes(changedIds, true);
       },
       setEdges: (edges: Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
         updateConnectionLookup(connectionLookup, edgeLookup, edges);
+        rebuildIncidentEdges(edges);
 
         set({ edges });
       },
@@ -199,6 +411,10 @@ const createStore = ({
           // we always want to trigger useStore calls whenever updateNodeInternals is called
           set({});
         }
+
+        // measuring a parent re-clamps its extent-bound children, which may be culled, so re-path
+        // their visible edges too
+        notifyNodes(undefined, true);
 
         if (changes?.length > 0) {
           if (debug) {
@@ -412,6 +628,8 @@ const createStore = ({
         });
 
         set({ nodeExtent: nextNodeExtent });
+        // re-clamping to the new extent can move any node, including culled ones
+        notifyNodes(undefined, true);
       },
       panBy: (delta): Promise<boolean> => {
         const { transform, width, height, panZoom, translateExtent } = get();
@@ -447,7 +665,18 @@ const createStore = ({
         set({ connection });
       },
 
-      reset: () => set({ ...getInitialState() }),
+      reset: () => {
+        // clear the per-node/edge prev + incident maps so the next notify re-detects against the
+        // fresh graph instead of dead node references (versions stay monotonic on purpose)
+        incidentEdges.clear();
+        prevNodeRef.clear();
+        prevIsParent.clear();
+        set({ ...getInitialState() });
+      },
+      subscribeNode,
+      getNodeVersion,
+      subscribeEdge,
+      getEdgeVersion,
     };
   }, Object.is);
 

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -176,6 +176,17 @@ export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   cancelConnection: () => void;
   updateConnection: UpdateConnection<InternalNode<NodeType>>;
   reset: () => void;
+  /** @internal Per-node subscription used by the node renderer; bypasses the
+   *  global notify-all fan-out. Paired with getNodeVersion for useSyncExternalStore. */
+  subscribeNode: (id: string, listener: () => void) => () => void;
+  /** @internal Version counter for a subscribed node; bumps when the node's
+   *  internalNode reference or parent status changes. */
+  getNodeVersion: (id: string) => number;
+  /** @internal Per-edge subscription used by the edge renderer; fires on edge-data
+   *  or endpoint-node changes. Paired with getEdgeVersion for useSyncExternalStore. */
+  subscribeEdge: (id: string, listener: () => void) => () => void;
+  /** @internal Version counter for a subscribed edge. */
+  getEdgeVersion: (id: string) => number;
   triggerNodeChanges: (changes: NodeChange<NodeType>[]) => void;
   triggerEdgeChanges: (changes: EdgeChange<EdgeType>[]) => void;
   panBy: PanBy;

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -115,6 +115,10 @@ type UpdateNodesOptions<NodeType extends NodeBase> = {
   defaults?: Partial<NodeType>;
   zIndexMode?: ZIndexMode;
   checkEquality?: boolean;
+  /** Opt into the in-place fast path (no Map clone/clear/rebuild) when the incoming
+   *  array is structurally identical (flat, no parents, same ids in same order).
+   *  Returns changedIds. Falls back to the full rebuild otherwise. */
+  incremental?: boolean;
 };
 
 export function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
@@ -124,7 +128,87 @@ export function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
 type AdoptUserNodesReturn = {
   nodesInitialized: boolean;
   hasSelectedNodes: boolean;
+  /** ids whose internalNode was (re)created this call. Only populated on the
+   *  incremental fast path; undefined means "unknown, assume all changed". */
+  changedIds?: string[];
 };
+
+/** Can we reconcile the incoming array into the current lookup in place (no clone+clear+rebuild)?
+ *  Yes when the structure is unchanged: same ids in the same order and no re-parenting. A parented
+ *  node is allowed, its absolute position is cascaded from its parent, except under `auto`
+ *  zIndexMode whose rootParentIndex cascade mutates parents in place. */
+function canIncrementalAdopt<NodeType extends NodeBase>(
+  nodes: NodeType[],
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
+  zIndexMode?: ZIndexMode
+): boolean {
+  if (nodes.length !== nodeLookup.size) {
+    return false;
+  }
+  const keys = nodeLookup.keys();
+  const seen = new Set<string>();
+  for (const userNode of nodes) {
+    if (keys.next().value !== userNode.id) {
+      // an add / remove / reorder changes the id sequence
+      return false;
+    }
+    const internalNode = nodeLookup.get(userNode.id)!;
+    // re-parenting (including gaining or losing a parent) has to rebuild parentLookup ordering
+    if (userNode.parentId !== internalNode.parentId) {
+      return false;
+    }
+    if (userNode.parentId) {
+      // the cascade reads the parent from nodeLookup, so the parent must already be processed this
+      // pass; a child-before-parent order (or a missing parent) takes the full path, which handles
+      // it the same way main does. auto zIndexMode mutates parents in place, also full path.
+      if (zIndexMode === 'auto' || !seen.has(userNode.parentId)) {
+        return false;
+      }
+    }
+    seen.add(userNode.id);
+  }
+  return true;
+}
+
+/** Build the internal node for a user node. Shared by both adopt paths (full
+ *  rebuild and incremental fast path). `prevInternalNode` is the previous internal
+ *  node, if any, used to carry over handle bounds. */
+function createInternalNode<NodeType extends NodeBase>(
+  userNode: NodeType,
+  prevInternalNode: InternalNodeBase<NodeType> | undefined,
+  options: typeof adoptUserNodesDefaultOptions,
+  selectedNodeZ: number
+): InternalNodeBase<NodeType> {
+  const positionWithOrigin = getNodePositionWithOrigin(userNode, options.nodeOrigin);
+  const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : options.nodeExtent;
+  const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
+
+  return {
+    ...options.defaults,
+    ...userNode,
+    measured: {
+      width: userNode.measured?.width,
+      height: userNode.measured?.height,
+    },
+    internals: {
+      positionAbsolute: clampedPosition,
+      // if the user re-initializes the node or removes `measured`, reset handleBounds so the node gets re-measured
+      handleBounds: parseHandles(userNode, prevInternalNode),
+      z: calculateZ(userNode, selectedNodeZ, options.zIndexMode),
+      userNode,
+    },
+  };
+}
+
+/** A node still needs measuring when it has no measured size yet and is not hidden. */
+function isNodeUnmeasured<NodeType extends NodeBase>(internalNode: InternalNodeBase<NodeType>): boolean {
+  return (
+    (internalNode.measured === undefined ||
+      internalNode.measured.width === undefined ||
+      internalNode.measured.height === undefined) &&
+    !internalNode.hidden
+  );
+}
 
 export function adoptUserNodes<NodeType extends NodeBase>(
   nodes: NodeType[],
@@ -134,12 +218,46 @@ export function adoptUserNodes<NodeType extends NodeBase>(
 ): AdoptUserNodesReturn {
   const _options = mergeObjects(adoptUserNodesDefaultOptions, options);
   const rootParentIndex = { i: 0 };
-  const tmpLookup = new Map(nodeLookup);
   const selectedNodeZ: number =
     _options?.elevateNodesOnSelect && !isManualZIndexMode(_options.zIndexMode) ? SELECTED_NODE_Z : 0;
   let nodesInitialized = nodes.length > 0;
   let hasSelectedNodes = false;
 
+  // in-place fast path: reconcile only changed entries instead of clone + clear + rebuild.
+  // canIncrementalAdopt guarantees no add / remove / reorder / reparent, so parentLookup stays valid.
+  if (options.incremental && canIncrementalAdopt(nodes, nodeLookup, _options.zIndexMode)) {
+    const changedIds = new Set<string>();
+    for (const userNode of nodes) {
+      const prevInternalNode = nodeLookup.get(userNode.id)!;
+      let internalNode = prevInternalNode;
+      if (!(_options.checkEquality && userNode === internalNode.internals.userNode)) {
+        internalNode = createInternalNode(userNode, internalNode, _options, selectedNodeZ);
+        nodeLookup.set(userNode.id, internalNode);
+      }
+
+      if (isNodeUnmeasured(internalNode)) {
+        nodesInitialized = false;
+      }
+
+      // recompute / re-clamp the child against its parent only when the child's own object changed
+      // or its parent moved (the parent is processed first, so changedIds already reflects it)
+      if (userNode.parentId && (internalNode !== prevInternalNode || changedIds.has(userNode.parentId))) {
+        updateChildNode(internalNode, nodeLookup, parentLookup, options);
+      }
+
+      // changed = own userNode replaced, or cascaded by a moved parent (updateChildNode swapped it)
+      if (nodeLookup.get(userNode.id) !== prevInternalNode) {
+        changedIds.add(userNode.id);
+      }
+
+      hasSelectedNodes ||= userNode.selected ?? false;
+    }
+
+    return { nodesInitialized, hasSelectedNodes, changedIds: [...changedIds] };
+  }
+
+  // full rebuild: snapshot the old lookup, then clear and re-adopt every node
+  const tmpLookup = new Map(nodeLookup);
   nodeLookup.clear();
   parentLookup.clear();
 
@@ -149,26 +267,7 @@ export function adoptUserNodes<NodeType extends NodeBase>(
     if (_options.checkEquality && userNode === internalNode?.internals.userNode) {
       nodeLookup.set(userNode.id, internalNode);
     } else {
-      const positionWithOrigin = getNodePositionWithOrigin(userNode, _options.nodeOrigin);
-      const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : _options.nodeExtent;
-      const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
-
-      internalNode = {
-        ..._options.defaults,
-        ...userNode,
-        measured: {
-          width: userNode.measured?.width,
-          height: userNode.measured?.height,
-        },
-        internals: {
-          positionAbsolute: clampedPosition,
-          // if user re-initializes the node or removes `measured` for whatever reason, we reset the handleBounds so that the node gets re-measured
-          handleBounds: parseHandles(userNode, internalNode),
-          z: calculateZ(userNode, selectedNodeZ, _options.zIndexMode),
-          userNode,
-        },
-      };
-
+      internalNode = createInternalNode(userNode, internalNode, _options, selectedNodeZ);
       nodeLookup.set(userNode.id, internalNode);
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       react-dom:
         specifier: '>=17'
         version: 18.3.1(react@18.3.1)
+      use-sync-external-store:
+        specifier: ^1.2.0
+        version: 1.6.0(react@18.3.1)
       zustand:
         specifier: ^4.4.0
         version: 4.5.7(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)
@@ -227,6 +230,9 @@ importers:
       '@types/react-dom':
         specifier: '>=17'
         version: 18.3.7(@types/react@18.3.29)
+      '@types/use-sync-external-store':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@xyflow/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config


### PR DESCRIPTION
This is the base of a perf stack. Built on top of it, in order: #5829 (EdgeWrapper), #5830 (renderers and selection), #5831 (MiniMap), #5832 (patchNodes).

### What this does

Every mounted `NodeWrapper` and `EdgeWrapper` subscribes to the store through a global `useStore`
selector that re-runs on every store emit. On a node drag the store emits each frame, so every node's
and every edge's selector re-runs even though only one node moved. The selectors mostly bail (shallow
equal), but the per-emit evaluation times the node/edge count is the dominant per-frame cost on large
graphs.

This adds per-entity subscription so a single-node change wakes only that node:

1. The store keeps a per-node and per-edge registry (`subscribeNode` / `subscribeEdge` with a version
   the subscriber reads through `useSyncExternalStore`). A node bumps its version when its
   `internalNode` reference or parent status changes; an edge re-paths when one of its endpoint nodes
   moves (an `incidentEdges` map keyed by node id). `NodeWrapper` reads its node through this channel
   instead of the global selector.
2. `adoptUserNodes` reconciles a structurally unchanged array (same ids, same order, no re-parenting)
   in place instead of clone + clear + rebuild of `nodeLookup`. It returns the ids it actually
   re-created, and recomputes absolute position only for the moved nodes and the children they
   cascade to. This works for flat and nested graphs: a position-only drag is O(changed + cascaded
   descendants), not O(nodes). It self-gates (`canIncrementalAdopt`) and falls back to the full
   rebuild for any add / remove / reorder / reparent (and for `auto` zIndexMode), so the result is
   identical to today on every path.

No breaking change, no opt-in, same `onNodesChange` flow and same rendered output. This is the base
the rest of the perf stack (EdgeWrapper / renderers+selection / MiniMap / patchNodes) builds on.

### React 17 compatibility

The per-entity subscription reads its version through `useSyncExternalStore` from
`use-sync-external-store/shim`, not React's built-in hook. The built-in ships only from React 18, and
`@xyflow/react` keeps `react >=17` as a peer dependency, so the shim keeps 17 working (native hook on
18, backfill on 17). This adds `use-sync-external-store` as a direct dependency, which was already in
the tree through zustand.

### Verification

- `tsc` and eslint clean.
- Nested incremental adopt is proven **byte-identical** to the full rebuild (`nodeLookup` and
  `parentLookup` compared entry-by-entry) across move-parent, move-child, data change, select-child
  and select-parent, with reparent / add / child-before-parent correctly taking the full path.
  Position cascade and z-elevation match main.
- Under `onlyRenderVisibleElements`, a culled node moved by a subflow cascade or a `nodeExtent`
  re-clamp still re-paths its visible incident edges (proven with a culling + subflow scene).
- Full Cypress e2e 61/67, identical to `main` (the 6 reds are pre-existing headless-Electron
  box-select limits, the same tests fail on `main`).


## Benchmark

Per-update cost (ms, median of 3), driven with `flushSync` so each sample is the real store write plus subscriber fan-out plus React commit, with no paint. Realistic graph: a grid of nodes each rendering 2 `<Handle>`s chained by edges, so `NodeWrapper` x N, `Handle` x 2N and `EdgeWrapper` x N-1 are all mounted and reading the store. Only default store actions (`setNodes` / `setEdges` / `updateConnection`) are used, so the same harness runs on both `main` and the branch.

This is the combined effect of the four fan-out PRs (#5827 Handle, #5828 this one, #5829 EdgeWrapper, #5830 renderers and selection); each removes a different per-frame subscriber fan-out and the wins compound.

| N | gesture | main (ms) | branch (ms) | speedup |
|--:|---------|----------:|------------:|--------:|
| 1000 | drag | 2.14 | 0.70 | 3.1x |
| 1000 | connection | 1.67 | 0.36 | 4.6x |
| 10000 | drag | 25.5 | 8.5 | 3.0x |
| 10000 | select | 25.4 | 8.7 | 2.9x |
| 10000 | setEdges | 33.5 | 12.6 | 2.7x |
| 10000 | connection | 23.8 | 5.4 | 4.4x |

The win grows with N because `main` re-runs every mounted node, handle and edge `useStore` selector on each `set()`, while the branch wakes only the entities that changed. Connection has the largest win because on `main` `updateConnection` fans out to every selector; the branch routes it to a dedicated channel. Structural add/remove is about 1.2x (both versions do the same O(N) adopt). Nothing regressed: branch is at or below `main` on every per-frame cell.

