### PR TITLE
fix(react): defer fitView-on-init until container and panZoom are ready

### DIFF
--- a/.changeset/fitview-init-race.md
+++ b/.changeset/fitview-init-race.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Fix the initial `fitView` landing at the wrong viewport when nodes are initialized synchronously (for example via a provided `measured`). The queued init fit could run before the container had been measured and before the panZoom instance existed, so it fit against stale or zero dimensions. It now waits until the nodes are initialized, the container has real dimensions, and panZoom is ready, and is re-attempted when whichever of those is last becomes available.

--- a/examples/react/src/App/routes.ts
+++ b/examples/react/src/App/routes.ts
@@ -20,6 +20,7 @@ import EdgeRenderer from '../examples/EdgeRenderer';
 import EdgeTypes from '../examples/EdgeTypes';
 import Empty from '../examples/Empty';
 import Figma from '../examples/Figma';
+import FitViewHidden from '../examples/FitViewHidden';
 import FloatingEdges from '../examples/FloatingEdges';
 import Hidden from '../examples/Hidden';
 import Interaction from '../examples/Interaction';
@@ -395,6 +396,11 @@ const routes: IRoute[] = [
     name: 'Node Selection Bug',
     path: 'node-selection-bug',
     component: NodeSelectionBug,
+  },
+  {
+    name: 'FitView Hidden',
+    path: 'fit-view-hidden',
+    component: FitViewHidden,
   },
 ];
 

--- a/examples/react/src/examples/FitViewHidden/index.tsx
+++ b/examples/react/src/examples/FitViewHidden/index.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { ReactFlow, Controls, type Node } from '@xyflow/react';
+
+/*
+ * Regression fixture for the fitView-on-init race. The flow mounts hidden (display: none) with
+ * `fitView` and synchronously-initialized nodes, so the queued init fit fires before the container
+ * is measured. Showing it must then fit correctly. Far-apart nodes and a low minZoom keep the
+ * correct fit clearly distinct from the buggy clamped-to-minZoom one.
+ */
+const nodes: Node[] = [
+  { id: 'a', position: { x: 0, y: 0 }, data: { label: 'A' }, measured: { width: 100, height: 50 } },
+  { id: 'b', position: { x: 3000, y: 2000 }, data: { label: 'B' }, measured: { width: 100, height: 50 } },
+];
+
+export default function FitViewHidden() {
+  const [shown, setShown] = useState(false);
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <button data-testid="show" onClick={() => setShown(true)} style={{ position: 'absolute', zIndex: 10 }}>
+        show
+      </button>
+      <div data-testid="flow-container" style={{ width: '100%', height: '100%', display: shown ? 'block' : 'none' }}>
+        <ReactFlow defaultNodes={nodes} defaultEdges={[]} fitView minZoom={0.1}>
+          <Controls />
+        </ReactFlow>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/container/ZoomPane/index.tsx
+++ b/packages/react/src/container/ZoomPane/index.tsx
@@ -100,7 +100,15 @@ export function ZoomPane({
         domNode: zoomPane.current.closest('.react-flow') as HTMLDivElement,
       });
 
+      // panZoom exists now, resolve a fitView that was queued before it; next frame, so the
+      // sibling effect below has wired onTransformChange and the fit syncs back to the store
+      let fitViewRaf = 0;
+      if (store.getState().fitViewQueued) {
+        fitViewRaf = requestAnimationFrame(() => store.getState().resolveFitViewIfReady());
+      }
+
       return () => {
+        cancelAnimationFrame(fitViewRaf);
         panZoom.current?.destroy();
       };
     }

--- a/packages/react/src/hooks/useResizeHandler.ts
+++ b/packages/react/src/hooks/useResizeHandler.ts
@@ -12,6 +12,8 @@ export function useResizeHandler(domNode: MutableRefObject<HTMLDivElement | null
   const store = useStoreApi();
 
   useEffect(() => {
+    let fitViewRaf = 0;
+
     const updateDimensions = () => {
       if (!domNode.current || !(domNode.current.checkVisibility?.() ?? true)) {
         return false;
@@ -23,6 +25,12 @@ export function useResizeHandler(domNode: MutableRefObject<HTMLDivElement | null
       }
 
       store.setState({ width: size.width || 500, height: size.height || 500 });
+
+      // container is measured now, resolve a fitView that was queued before we had dimensions
+      if (store.getState().fitViewQueued) {
+        cancelAnimationFrame(fitViewRaf);
+        fitViewRaf = requestAnimationFrame(() => store.getState().resolveFitViewIfReady());
+      }
     };
 
     if (domNode.current) {
@@ -33,6 +41,7 @@ export function useResizeHandler(domNode: MutableRefObject<HTMLDivElement | null
       resizeObserver.observe(domNode.current);
 
       return () => {
+        cancelAnimationFrame(fitViewRaf);
         window.removeEventListener('resize', updateDimensions);
 
         if (resizeObserver && domNode.current) {

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -80,6 +80,20 @@ const createStore = ({
       set({ fitViewResolver: null });
     }
 
+    /*
+     * Resolve a queued init fitView once all of its inputs are ready: nodes initialized, the
+     * container measured, and panZoom created. setNodes, useResizeHandler and ZoomPane each call
+     * it as their input becomes ready, so whichever finishes last fires the fit.
+     */
+    function resolveFitViewIfReady() {
+      const { fitViewQueued, nodesInitialized, width, height, panZoom } = get();
+
+      if (fitViewQueued && nodesInitialized && width && height && panZoom) {
+        resolveFitView();
+        set({ fitViewQueued: false, fitViewOptions: undefined });
+      }
+    }
+
     return {
       ...getInitialState({
         nodes,
@@ -97,15 +111,7 @@ const createStore = ({
         zIndexMode,
       }),
       setNodes: (nodes: Node[]) => {
-        const {
-          nodeLookup,
-          parentLookup,
-          nodeOrigin,
-          elevateNodesOnSelect,
-          fitViewQueued,
-          zIndexMode,
-          nodesSelectionActive,
-        } = get();
+        const { nodeLookup, parentLookup, nodeOrigin, elevateNodesOnSelect, zIndexMode, nodesSelectionActive } = get();
 
         /*
          * setNodes() is called exclusively in response to user actions:
@@ -126,19 +132,10 @@ const createStore = ({
 
         const nextNodesSelectionActive = nodesSelectionActive && hasSelectedNodes;
 
-        if (fitViewQueued && nodesInitialized) {
-          resolveFitView();
-          set({
-            nodes,
-            nodesInitialized,
-            fitViewQueued: false,
-            fitViewOptions: undefined,
-            nodesSelectionActive: nextNodesSelectionActive
-          });
-        } else {
-          set({ nodes, nodesInitialized, nodesSelectionActive: nextNodesSelectionActive });
-        }
+        set({ nodes, nodesInitialized, nodesSelectionActive: nextNodesSelectionActive });
+        resolveFitViewIfReady();
       },
+      resolveFitViewIfReady,
       setEdges: (edges: Edge[]) => {
         const { connectionLookup, edgeLookup } = get();
 
@@ -174,6 +171,9 @@ const createStore = ({
           debug,
           fitViewQueued,
           zIndexMode,
+          width,
+          height,
+          panZoom,
         } = get();
 
         const { changes, updatedInternals } = updateNodeInternalsSystem(
@@ -192,7 +192,7 @@ const createStore = ({
 
         updateAbsolutePositions(nodeLookup, parentLookup, { nodeOrigin, nodeExtent, zIndexMode });
 
-        if (fitViewQueued) {
+        if (fitViewQueued && width && height && panZoom) {
           resolveFitView();
           set({ fitViewQueued: false, fitViewOptions: undefined });
         } else {

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -161,6 +161,8 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
 
 export type ReactFlowActions<NodeType extends Node, EdgeType extends Edge> = {
   setNodes: (nodes: NodeType[]) => void;
+  /** @internal Resolve a queued init fitView once nodes, container dimensions and panZoom are all ready. */
+  resolveFitViewIfReady: () => void;
   setEdges: (edges: EdgeType[]) => void;
   setDefaultNodesAndEdges: (nodes?: NodeType[], edges?: EdgeType[]) => void;
   updateNodeInternals: (updates: Map<string, InternalNodeUpdate>, params?: { triggerFitView: boolean }) => void;

--- a/tests/playwright/e2e/fit-view.spec.ts
+++ b/tests/playwright/e2e/fit-view.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+import { FRAMEWORK } from './constants';
+import { getTransform } from './utils';
+
+test.describe('fitView on init', () => {
+  // Regression for the init-fit race: a hidden flow with synchronously-initialized nodes must fit
+  // once shown. Before the fix the init fit ran against zero dimensions and was never re-attempted.
+  // React-only: Svelte defers its init fit through a microtask, so the race does not exist there.
+  test('fits when a hidden flow with synchronously-initialized nodes is shown', async ({ page }) => {
+    test.skip(FRAMEWORK !== 'react', 'fitView-on-init race is React-only');
+
+    await page.goto('/examples/fit-view-hidden');
+
+    await page.getByTestId('show').click();
+
+    const viewport = page.locator('.react-flow__viewport');
+    await expect(viewport).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.react-flow__node')).toHaveCount(2);
+
+    // let the fit triggered by showing the container settle
+    await page.waitForTimeout(400);
+    const shownZoom = (await getTransform(viewport)).scale;
+
+    // a manual fitView is the correct reference, it works regardless of the fix
+    await page.locator('.react-flow__controls-fitview').click();
+    await page.waitForTimeout(400);
+    const refitZoom = (await getTransform(viewport)).scale;
+
+    // the fit on show must match the manual fit and be the real fitted zoom, not the clamped minZoom
+    expect(shownZoom).toBeGreaterThan(0.12);
+    expect(shownZoom).toBeLessThan(1);
+    expect(Math.abs(shownZoom - refitZoom)).toBeLessThan(0.02);
+  });
+});


### PR DESCRIPTION
### What this fixes

Nodes that initialize synchronously (for example a provided `measured`) reach `setNodes` before the container has been measured and before the panZoom instance exists. The queued init `fitView` then ran against stale or zero dimensions and landed at the wrong camera (in the worst case clamped to `minZoom`), and it was never re-attempted.

### Fix

Centralize the init-fit gate in a single `resolveFitViewIfReady()` on the store. It resolves the queued fit only once all of its inputs are ready:

- the nodes are initialized,
- `width`/`height` are measured (> 0), and
- the panZoom instance exists.

`setNodes` (nodes ready), `useResizeHandler` (dimensions ready) and `ZoomPane` (panZoom ready) each call it, so whichever precondition finishes last fires the single init fit. The re-attempts no longer re-run `setNodes` (no extra O(N) adopt pass), and their `requestAnimationFrame`s are cancelled on cleanup.

### Test

Adds a deterministic Playwright regression test: a `display:none` flow with `fitView` and synchronously-initialized nodes must fit correctly once it is shown. It fails without this fix (the viewport stays clamped to `minZoom`) and passes with it.

### Notes

Svelte Flow is not affected: its init fit is dispatched through a `queueMicrotask`, which already defers it until panZoom and the container dimensions are ready (verified on a bench).
