### PR TITLE
perf(react): take the MiniMap off the global store fan-out

### DIFF
--- a/.changeset/edge-off-fanout.md
+++ b/.changeset/edge-off-fanout.md
@@ -1,0 +1,11 @@
+---
+'@xyflow/react': patch
+---
+
+Take `EdgeWrapper` off the global store. Each edge now reads its data through a per-edge channel
+and gets its static config (`defaultEdgeOptions`, `connectionMode`, `elevateEdgesOnSelect`,
+`zIndexMode`) from a single provider subscription, so a node drag no longer re-runs a per-edge
+selector for every edge, and changing one edge re-renders only that edge. `setEdges` wakes the
+channel for the edges whose object actually changed.
+
+Behaviour is unchanged: same props, same edge rendering.

--- a/.changeset/granular-node-updates.md
+++ b/.changeset/granular-node-updates.md
@@ -1,0 +1,13 @@
+---
+'@xyflow/react': minor
+'@xyflow/system': patch
+---
+
+Make single-node updates scale to large graphs. Node components subscribe to their own
+node instead of the global store, so changing one node out of thousands no longer re-runs
+every node's selector. Edges re-path through a per-edge channel when an endpoint node
+moves, so a single-node move re-renders only the edges that touch it. `setNodes` also
+reconciles structurally unchanged arrays (flat or nested) in place, recomputing only the
+moved nodes and their cascaded children (no `nodeLookup` clone/clear/rebuild).
+
+Behaviour is unchanged for existing apps: same props, same `onNodesChange` flow.

--- a/.changeset/lists-and-selection.md
+++ b/.changeset/lists-and-selection.md
@@ -1,0 +1,11 @@
+---
+'@xyflow/react': patch
+---
+
+Take the node/edge renderers and selection off the global store fan-out. The renderers read their
+visible id list from a node/edge list version channel that bumps only when the id set or order
+changes, so a node drag no longer recomputes and shallow-compares the whole id list on every frame.
+`SelectionListener` reads selection from a dedicated channel that bumps only when the selected set
+changes, instead of scanning every node and edge on every store emit.
+
+Behaviour is unchanged: same rendered output, same `onSelectionChange` timing.

--- a/.changeset/minimap-off-fanout.md
+++ b/.changeset/minimap-off-fanout.md
@@ -1,0 +1,10 @@
+---
+'@xyflow/react': patch
+---
+
+Take the `MiniMap` off the global store fan-out, the same way the main renderer now is.
+`MiniMap` reads its node id list from the node-list channel and each minimap node subscribes to its
+own node through the per-node channel, so dragging one node no longer re-runs every minimap node's
+selector on every store emit.
+
+Behaviour is unchanged: same minimap rendering.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@xyflow/system": "workspace:*",
     "classcat": "^5.0.3",
+    "use-sync-external-store": "^1.2.0",
     "zustand": "^4.4.0"
   },
   "peerDependencies": {
@@ -83,6 +84,7 @@
     "@types/node": "^18.7.16",
     "@types/react": ">=17",
     "@types/react-dom": ">=17",
+    "@types/use-sync-external-store": "^0.0.6",
     "@xyflow/eslint-config": "workspace:*",
     "@xyflow/rollup-config": "workspace:*",
     "@xyflow/tsconfig": "workspace:*",

--- a/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMapNodes.tsx
@@ -1,17 +1,18 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ComponentType, memo } from 'react';
+import { ComponentType, memo, useCallback } from 'react';
 import { getNodeDimensions, nodeHasDimensions } from '@xyflow/system';
 import { shallow } from 'zustand/shallow';
 
-import { useStore } from '../../hooks/useStore';
+import { useStoreApi } from '../../hooks/useStore';
+import { useVisibleNodeIds } from '../../hooks/useVisibleNodeIds';
+import { useExternalSnapshot } from '../../hooks/useExternalSnapshot';
 import { MiniMapNode } from './MiniMapNode';
-import type { ReactFlowState, Node } from '../../types';
+import type { Node } from '../../types';
 import type { MiniMapNodes as MiniMapNodesProps, GetMiniMapNodeAttribute, MiniMapNodeProps } from './types';
 
 declare const window: any;
 
-const selectorNodeIds = (s: ReactFlowState) => s.nodes.map((node) => node.id);
 const getAttrFunction = <NodeType extends Node>(func: any): GetMiniMapNodeAttribute<NodeType> =>
   func instanceof Function ? func : () => func;
 
@@ -28,7 +29,7 @@ function MiniMapNodes<NodeType extends Node>({
   nodeComponent: NodeComponent = MiniMapNode,
   onClick,
 }: MiniMapNodesProps<NodeType>) {
-  const nodeIds = useStore(selectorNodeIds, shallow);
+  const nodeIds = useVisibleNodeIds(false);
   const nodeColorFunc = getAttrFunction<NodeType>(nodeColor);
   const nodeStrokeColorFunc = getAttrFunction<NodeType>(nodeStrokeColor);
   const nodeClassNameFunc = getAttrFunction<NodeType>(nodeClassName);
@@ -83,8 +84,16 @@ function NodeComponentWrapperInner<NodeType extends Node>({
   onClick: MiniMapNodesProps['onClick'];
   shapeRendering: string;
 }) {
-  const { node, x, y, width, height } = useStore((s) => {
-    const node = s.nodeLookup.get(id);
+  const store = useStoreApi();
+  const subscribe = useCallback((onChange: () => void) => store.getState().subscribeNode(id, onChange), [store, id]);
+  const compute = useCallback((): {
+    node: NodeType | undefined;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } => {
+    const node = store.getState().nodeLookup.get(id);
 
     if (!node) {
       return { node: undefined, x: 0, y: 0, width: 0, height: 0 };
@@ -94,14 +103,10 @@ function NodeComponentWrapperInner<NodeType extends Node>({
     const { x, y } = node.internals.positionAbsolute;
     const { width, height } = getNodeDimensions(userNode);
 
-    return {
-      node: userNode,
-      x,
-      y,
-      width,
-      height,
-    };
-  }, shallow);
+    return { node: userNode, x, y, width, height };
+  }, [store, id]);
+
+  const { node, x, y, width, height } = useExternalSnapshot(subscribe, compute, shallow);
 
   if (!node || node.hidden || !nodeHasDimensions(node)) {
     return null;

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, type KeyboardEvent, useCallback, JSX, memo } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import cc from 'classcat';
 import { shallow } from 'zustand/shallow';
 import {
@@ -13,7 +14,16 @@ import { useStoreApi, useStore } from '../../hooks/useStore';
 import { ARIA_EDGE_DESC_KEY } from '../A11yDescriptions';
 import { builtinEdgeTypes, nullPosition } from './utils';
 import { EdgeUpdateAnchors } from './EdgeUpdateAnchors';
-import type { Edge, EdgeWrapperProps } from '../../types';
+import type { Edge, EdgeWrapperProps, ReactFlowState } from '../../types';
+
+// edge config that affects path/zIndex; changes rarely, so a global subscription
+// here costs nothing on node drags (it bails) while the hot endpoint-position
+// dependency is handled by the per-edge subscription below
+const edgeConfigSelector = (s: ReactFlowState) => ({
+  connectionMode: s.connectionMode,
+  elevateEdgesOnSelect: s.elevateEdgesOnSelect,
+  zIndexMode: s.zIndexMode,
+});
 
 function EdgeWrapper<EdgeType extends Edge = Edge>({
   id,
@@ -60,52 +70,45 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
   const [reconnecting, setReconnecting] = useState<boolean>(false);
   const store = useStoreApi();
 
-  const {
-    zIndex = edge.zIndex,
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  } = useStore(
-    useCallback(
-      (store) => {
-        const sourceNode = store.nodeLookup.get(edge.source);
-        const targetNode = store.nodeLookup.get(edge.target);
-
-        if (!sourceNode || !targetNode) {
-          return nullPosition;
-        }
-
-        const edgePosition = getEdgePosition({
-          id,
-          sourceNode,
-          targetNode,
-          sourceHandle: edge.sourceHandle || null,
-          targetHandle: edge.targetHandle || null,
-          connectionMode: store.connectionMode,
-          onError,
-        });
-
-        const zIndex = getElevatedEdgeZIndex({
-          selected: edge.selected,
-          zIndex: edge.zIndex,
-          sourceNode,
-          targetNode,
-          elevateOnSelect: store.elevateEdgesOnSelect,
-          zIndexMode: store.zIndexMode,
-        });
-
-        return {
-          ...(edgePosition || nullPosition),
-          zIndex,
-        };
-      },
-      [edge.source, edge.target, edge.sourceHandle, edge.targetHandle, edge.selected, edge.zIndex]
-    ),
-    shallow
+  // Per-edge subscription: re-render only when this edge's data or one of its endpoint nodes
+  // changes (via the store's incidentEdges map), not on every store emit. This is what lets a
+  // single-node move re-path only its edges.
+  const getEdgeVersion = useCallback(() => store.getState().getEdgeVersion(id), [store, id]);
+  useSyncExternalStore(
+    useCallback((onChange) => store.getState().subscribeEdge(id, onChange), [store, id]),
+    getEdgeVersion,
+    getEdgeVersion
   );
+
+  const { connectionMode, elevateEdgesOnSelect, zIndexMode } = useStore(edgeConfigSelector, shallow);
+
+  // computed fresh from the live nodeLookup on each (subscription-driven) render
+  const { nodeLookup } = store.getState();
+  const sourceNode = nodeLookup.get(edge.source);
+  const targetNode = nodeLookup.get(edge.target);
+
+  const { zIndex, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition } =
+    sourceNode && targetNode
+      ? {
+          ...(getEdgePosition({
+            id,
+            sourceNode,
+            targetNode,
+            sourceHandle: edge.sourceHandle || null,
+            targetHandle: edge.targetHandle || null,
+            connectionMode,
+            onError,
+          }) || nullPosition),
+          zIndex: getElevatedEdgeZIndex({
+            selected: edge.selected,
+            zIndex: edge.zIndex,
+            sourceNode,
+            targetNode,
+            elevateOnSelect: elevateEdgesOnSelect,
+            zIndexMode,
+          }),
+        }
+      : { ...nullPosition, zIndex: edge.zIndex };
 
   const markerStartUrl = useMemo(
     () => (edge.markerStart ? `url('#${getMarkerId(edge.markerStart, rfId)}')` : undefined),

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -1,7 +1,5 @@
-import { useState, useMemo, useRef, type KeyboardEvent, useCallback, JSX, memo } from 'react';
-import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import { useState, useMemo, useRef, type KeyboardEvent, JSX, memo } from 'react';
 import cc from 'classcat';
-import { shallow } from 'zustand/shallow';
 import {
   getMarkerId,
   elementSelectionKeys,
@@ -10,20 +8,13 @@ import {
   getElevatedEdgeZIndex,
 } from '@xyflow/system';
 
-import { useStoreApi, useStore } from '../../hooks/useStore';
+import { useStoreApi } from '../../hooks/useStore';
+import { useEdge } from '../../hooks/useEdge';
+import { useEdgeConfig } from '../../contexts/EdgeConfigContext';
 import { ARIA_EDGE_DESC_KEY } from '../A11yDescriptions';
 import { builtinEdgeTypes, nullPosition } from './utils';
 import { EdgeUpdateAnchors } from './EdgeUpdateAnchors';
-import type { Edge, EdgeWrapperProps, ReactFlowState } from '../../types';
-
-// edge config that affects path/zIndex; changes rarely, so a global subscription
-// here costs nothing on node drags (it bails) while the hot endpoint-position
-// dependency is handled by the per-edge subscription below
-const edgeConfigSelector = (s: ReactFlowState) => ({
-  connectionMode: s.connectionMode,
-  elevateEdgesOnSelect: s.elevateEdgesOnSelect,
-  zIndexMode: s.zIndexMode,
-});
+import type { Edge, EdgeWrapperProps } from '../../types';
 
 function EdgeWrapper<EdgeType extends Edge = Edge>({
   id,
@@ -46,8 +37,11 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
   onError,
   disableKeyboardA11y,
 }: EdgeWrapperProps<EdgeType>): JSX.Element | null {
-  let edge = useStore((s) => s.edgeLookup.get(id)!) as EdgeType;
-  const defaultEdgeOptions = useStore((s) => s.defaultEdgeOptions);
+  const store = useStoreApi();
+
+  let edge = useEdge<EdgeType>(id);
+
+  const { defaultEdgeOptions, connectionMode, elevateEdgesOnSelect, zIndexMode } = useEdgeConfig();
   edge = defaultEdgeOptions ? { ...defaultEdgeOptions, ...edge } : edge;
 
   let edgeType = edge.type || 'default';
@@ -68,21 +62,7 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
   const edgeRef = useRef<SVGGElement>(null);
   const [updateHover, setUpdateHover] = useState<boolean>(false);
   const [reconnecting, setReconnecting] = useState<boolean>(false);
-  const store = useStoreApi();
 
-  // Per-edge subscription: re-render only when this edge's data or one of its endpoint nodes
-  // changes (via the store's incidentEdges map), not on every store emit. This is what lets a
-  // single-node move re-path only its edges.
-  const getEdgeVersion = useCallback(() => store.getState().getEdgeVersion(id), [store, id]);
-  useSyncExternalStore(
-    useCallback((onChange) => store.getState().subscribeEdge(id, onChange), [store, id]),
-    getEdgeVersion,
-    getEdgeVersion
-  );
-
-  const { connectionMode, elevateEdgesOnSelect, zIndexMode } = useStore(edgeConfigSelector, shallow);
-
-  // computed fresh from the live nodeLookup on each (subscription-driven) render
   const { nodeLookup } = store.getState();
   const sourceNode = nodeLookup.get(edge.source);
   const targetNode = nodeLookup.get(edge.target);

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -1,6 +1,5 @@
 import { type MouseEvent, type KeyboardEvent, memo } from 'react';
 import cc from 'classcat';
-import { shallow } from 'zustand/shallow';
 import {
   elementSelectionKeys,
   errorMessages,
@@ -10,7 +9,8 @@ import {
   getNodesInside,
 } from '@xyflow/system';
 
-import { useStore, useStoreApi } from '../../hooks/useStore';
+import { useStoreApi } from '../../hooks/useStore';
+import { useNode } from '../../hooks/useNode';
 import { Provider } from '../../contexts/NodeIdContext';
 import { ARIA_NODE_DESC_KEY } from '../A11yDescriptions';
 import { useDrag } from '../../hooks/useDrag';
@@ -18,7 +18,7 @@ import { useMoveSelectedNodes } from '../../hooks/useMoveSelectedNodes';
 import { handleNodeClick } from '../Nodes/utils';
 import { arrowKeyDiffs, builtinNodeTypes, getNodeInlineStyleDimensions } from './utils';
 import { useNodeObserver } from './useNodeObserver';
-import type { InternalNode, Node, NodeWrapperProps } from '../../types';
+import type { Node, NodeWrapperProps } from '../../types';
 
 function NodeWrapper<NodeType extends Node>({
   id,
@@ -41,16 +41,7 @@ function NodeWrapper<NodeType extends Node>({
   nodeClickDistance,
   onError,
 }: NodeWrapperProps<NodeType>) {
-  const { node, internals, isParent } = useStore((s) => {
-    const node = s.nodeLookup.get(id)! as InternalNode<NodeType>;
-    const isParent = s.parentLookup.has(id);
-
-    return {
-      node,
-      internals: node.internals,
-      isParent,
-    };
-  }, shallow);
+  const { node, internals, isParent } = useNode<NodeType>(id);
 
   let nodeType = node.type || 'default';
   let NodeComponent = nodeTypes?.[nodeType] || builtinNodeTypes[nodeType];

--- a/packages/react/src/components/SelectionListener/index.tsx
+++ b/packages/react/src/components/SelectionListener/index.tsx
@@ -4,10 +4,11 @@
  * or is using the useOnSelectionChange hook.
  * @TODO: Now that we have the onNodesChange and on EdgesChange listeners, do we still need this component?
  */
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
+import { useExternalSnapshot } from '../../hooks/useExternalSnapshot';
 import type { ReactFlowState, OnSelectionChangeFunc, Node, Edge } from '../../types';
 
 type SelectionListenerProps<NodeType extends Node = Node, EdgeType extends Edge = Edge> = {
@@ -48,7 +49,17 @@ function SelectionListenerInner<NodeType extends Node = Node, EdgeType extends E
   onSelectionChange,
 }: SelectionListenerProps<NodeType, EdgeType>) {
   const store = useStoreApi<NodeType, EdgeType>();
-  const { selectedNodes, selectedEdges } = useStore(selector, areEqual);
+
+  /*
+   * Read selection through the selection channel: it notifies only when the selected set changes,
+   * so the O(N+E) scan does not run on every emit. areEqual keeps a stable reference so the effect
+   * fires only on a real selection change.
+   */
+  const subscribe = useCallback((onChange: () => void) => store.getState().subscribeSelection(onChange), [store]);
+  // selector only reads nodeLookup/edgeLookup, so the default-typed state is fine here (the same
+  // widening useStore applies internally)
+  const compute = useCallback(() => selector(store.getState() as unknown as ReactFlowState), [store]);
+  const { selectedNodes, selectedEdges } = useExternalSnapshot(subscribe, compute, areEqual);
 
   useEffect(() => {
     const params = { nodes: selectedNodes as NodeType[], edges: selectedEdges as EdgeType[] };

--- a/packages/react/src/container/GraphView/index.tsx
+++ b/packages/react/src/container/GraphView/index.tsx
@@ -7,6 +7,7 @@ import { Viewport } from '../Viewport';
 import { useOnInitHandler } from '../../hooks/useOnInitHandler';
 import { useViewportSync } from '../../hooks/useViewportSync';
 import { ConnectionLineWrapper } from '../../components/ConnectionLine';
+import { EdgeConfigProvider } from '../../contexts/EdgeConfigContext';
 import { useNodeOrEdgeTypesWarning } from './useNodeOrEdgeTypesWarning';
 import type { Edge, Node, ReactFlowProps } from '../../types';
 import { useStylesLoadedWarning } from './useStylesLoadedWarning';
@@ -154,24 +155,26 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
       isControlledViewport={!!viewport}
     >
       <Viewport>
-        <EdgeRenderer<EdgeType>
-          edgeTypes={edgeTypes}
-          onEdgeClick={onEdgeClick}
-          onEdgeDoubleClick={onEdgeDoubleClick}
-          onReconnect={onReconnect}
-          onReconnectStart={onReconnectStart}
-          onReconnectEnd={onReconnectEnd}
-          onlyRenderVisibleElements={onlyRenderVisibleElements}
-          onEdgeContextMenu={onEdgeContextMenu}
-          onEdgeMouseEnter={onEdgeMouseEnter}
-          onEdgeMouseMove={onEdgeMouseMove}
-          onEdgeMouseLeave={onEdgeMouseLeave}
-          reconnectRadius={reconnectRadius}
-          defaultMarkerColor={defaultMarkerColor}
-          noPanClassName={noPanClassName}
-          disableKeyboardA11y={disableKeyboardA11y}
-          rfId={rfId}
-        />
+        <EdgeConfigProvider>
+          <EdgeRenderer<EdgeType>
+            edgeTypes={edgeTypes}
+            onEdgeClick={onEdgeClick}
+            onEdgeDoubleClick={onEdgeDoubleClick}
+            onReconnect={onReconnect}
+            onReconnectStart={onReconnectStart}
+            onReconnectEnd={onReconnectEnd}
+            onlyRenderVisibleElements={onlyRenderVisibleElements}
+            onEdgeContextMenu={onEdgeContextMenu}
+            onEdgeMouseEnter={onEdgeMouseEnter}
+            onEdgeMouseMove={onEdgeMouseMove}
+            onEdgeMouseLeave={onEdgeMouseLeave}
+            reconnectRadius={reconnectRadius}
+            defaultMarkerColor={defaultMarkerColor}
+            noPanClassName={noPanClassName}
+            disableKeyboardA11y={disableKeyboardA11y}
+            rfId={rfId}
+          />
+        </EdgeConfigProvider>
         <ConnectionLineWrapper<NodeType>
           style={connectionLineStyle}
           type={connectionLineType}

--- a/packages/react/src/contexts/EdgeConfigContext.tsx
+++ b/packages/react/src/contexts/EdgeConfigContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { shallow } from 'zustand/shallow';
+import { ConnectionMode, type ZIndexMode } from '@xyflow/system';
+
+import { useStore } from '../hooks/useStore';
+import type { DefaultEdgeOptions, ReactFlowState } from '../types';
+
+/*
+ * defaultEdgeOptions / connectionMode / elevateEdgesOnSelect / zIndexMode are the same for every
+ * edge, so they are shared through context from a single store subscription instead of a per-edge
+ * selector.
+ */
+export type EdgeConfig = {
+  defaultEdgeOptions: DefaultEdgeOptions | undefined;
+  connectionMode: ConnectionMode;
+  elevateEdgesOnSelect: boolean;
+  zIndexMode: ZIndexMode;
+};
+
+const EdgeConfigContext = createContext<EdgeConfig | null>(null);
+
+const selector = (s: ReactFlowState): EdgeConfig => ({
+  defaultEdgeOptions: s.defaultEdgeOptions,
+  connectionMode: s.connectionMode,
+  elevateEdgesOnSelect: s.elevateEdgesOnSelect,
+  zIndexMode: s.zIndexMode,
+});
+
+export function EdgeConfigProvider({ children }: { children: ReactNode }) {
+  const config = useStore(selector, shallow);
+  return <EdgeConfigContext.Provider value={config}>{children}</EdgeConfigContext.Provider>;
+}
+
+export function useEdgeConfig(): EdgeConfig {
+  const config = useContext(EdgeConfigContext);
+
+  if (!config) {
+    throw new Error('useEdgeConfig must be used within an EdgeConfigProvider');
+  }
+
+  return config;
+}

--- a/packages/react/src/hooks/useEdge.ts
+++ b/packages/react/src/hooks/useEdge.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+import { useStoreApi } from './useStore';
+import type { Edge } from '../types';
+
+/*
+ * Per-edge subscription for EdgeWrapper, mirroring useNode: an edge wakes only when its own object
+ * changes (setEdges) or one of its endpoint nodes moves (incidentEdges).
+ */
+export function useEdge<EdgeType extends Edge = Edge>(id: string): EdgeType {
+  const store = useStoreApi();
+
+  const getVersion = useCallback(() => store.getState().getEdgeVersion(id), [store, id]);
+  useSyncExternalStore(
+    useCallback((onChange) => store.getState().subscribeEdge(id, onChange), [store, id]),
+    getVersion,
+    getVersion // getServerSnapshot: the version is environment-agnostic, so SSR is safe
+  );
+
+  // EdgeWrapper only renders ids present in edgeLookup, so the edge is guaranteed here
+  return store.getState().edgeLookup.get(id)! as EdgeType;
+}

--- a/packages/react/src/hooks/useExternalSnapshot.ts
+++ b/packages/react/src/hooks/useExternalSnapshot.ts
@@ -1,0 +1,28 @@
+import { useCallback, useRef } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+/*
+ * useSyncExternalStore over a notify-only channel: `subscribe` registers on the channel, `compute`
+ * rebuilds the snapshot when notified, and `isEqual` dedups against the cached snapshot so an
+ * unchanged result keeps a stable reference (the consumer does not re-render). Used by the node/edge
+ * id-list hooks and SelectionListener, which all recompute a derived value on a coarse
+ * "something in this category changed" signal instead of a global store selector.
+ */
+export function useExternalSnapshot<T>(
+  subscribe: (onChange: () => void) => () => void,
+  compute: () => T,
+  isEqual: (a: T, b: T) => boolean
+): T {
+  const cache = useRef<T | null>(null);
+
+  const getSnapshot = useCallback(() => {
+    const next = compute();
+    if (cache.current !== null && isEqual(cache.current, next)) {
+      return cache.current;
+    }
+    cache.current = next;
+    return next;
+  }, [compute, isEqual]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/react/src/hooks/useNode.ts
+++ b/packages/react/src/hooks/useNode.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+import { useStoreApi } from './useStore';
+import type { InternalNode, Node } from '../types';
+
+/*
+ * Per-node subscription for NodeWrapper: read this node's version from the store's per-node registry
+ * so a single-node change wakes only this node, not every mounted node.
+ */
+
+export type NodeRenderSlice<NodeType extends Node = Node> = {
+  node: InternalNode<NodeType>;
+  internals: InternalNode<NodeType>['internals'];
+  isParent: boolean;
+};
+
+export function useNode<NodeType extends Node = Node>(id: string): NodeRenderSlice<NodeType> {
+  const store = useStoreApi();
+
+  const getVersion = useCallback(() => store.getState().getNodeVersion(id), [store, id]);
+  useSyncExternalStore(
+    useCallback((onChange) => store.getState().subscribeNode(id, onChange), [store, id]),
+    getVersion,
+    getVersion // getServerSnapshot: the version is environment-agnostic, so SSR is safe
+  );
+
+  // NodeWrapper only renders ids present in nodeLookup, so the node is guaranteed here
+  const { nodeLookup, parentLookup } = store.getState();
+  const node = nodeLookup.get(id)! as InternalNode<NodeType>;
+  // cast works around a generic-variance quirk in InternalNode<NodeType>['internals']
+  return { node, internals: node.internals, isParent: parentLookup.has(id) } as NodeRenderSlice<NodeType>;
+}

--- a/packages/react/src/hooks/useVisibleEdgeIds.ts
+++ b/packages/react/src/hooks/useVisibleEdgeIds.ts
@@ -2,53 +2,63 @@ import { useCallback } from 'react';
 import { shallow } from 'zustand/shallow';
 import { isEdgeVisible } from '@xyflow/system';
 
-import { useStore } from './useStore';
-import { type ReactFlowState } from '../types';
+import { useStoreApi } from './useStore';
+import { useExternalSnapshot } from './useExternalSnapshot';
 
 /**
  * Hook for getting the visible edge ids from the store.
+ *
+ * The id list only changes on an edge membership/order change (add/remove/reorder), or, when
+ * culling, on a viewport/endpoint-position change, so we recompute only on the edge-list channel
+ * (plus the store when culling) rather than on every emit.
  *
  * @internal
  * @param onlyRenderVisible
  * @returns array with visible edge ids
  */
 export function useVisibleEdgeIds(onlyRenderVisible: boolean): string[] {
-  const edgeIds = useStore(
-    useCallback(
-      (s: ReactFlowState) => {
-        if (!onlyRenderVisible) {
-          return s.edges.map((edge) => edge.id);
+  const store = useStoreApi();
+
+  const compute = useCallback((): string[] => {
+    const s = store.getState();
+
+    if (!onlyRenderVisible) {
+      return s.edges.map((edge) => edge.id);
+    }
+
+    const next: string[] = [];
+    if (s.width && s.height) {
+      for (const edge of s.edges) {
+        const sourceNode = s.nodeLookup.get(edge.source);
+        const targetNode = s.nodeLookup.get(edge.target);
+
+        if (
+          sourceNode &&
+          targetNode &&
+          isEdgeVisible({ sourceNode, targetNode, width: s.width, height: s.height, transform: s.transform })
+        ) {
+          next.push(edge.id);
         }
+      }
+    }
+    return next;
+  }, [store, onlyRenderVisible]);
 
-        const visibleEdgeIds = [];
-
-        if (s.width && s.height) {
-          for (const edge of s.edges) {
-            const sourceNode = s.nodeLookup.get(edge.source);
-            const targetNode = s.nodeLookup.get(edge.target);
-
-            if (
-              sourceNode &&
-              targetNode &&
-              isEdgeVisible({
-                sourceNode,
-                targetNode,
-                width: s.width,
-                height: s.height,
-                transform: s.transform,
-              })
-            ) {
-              visibleEdgeIds.push(edge.id);
-            }
-          }
-        }
-
-        return visibleEdgeIds;
-      },
-      [onlyRenderVisible]
-    ),
-    shallow
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubList = store.getState().subscribeEdgesList(onChange);
+      if (!onlyRenderVisible) {
+        return unsubList;
+      }
+      // culling additionally depends on the viewport and endpoint positions, so also wake on any emit
+      const unsubStore = store.subscribe(onChange);
+      return () => {
+        unsubList();
+        unsubStore();
+      };
+    },
+    [store, onlyRenderVisible]
   );
 
-  return edgeIds;
+  return useExternalSnapshot(subscribe, compute, shallow);
 }

--- a/packages/react/src/hooks/useVisibleNodeIds.ts
+++ b/packages/react/src/hooks/useVisibleNodeIds.ts
@@ -2,26 +2,48 @@ import { useCallback } from 'react';
 import { shallow } from 'zustand/shallow';
 import { getNodesInside } from '@xyflow/system';
 
-import { useStore } from './useStore';
-import type { Node, ReactFlowState } from '../types';
-
-const selector = (onlyRenderVisible: boolean) => (s: ReactFlowState) => {
-  return onlyRenderVisible
-    ? getNodesInside<Node>(s.nodeLookup, { x: 0, y: 0, width: s.width, height: s.height }, s.transform, true).map(
-      (node) => node.id
-    )
-    : Array.from(s.nodeLookup.keys());
-};
+import { useStoreApi } from './useStore';
+import { useExternalSnapshot } from './useExternalSnapshot';
+import type { Node } from '../types';
 
 /**
  * Hook for getting the visible node ids from the store.
+ *
+ * The id list only changes on a structural change (add/remove/reorder), or, when culling, on a
+ * viewport/position change, so we recompute only on the node-list channel (plus the store when
+ * culling) rather than on every emit.
  *
  * @internal
  * @param onlyRenderVisible
  * @returns array with visible node ids
  */
-export function useVisibleNodeIds(onlyRenderVisible: boolean) {
-  const nodeIds = useStore(useCallback(selector(onlyRenderVisible), [onlyRenderVisible]), shallow);
+export function useVisibleNodeIds(onlyRenderVisible: boolean): string[] {
+  const store = useStoreApi();
 
-  return nodeIds;
+  const compute = useCallback((): string[] => {
+    const s = store.getState();
+    return onlyRenderVisible
+      ? getNodesInside<Node>(s.nodeLookup, { x: 0, y: 0, width: s.width, height: s.height }, s.transform, true).map(
+          (node) => node.id
+        )
+      : Array.from(s.nodeLookup.keys());
+  }, [store, onlyRenderVisible]);
+
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubList = store.getState().subscribeNodesList(onChange);
+      if (!onlyRenderVisible) {
+        return unsubList;
+      }
+      // culling additionally depends on the viewport and node positions, so also wake on any emit
+      const unsubStore = store.subscribe(onChange);
+      return () => {
+        unsubList();
+        unsubStore();
+      };
+    },
+    [store, onlyRenderVisible]
+  );
+
+  return useExternalSnapshot(subscribe, compute, shallow);
 }

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -16,7 +16,7 @@ import {
   fitViewport,
   getHandlePosition,
   Position,
-  ZIndexMode
+  ZIndexMode,
 } from '@xyflow/system';
 
 import { applyEdgeChanges, applyNodeChanges, createSelectionChange, getSelectionChanges } from '../utils/changes';
@@ -53,6 +53,205 @@ const createStore = ({
   zIndexMode?: ZIndexMode;
 }) =>
   createWithEqualityFn<ReactFlowState>((set, get) => {
+    /*
+     * Per-node subscription registry. A node subscribes to only its own internalNode (via
+     * `useNode`) instead of the global notify-all store, so a single-node change no longer re-runs
+     * every node's selector, the dominant cost when dragging one node out of thousands.
+     *
+     * Each subscribed node has a version counter that the subscriber reads through `getNodeVersion`.
+     * We bump it when the node's internalNode reference changes or when its parent status
+     * (`parentLookup.has(id)`) flips. The parent-status part matters because a child gaining or
+     * losing `parentId` does not change the parent's own reference, so a plain ref check misses it.
+     */
+    const nodeListeners = new Map<string, Set<() => void>>();
+    const nodeVersions = new Map<string, number>();
+    const prevNodeRef = new Map<string, unknown>();
+    const prevIsParent = new Map<string, boolean>();
+
+    function notifyNode(id: string) {
+      const { nodeLookup, parentLookup } = get();
+      prevNodeRef.set(id, nodeLookup.get(id));
+      prevIsParent.set(id, parentLookup.has(id));
+      nodeVersions.set(id, (nodeVersions.get(id) ?? 0) + 1);
+      const listeners = nodeListeners.get(id);
+      if (listeners) {
+        for (const l of listeners) l();
+      }
+    }
+
+    function subscribeNode(id: string, listener: () => void) {
+      let listeners = nodeListeners.get(id);
+      if (!listeners) {
+        listeners = new Set();
+        nodeListeners.set(id, listeners);
+        // record the current values in the prev maps so the first notify doesn't fire spuriously
+        const { nodeLookup, parentLookup } = get();
+        prevNodeRef.set(id, nodeLookup.get(id));
+        prevIsParent.set(id, parentLookup.has(id));
+        if (!nodeVersions.has(id)) nodeVersions.set(id, 0);
+      }
+      listeners.add(listener);
+      return () => {
+        const listenerSet = nodeListeners.get(id);
+        if (listenerSet) {
+          listenerSet.delete(listener);
+          if (listenerSet.size === 0) {
+            nodeListeners.delete(id);
+            nodeVersions.delete(id);
+            prevNodeRef.delete(id);
+            prevIsParent.delete(id);
+          }
+        }
+      };
+    }
+
+    function getNodeVersion(id: string) {
+      return nodeVersions.get(id) ?? 0;
+    }
+
+    /*
+     * `mayMoveCulledNodes`: the caller took a full-rebuild path that can move nodes the per-node
+     * scan can't see, e.g. a subflow cascade (a parented graph takes the full rebuild under `auto`
+     * zIndexMode, child-before-parent ordering, or a structural change, and a parent move then
+     * cascades to its children) or a nodeExtent re-clamp. Only relevant under
+     * onlyRenderVisibleElements, where such a node may be culled (unmounted) yet still have a
+     * visible incident edge.
+     */
+    function notifyNodes(changedIds?: string[], mayMoveCulledNodes = false) {
+      // O(changed): the caller (incremental adopt / delta write) listed exactly
+      // which nodes changed and guarantees no parent-status flips.
+      if (changedIds) {
+        if (nodeListeners.size > 0) {
+          for (const id of changedIds) {
+            if (nodeListeners.has(id)) notifyNode(id);
+          }
+        }
+        notifyIncidentEdges(changedIds);
+        return;
+      }
+
+      // No change list: scan subscribed nodes, fire on a ref or parent-status change. Removed ids go
+      // to the edge notify but never to notifyNode (their NodeWrapper is unmounting; useNode would
+      // dereference a missing nodeLookup entry).
+      if (nodeListeners.size === 0) {
+        notifyIncidentEdges();
+        return;
+      }
+      const { nodeLookup, parentLookup } = get();
+      const changedForEdges: string[] = [];
+      for (const id of nodeListeners.keys()) {
+        const node = nodeLookup.get(id);
+        if (node === undefined) {
+          changedForEdges.push(id);
+          continue;
+        }
+        if (prevNodeRef.get(id) !== node || prevIsParent.get(id) !== parentLookup.has(id)) {
+          notifyNode(id);
+          changedForEdges.push(id);
+        }
+      }
+      /*
+       * If the caller may have moved culled nodes and some nodes are culled (mounted < total), the
+       * scan above missed any culled-but-moved node, so re-path all mounted edges. Only on-screen
+       * edges are mounted under culling, so this is bounded, and it's paid only by
+       * onlyRenderVisibleElements users on a full-rebuild/extent path. Without culling the scan
+       * already covers every node, so this is skipped entirely.
+       */
+      if (mayMoveCulledNodes && nodeListeners.size < nodeLookup.size) {
+        notifyIncidentEdges();
+      } else {
+        notifyIncidentEdges(changedForEdges);
+      }
+    }
+
+    /*
+     * Per-edge subscription registry, mirroring the per-node one. An edge re-renders
+     * on one of its endpoint nodes moving: the `incidentEdges` map (nodeId -> edge
+     * ids touching it) lets a single-node move re-path only those edges. Edge data
+     * and config changes still come through cheap global useStore selectors in
+     * EdgeWrapper (see there), not this registry.
+     *
+     * We key incident edges by bare nodeId rather than reusing connectionLookup,
+     * which dedupes by handle pair and would collapse parallel edges (same endpoints
+     * and handles) into one entry, missing all but one of them on a node move.
+     */
+    const edgeListeners = new Map<string, Set<() => void>>();
+    const edgeVersions = new Map<string, number>();
+    const incidentEdges = new Map<string, Set<string>>();
+
+    function addIncidentEdge(nodeId: string, edgeId: string) {
+      let edges = incidentEdges.get(nodeId);
+      if (!edges) {
+        edges = new Set();
+        incidentEdges.set(nodeId, edges);
+      }
+      edges.add(edgeId);
+    }
+
+    function rebuildIncidentEdges(edges: Edge[]) {
+      incidentEdges.clear();
+      for (const edge of edges) {
+        addIncidentEdge(edge.source, edge.id);
+        addIncidentEdge(edge.target, edge.id);
+      }
+    }
+
+    function notifyEdge(edgeId: string) {
+      // only bump for a subscribed edge; notifyIncidentEdges fires on incident edges that may be
+      // culled (unmounted) under onlyRenderVisibleElements, and an orphan version entry would leak
+      const listeners = edgeListeners.get(edgeId);
+      if (!listeners) {
+        return;
+      }
+      edgeVersions.set(edgeId, (edgeVersions.get(edgeId) ?? 0) + 1);
+      for (const l of listeners) l();
+    }
+
+    function notifyIncidentEdges(changedNodeIds?: string[]) {
+      if (edgeListeners.size === 0) return;
+      if (!changedNodeIds) {
+        for (const edgeId of edgeListeners.keys()) notifyEdge(edgeId);
+        return;
+      }
+      // dedupe so an edge spanning two changed nodes (or a parallel pair sharing a
+      // moved node) fires once
+      const seen = new Set<string>();
+      for (const nodeId of changedNodeIds) {
+        const edges = incidentEdges.get(nodeId);
+        if (!edges) continue;
+        for (const edgeId of edges) {
+          if (!seen.has(edgeId)) {
+            seen.add(edgeId);
+            notifyEdge(edgeId);
+          }
+        }
+      }
+    }
+
+    function subscribeEdge(id: string, listener: () => void) {
+      let listeners = edgeListeners.get(id);
+      if (!listeners) {
+        listeners = new Set();
+        edgeListeners.set(id, listeners);
+        if (!edgeVersions.has(id)) edgeVersions.set(id, 0);
+      }
+      listeners.add(listener);
+      return () => {
+        const listenerSet = edgeListeners.get(id);
+        if (listenerSet) {
+          listenerSet.delete(listener);
+          if (listenerSet.size === 0) {
+            edgeListeners.delete(id);
+            edgeVersions.delete(id);
+          }
+        }
+      };
+    }
+
+    function getEdgeVersion(id: string) {
+      return edgeVersions.get(id) ?? 0;
+    }
+
     async function resolveFitView() {
       const { nodeLookup, panZoom, fitViewOptions, fitViewResolver, width, height, minZoom, maxZoom } = get();
 
@@ -79,6 +278,10 @@ const createStore = ({
        */
       set({ fitViewResolver: null });
     }
+
+    // seed the incident-edge map from the initial edges so a node measurement that fires before the
+    // first setEdges still re-paths its edges (setEdges rebuilds it on every later change)
+    rebuildIncidentEdges(defaultEdges ?? edges ?? []);
 
     return {
       ...getInitialState({
@@ -116,12 +319,14 @@ const createStore = ({
          * relevant for internal React Flow operations.
          */
 
-        const { nodesInitialized, hasSelectedNodes } = adoptUserNodes(nodes, nodeLookup, parentLookup, {
+        const { nodesInitialized, hasSelectedNodes, changedIds } = adoptUserNodes(nodes, nodeLookup, parentLookup, {
           nodeOrigin,
           nodeExtent,
           elevateNodesOnSelect,
           checkEquality: true,
           zIndexMode,
+          // self-gates via canIncrementalAdopt and falls back to the full rebuild
+          incremental: true,
         });
 
         const nextNodesSelectionActive = nodesSelectionActive && hasSelectedNodes;
@@ -138,11 +343,18 @@ const createStore = ({
         } else {
           set({ nodes, nodesInitialized, nodesSelectionActive: nextNodesSelectionActive });
         }
+
+        // a full rebuild (changedIds === undefined, e.g. a structural change, or a parented graph
+        // under `auto` zIndexMode or child-before-parent ordering) may have moved culled nodes in
+        // its parent cascade, so flag it and let visible edges to those nodes still re-path under
+        // onlyRenderVisibleElements.
+        notifyNodes(changedIds, true);
       },
       setEdges: (edges: Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
         updateConnectionLookup(connectionLookup, edgeLookup, edges);
+        rebuildIncidentEdges(edges);
 
         set({ edges });
       },
@@ -199,6 +411,10 @@ const createStore = ({
           // we always want to trigger useStore calls whenever updateNodeInternals is called
           set({});
         }
+
+        // measuring a parent re-clamps its extent-bound children, which may be culled, so re-path
+        // their visible edges too
+        notifyNodes(undefined, true);
 
         if (changes?.length > 0) {
           if (debug) {
@@ -412,6 +628,8 @@ const createStore = ({
         });
 
         set({ nodeExtent: nextNodeExtent });
+        // re-clamping to the new extent can move any node, including culled ones
+        notifyNodes(undefined, true);
       },
       panBy: (delta): Promise<boolean> => {
         const { transform, width, height, panZoom, translateExtent } = get();
@@ -447,7 +665,18 @@ const createStore = ({
         set({ connection });
       },
 
-      reset: () => set({ ...getInitialState() }),
+      reset: () => {
+        // clear the per-node/edge prev + incident maps so the next notify re-detects against the
+        // fresh graph instead of dead node references (versions stay monotonic on purpose)
+        incidentEdges.clear();
+        prevNodeRef.clear();
+        prevIsParent.clear();
+        set({ ...getInitialState() });
+      },
+      subscribeNode,
+      getNodeVersion,
+      subscribeEdge,
+      getEdgeVersion,
     };
   }, Object.is);
 

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -23,6 +23,30 @@ import { applyEdgeChanges, applyNodeChanges, createSelectionChange, getSelection
 import getInitialState from './initialState';
 import type { ReactFlowState, Node, Edge, UnselectNodesAndEdgesParams, FitViewOptions } from '../types';
 
+/*
+ * A notify-only channel for useSyncExternalStore: `subscribe` registers a listener, `notify` fires
+ * them. Used for the coarse "something in this category changed" signals (node list, edge list,
+ * selection); each consumer keeps its own recomputed snapshot and just needs to be told when to
+ * recompute, instead of re-running a global store selector on every emit.
+ */
+function createNotifyChannel() {
+  const listeners = new Set<() => void>();
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    notify() {
+      for (const listener of listeners) listener();
+    },
+    get size() {
+      return listeners.size;
+    },
+  };
+}
+
 const createStore = ({
   nodes,
   edges,
@@ -252,6 +276,20 @@ const createStore = ({
       return edgeVersions.get(id) ?? 0;
     }
 
+    /*
+     * Coarse structural / selection signals. The renderers read the visible id list through the
+     * node/edge list channels (bumped only when the id set or order changes, not on a position
+     * drag), and SelectionListener reads selection through the selection channel. selectedNodeIds /
+     * selectedEdgeIds are the store's own copy of the selected set, so setNodes / setEdges can diff
+     * the incoming array against them and detect a selection change even though the user passes a
+     * fresh array each time (and even if a node is mutated in place).
+     */
+    const nodesList = createNotifyChannel();
+    const edgesList = createNotifyChannel();
+    const selection = createNotifyChannel();
+    const selectedNodeIds = new Set<string>();
+    const selectedEdgeIds = new Set<string>();
+
     async function resolveFitView() {
       const { nodeLookup, panZoom, fitViewOptions, fitViewResolver, width, height, minZoom, maxZoom } = get();
 
@@ -349,27 +387,78 @@ const createStore = ({
         // its parent cascade, so flag it and let visible edges to those nodes still re-path under
         // onlyRenderVisibleElements.
         notifyNodes(changedIds, true);
+
+        // a full adopt (changedIds === undefined) means the id set or order changed, so bump the
+        // node-list version to recompute the rendered id list; a position-only drag takes the
+        // incremental path (changedIds defined) and bumps nothing.
+        if (changedIds === undefined) {
+          nodesList.notify();
+        }
+
+        /*
+         * Selection: only when a SelectionListener is subscribed, diff the incoming array against the
+         * store's own selected set (a newly-selected id, or a count mismatch for deselects/removals).
+         * Skipped when nothing listens, so a position-only drag does no extra work here.
+         */
+        if (selection.size > 0) {
+          let newSelectedNodeCount = 0;
+          let nodeSelectionChanged = false;
+          for (const userNode of nodes) {
+            if (userNode.selected) {
+              newSelectedNodeCount++;
+              if (!selectedNodeIds.has(userNode.id)) {
+                nodeSelectionChanged = true;
+              }
+            }
+          }
+          if (newSelectedNodeCount !== selectedNodeIds.size) {
+            nodeSelectionChanged = true;
+          }
+          if (nodeSelectionChanged) {
+            selectedNodeIds.clear();
+            for (const userNode of nodes) {
+              if (userNode.selected) {
+                selectedNodeIds.add(userNode.id);
+              }
+            }
+            selection.notify();
+          }
+        }
       },
       setEdges: (edges: Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
         /*
-         * Diff the incoming edges against the still-current edgeLookup (before updateConnectionLookup
-         * rebuilds it) to collect the ones whose object changed, then wake the per-edge channel for
-         * them after the rebuild. EdgeWrapper reads its edge through that channel (subscribeEdge)
-         * instead of a global useStore selector that re-ran for every edge on every store emit (e.g.
-         * each node-drag frame). Only done when an edge is subscribed; setEdges is not the node-drag
-         * hot path, so the O(E) scan is fine.
+         * Single pre-rebuild pass (edgeLookup still holds the old edges in their old order): collect
+         * object-changed edges to wake their channels, detect an id set / order change for the
+         * edge-list version, and diff selection. Edge array order is the SVG paint order, so a reorder
+         * of the same id set must bump the list to repaint (nodes get this from the full adopt; edges
+         * have no such fallback).
          */
-        let changedEdgeIds: string[] | null = null;
-        if (edgeListeners.size > 0) {
-          changedEdgeIds = [];
-          for (const edge of edges) {
-            const prev = edgeLookup.get(edge.id);
-            if (prev !== undefined && prev !== edge) {
-              changedEdgeIds.push(edge.id);
+        const changedEdgeIds: string[] | null = edgeListeners.size > 0 ? [] : null;
+        const oldEdgeKeys = edgeLookup.keys();
+        let edgeListChanged = edges.length !== edgeLookup.size;
+        let newSelectedEdgeCount = 0;
+        let edgeSelectionChanged = false;
+        for (const edge of edges) {
+          const prev = edgeLookup.get(edge.id);
+          if (prev === undefined) {
+            edgeListChanged = true; // added
+          } else if (prev !== edge && changedEdgeIds) {
+            changedEdgeIds.push(edge.id);
+          }
+          if (!edgeListChanged && oldEdgeKeys.next().value !== edge.id) {
+            edgeListChanged = true; // reorder (same id set, new paint order)
+          }
+          if (edge.selected) {
+            newSelectedEdgeCount++;
+            if (!selectedEdgeIds.has(edge.id)) {
+              edgeSelectionChanged = true;
             }
           }
+        }
+        if (newSelectedEdgeCount !== selectedEdgeIds.size) {
+          edgeSelectionChanged = true;
         }
 
         updateConnectionLookup(connectionLookup, edgeLookup, edges);
@@ -381,6 +470,18 @@ const createStore = ({
           for (const id of changedEdgeIds) {
             notifyEdge(id);
           }
+        }
+        if (edgeListChanged) {
+          edgesList.notify();
+        }
+        if (edgeSelectionChanged) {
+          selectedEdgeIds.clear();
+          for (const edge of edges) {
+            if (edge.selected) {
+              selectedEdgeIds.add(edge.id);
+            }
+          }
+          selection.notify();
         }
       },
       setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => {
@@ -534,28 +635,28 @@ const createStore = ({
           onEdgesChange?.(changes);
         }
       },
-      addSelectedNodes: (selectedNodeIds) => {
+      addSelectedNodes: (nodeIds) => {
         const { multiSelectionActive, edgeLookup, nodeLookup, triggerNodeChanges, triggerEdgeChanges } = get();
 
         if (multiSelectionActive) {
-          const nodeChanges = selectedNodeIds.map((nodeId) => createSelectionChange(nodeId, true));
+          const nodeChanges = nodeIds.map((nodeId) => createSelectionChange(nodeId, true));
           triggerNodeChanges(nodeChanges);
           return;
         }
 
-        triggerNodeChanges(getSelectionChanges(nodeLookup, new Set([...selectedNodeIds]), true));
+        triggerNodeChanges(getSelectionChanges(nodeLookup, new Set([...nodeIds]), true));
         triggerEdgeChanges(getSelectionChanges(edgeLookup));
       },
-      addSelectedEdges: (selectedEdgeIds) => {
+      addSelectedEdges: (edgeIds) => {
         const { multiSelectionActive, edgeLookup, nodeLookup, triggerNodeChanges, triggerEdgeChanges } = get();
 
         if (multiSelectionActive) {
-          const changedEdges = selectedEdgeIds.map((edgeId) => createSelectionChange(edgeId, true));
+          const changedEdges = edgeIds.map((edgeId) => createSelectionChange(edgeId, true));
           triggerEdgeChanges(changedEdges);
           return;
         }
 
-        triggerEdgeChanges(getSelectionChanges(edgeLookup, new Set([...selectedEdgeIds])));
+        triggerEdgeChanges(getSelectionChanges(edgeLookup, new Set([...edgeIds])));
         triggerNodeChanges(getSelectionChanges(nodeLookup, new Set(), true));
       },
       unselectNodesAndEdges: ({ nodes, edges }: UnselectNodesAndEdgesParams = {}) => {
@@ -691,17 +792,28 @@ const createStore = ({
       },
 
       reset: () => {
-        // clear the per-node/edge prev + incident maps so the next notify re-detects against the
-        // fresh graph instead of dead node references (versions stay monotonic on purpose)
+        // clear the per-node/edge prev + incident maps and the selected-id sets so the next notify /
+        // diff re-detects against the fresh graph instead of dead references (versions stay monotonic
+        // on purpose)
         incidentEdges.clear();
         prevNodeRef.clear();
         prevIsParent.clear();
+        selectedNodeIds.clear();
+        selectedEdgeIds.clear();
         set({ ...getInitialState() });
+        // wake the list + selection channels so their consumers (the renderers, SelectionListener)
+        // re-read the now-empty graph; they no longer ride the global emit
+        nodesList.notify();
+        edgesList.notify();
+        selection.notify();
       },
       subscribeNode,
       getNodeVersion,
       subscribeEdge,
       getEdgeVersion,
+      subscribeNodesList: nodesList.subscribe,
+      subscribeEdgesList: edgesList.subscribe,
+      subscribeSelection: selection.subscribe,
     };
   }, Object.is);
 

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -165,11 +165,11 @@ const createStore = ({
     }
 
     /*
-     * Per-edge subscription registry, mirroring the per-node one. An edge re-renders
-     * on one of its endpoint nodes moving: the `incidentEdges` map (nodeId -> edge
-     * ids touching it) lets a single-node move re-path only those edges. Edge data
-     * and config changes still come through cheap global useStore selectors in
-     * EdgeWrapper (see there), not this registry.
+     * Per-edge subscription registry, mirroring the per-node one. An edge re-renders when its own
+     * object changes (setEdges wakes notifyEdge for it) or when one of its endpoint nodes moves: the
+     * `incidentEdges` map (nodeId -> edge ids touching it) lets a single-node move re-path only those
+     * edges. Edge config (connectionMode etc.) is shared through EdgeConfigContext, a single store
+     * subscription read by every edge.
      *
      * We key incident edges by bare nodeId rather than reusing connectionLookup,
      * which dedupes by handle pair and would collapse parallel edges (same endpoints
@@ -353,10 +353,35 @@ const createStore = ({
       setEdges: (edges: Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
+        /*
+         * Diff the incoming edges against the still-current edgeLookup (before updateConnectionLookup
+         * rebuilds it) to collect the ones whose object changed, then wake the per-edge channel for
+         * them after the rebuild. EdgeWrapper reads its edge through that channel (subscribeEdge)
+         * instead of a global useStore selector that re-ran for every edge on every store emit (e.g.
+         * each node-drag frame). Only done when an edge is subscribed; setEdges is not the node-drag
+         * hot path, so the O(E) scan is fine.
+         */
+        let changedEdgeIds: string[] | null = null;
+        if (edgeListeners.size > 0) {
+          changedEdgeIds = [];
+          for (const edge of edges) {
+            const prev = edgeLookup.get(edge.id);
+            if (prev !== undefined && prev !== edge) {
+              changedEdgeIds.push(edge.id);
+            }
+          }
+        }
+
         updateConnectionLookup(connectionLookup, edgeLookup, edges);
         rebuildIncidentEdges(edges);
 
         set({ edges });
+
+        if (changedEdgeIds) {
+          for (const id of changedEdgeIds) {
+            notifyEdge(id);
+          }
+        }
       },
       setDefaultNodesAndEdges: (nodes?: Node[], edges?: Edge[]) => {
         if (nodes) {

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -176,6 +176,17 @@ export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   cancelConnection: () => void;
   updateConnection: UpdateConnection<InternalNode<NodeType>>;
   reset: () => void;
+  /** @internal Per-node subscription used by the node renderer; bypasses the
+   *  global notify-all fan-out. Paired with getNodeVersion for useSyncExternalStore. */
+  subscribeNode: (id: string, listener: () => void) => () => void;
+  /** @internal Version counter for a subscribed node; bumps when the node's
+   *  internalNode reference or parent status changes. */
+  getNodeVersion: (id: string) => number;
+  /** @internal Per-edge subscription used by the edge renderer; fires on edge-data
+   *  or endpoint-node changes. Paired with getEdgeVersion for useSyncExternalStore. */
+  subscribeEdge: (id: string, listener: () => void) => () => void;
+  /** @internal Version counter for a subscribed edge. */
+  getEdgeVersion: (id: string) => number;
   triggerNodeChanges: (changes: NodeChange<NodeType>[]) => void;
   triggerEdgeChanges: (changes: EdgeChange<EdgeType>[]) => void;
   panBy: PanBy;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -187,6 +187,15 @@ export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   subscribeEdge: (id: string, listener: () => void) => () => void;
   /** @internal Version counter for a subscribed edge. */
   getEdgeVersion: (id: string) => number;
+  /** @internal Node-list signal: notifies when the node id set or order changes (not on a position
+   *  drag). The node renderer recomputes its visible id list from it. */
+  subscribeNodesList: (listener: () => void) => () => void;
+  /** @internal Edge-list signal: notifies when the edge id set or order (paint order) changes.
+   *  The edge renderer recomputes its visible id list from it. */
+  subscribeEdgesList: (listener: () => void) => () => void;
+  /** @internal Selection signal: notifies when the set of selected nodes or edges changes.
+   *  SelectionListener recomputes the selection from it. */
+  subscribeSelection: (listener: () => void) => () => void;
   triggerNodeChanges: (changes: NodeChange<NodeType>[]) => void;
   triggerEdgeChanges: (changes: EdgeChange<EdgeType>[]) => void;
   panBy: PanBy;

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -115,6 +115,10 @@ type UpdateNodesOptions<NodeType extends NodeBase> = {
   defaults?: Partial<NodeType>;
   zIndexMode?: ZIndexMode;
   checkEquality?: boolean;
+  /** Opt into the in-place fast path (no Map clone/clear/rebuild) when the incoming
+   *  array is structurally identical (flat, no parents, same ids in same order).
+   *  Returns changedIds. Falls back to the full rebuild otherwise. */
+  incremental?: boolean;
 };
 
 export function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
@@ -124,7 +128,87 @@ export function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
 type AdoptUserNodesReturn = {
   nodesInitialized: boolean;
   hasSelectedNodes: boolean;
+  /** ids whose internalNode was (re)created this call. Only populated on the
+   *  incremental fast path; undefined means "unknown, assume all changed". */
+  changedIds?: string[];
 };
+
+/** Can we reconcile the incoming array into the current lookup in place (no clone+clear+rebuild)?
+ *  Yes when the structure is unchanged: same ids in the same order and no re-parenting. A parented
+ *  node is allowed, its absolute position is cascaded from its parent, except under `auto`
+ *  zIndexMode whose rootParentIndex cascade mutates parents in place. */
+function canIncrementalAdopt<NodeType extends NodeBase>(
+  nodes: NodeType[],
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
+  zIndexMode?: ZIndexMode
+): boolean {
+  if (nodes.length !== nodeLookup.size) {
+    return false;
+  }
+  const keys = nodeLookup.keys();
+  const seen = new Set<string>();
+  for (const userNode of nodes) {
+    if (keys.next().value !== userNode.id) {
+      // an add / remove / reorder changes the id sequence
+      return false;
+    }
+    const internalNode = nodeLookup.get(userNode.id)!;
+    // re-parenting (including gaining or losing a parent) has to rebuild parentLookup ordering
+    if (userNode.parentId !== internalNode.parentId) {
+      return false;
+    }
+    if (userNode.parentId) {
+      // the cascade reads the parent from nodeLookup, so the parent must already be processed this
+      // pass; a child-before-parent order (or a missing parent) takes the full path, which handles
+      // it the same way main does. auto zIndexMode mutates parents in place, also full path.
+      if (zIndexMode === 'auto' || !seen.has(userNode.parentId)) {
+        return false;
+      }
+    }
+    seen.add(userNode.id);
+  }
+  return true;
+}
+
+/** Build the internal node for a user node. Shared by both adopt paths (full
+ *  rebuild and incremental fast path). `prevInternalNode` is the previous internal
+ *  node, if any, used to carry over handle bounds. */
+function createInternalNode<NodeType extends NodeBase>(
+  userNode: NodeType,
+  prevInternalNode: InternalNodeBase<NodeType> | undefined,
+  options: typeof adoptUserNodesDefaultOptions,
+  selectedNodeZ: number
+): InternalNodeBase<NodeType> {
+  const positionWithOrigin = getNodePositionWithOrigin(userNode, options.nodeOrigin);
+  const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : options.nodeExtent;
+  const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
+
+  return {
+    ...options.defaults,
+    ...userNode,
+    measured: {
+      width: userNode.measured?.width,
+      height: userNode.measured?.height,
+    },
+    internals: {
+      positionAbsolute: clampedPosition,
+      // if the user re-initializes the node or removes `measured`, reset handleBounds so the node gets re-measured
+      handleBounds: parseHandles(userNode, prevInternalNode),
+      z: calculateZ(userNode, selectedNodeZ, options.zIndexMode),
+      userNode,
+    },
+  };
+}
+
+/** A node still needs measuring when it has no measured size yet and is not hidden. */
+function isNodeUnmeasured<NodeType extends NodeBase>(internalNode: InternalNodeBase<NodeType>): boolean {
+  return (
+    (internalNode.measured === undefined ||
+      internalNode.measured.width === undefined ||
+      internalNode.measured.height === undefined) &&
+    !internalNode.hidden
+  );
+}
 
 export function adoptUserNodes<NodeType extends NodeBase>(
   nodes: NodeType[],
@@ -134,12 +218,46 @@ export function adoptUserNodes<NodeType extends NodeBase>(
 ): AdoptUserNodesReturn {
   const _options = mergeObjects(adoptUserNodesDefaultOptions, options);
   const rootParentIndex = { i: 0 };
-  const tmpLookup = new Map(nodeLookup);
   const selectedNodeZ: number =
     _options?.elevateNodesOnSelect && !isManualZIndexMode(_options.zIndexMode) ? SELECTED_NODE_Z : 0;
   let nodesInitialized = nodes.length > 0;
   let hasSelectedNodes = false;
 
+  // in-place fast path: reconcile only changed entries instead of clone + clear + rebuild.
+  // canIncrementalAdopt guarantees no add / remove / reorder / reparent, so parentLookup stays valid.
+  if (options.incremental && canIncrementalAdopt(nodes, nodeLookup, _options.zIndexMode)) {
+    const changedIds = new Set<string>();
+    for (const userNode of nodes) {
+      const prevInternalNode = nodeLookup.get(userNode.id)!;
+      let internalNode = prevInternalNode;
+      if (!(_options.checkEquality && userNode === internalNode.internals.userNode)) {
+        internalNode = createInternalNode(userNode, internalNode, _options, selectedNodeZ);
+        nodeLookup.set(userNode.id, internalNode);
+      }
+
+      if (isNodeUnmeasured(internalNode)) {
+        nodesInitialized = false;
+      }
+
+      // recompute / re-clamp the child against its parent only when the child's own object changed
+      // or its parent moved (the parent is processed first, so changedIds already reflects it)
+      if (userNode.parentId && (internalNode !== prevInternalNode || changedIds.has(userNode.parentId))) {
+        updateChildNode(internalNode, nodeLookup, parentLookup, options);
+      }
+
+      // changed = own userNode replaced, or cascaded by a moved parent (updateChildNode swapped it)
+      if (nodeLookup.get(userNode.id) !== prevInternalNode) {
+        changedIds.add(userNode.id);
+      }
+
+      hasSelectedNodes ||= userNode.selected ?? false;
+    }
+
+    return { nodesInitialized, hasSelectedNodes, changedIds: [...changedIds] };
+  }
+
+  // full rebuild: snapshot the old lookup, then clear and re-adopt every node
+  const tmpLookup = new Map(nodeLookup);
   nodeLookup.clear();
   parentLookup.clear();
 
@@ -149,26 +267,7 @@ export function adoptUserNodes<NodeType extends NodeBase>(
     if (_options.checkEquality && userNode === internalNode?.internals.userNode) {
       nodeLookup.set(userNode.id, internalNode);
     } else {
-      const positionWithOrigin = getNodePositionWithOrigin(userNode, _options.nodeOrigin);
-      const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : _options.nodeExtent;
-      const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
-
-      internalNode = {
-        ..._options.defaults,
-        ...userNode,
-        measured: {
-          width: userNode.measured?.width,
-          height: userNode.measured?.height,
-        },
-        internals: {
-          positionAbsolute: clampedPosition,
-          // if user re-initializes the node or removes `measured` for whatever reason, we reset the handleBounds so that the node gets re-measured
-          handleBounds: parseHandles(userNode, internalNode),
-          z: calculateZ(userNode, selectedNodeZ, _options.zIndexMode),
-          userNode,
-        },
-      };
-
+      internalNode = createInternalNode(userNode, internalNode, _options, selectedNodeZ);
       nodeLookup.set(userNode.id, internalNode);
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       react-dom:
         specifier: '>=17'
         version: 18.3.1(react@18.3.1)
+      use-sync-external-store:
+        specifier: ^1.2.0
+        version: 1.6.0(react@18.3.1)
       zustand:
         specifier: ^4.4.0
         version: 4.5.7(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)
@@ -227,6 +230,9 @@ importers:
       '@types/react-dom':
         specifier: '>=17'
         version: 18.3.7(@types/react@18.3.29)
+      '@types/use-sync-external-store':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@xyflow/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config


### PR DESCRIPTION
Part of a perf stack, to be reviewed and merged in order: #5828 (foundation), #5829 (EdgeWrapper), #5830 (renderers and selection), #5831 (MiniMap), #5832 (patchNodes). This PR sits on the previous branch, so its diff against `main` includes the earlier PRs until they merge; this PR's own change is its single latest commit.

### What this does

The minimap mirrored the main node renderer's old shape: `MiniMapNodes` read the node id list with a
`useStore` selector, and each minimap node read its node with a per-node `useStore` selector. Both
re-ran on every store emit (each node-drag frame), so a graph with a minimap paid a second per-node
fan-out on top of the main renderer's.

This routes the minimap onto the same channels the main renderer now uses:

1. `MiniMapNodes` reads its node id list from the node-list channel (`useVisibleNodeIds(false)`), so
   it recomputes only on add/remove/reorder, not every emit.
2. Each minimap node subscribes to its own node through the per-node channel (`subscribeNode`) and
   recomputes its `{ x, y, width, height, ... }` snapshot only when that node changes, with the same
   shallow dedup as before.

No breaking change, no opt-in, no visible difference. It removes the minimap's per-node fan-out for
any flow that renders a `<MiniMap />`.

### React 17 compatibility

The per-node read here goes through `useExternalSnapshot`, which reads `useSyncExternalStore` from
`use-sync-external-store/shim` rather than React's built-in hook, so the `react >=17` peer range keeps
working (native hook on 18, backfill on 17). The `use-sync-external-store` dependency was added by the
foundation PR.

### Verification

- `tsc` and eslint clean.
- The minimap renders every node; moving a node updates that node's minimap rect (x went 0 -> 120
  through the per-node channel); selecting it adds the `selected` class to its rect; adding a node
  grows the minimap (through the node-list channel). Proven against the source-aliased build.
- Behavior-equivalent to the old version: `Array.from(nodeLookup.keys())` is the same id list and
  order as the old `nodes.map(id)` (adopt builds the lookup in array order); hidden nodes are still
  included in the list and filtered in the wrapper; the per-node snapshot is unchanged.

