### PR TITLE
fix(system): guard against missing parent node in updateNodeInternals

### DIFF
--- a/.changeset/fix-update-node-internals-missing-parent.md
+++ b/.changeset/fix-update-node-internals-missing-parent.md
@@ -2,4 +2,4 @@
 "@xyflow/system": patch
 ---
 
-Fix a crash in `updateNodeInternals` when a node's `parentId` is absent from `nodeLookup` (for example the parent was removed while the child's ResizeObserver callback still fires). The position clamping is now skipped instead of throwing `TypeError: Cannot read properties of undefined (reading 'measured')`. (#5835)
+Check if parent node is in node lookup before clamp the position to prevent throwing an error.

--- a/.changeset/fix-update-node-internals-missing-parent.md
+++ b/.changeset/fix-update-node-internals-missing-parent.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix a crash in `updateNodeInternals` when a node's `parentId` is absent from `nodeLookup` (for example the parent was removed while the child's ResizeObserver callback still fires). The position clamping is now skipped instead of throwing `TypeError: Cannot read properties of undefined (reading 'measured')`. (#5835)

--- a/examples/react/cypress/components/utils/update-node-internals.cy.ts
+++ b/examples/react/cypress/components/utils/update-node-internals.cy.ts
@@ -1,0 +1,57 @@
+import {
+  updateNodeInternals,
+  adoptUserNodes,
+  type InternalNodeUpdate,
+  type NodeLookup,
+  type ParentLookup,
+} from '@xyflow/system';
+import type { Node } from '@xyflow/react';
+
+// Regression test for https://github.com/xyflow/xyflow/issues/5835
+// When a node references a `parentId` that is absent from `nodeLookup` (for
+// example the parent was removed while the child's ResizeObserver still fires),
+// `updateNodeInternals` used to call `clampPositionToParent(..., nodeLookup.get(parentId)!)`
+// with an `undefined` parent and crash with
+// `TypeError: Cannot read properties of undefined (reading 'measured')`.
+describe('updateNodeInternals with a missing parent', () => {
+  it('does not crash when a node parent is absent from nodeLookup', () => {
+    const nodeLookup: NodeLookup = new Map();
+    const parentLookup: ParentLookup = new Map();
+
+    // A child whose parent ("missing-parent") is never added to the lookup.
+    const child: Node = {
+      id: 'child',
+      data: { label: 'child' },
+      position: { x: 0, y: 0 },
+      parentId: 'missing-parent',
+      extent: 'parent',
+      measured: { width: 50, height: 50 },
+    };
+    adoptUserNodes([child], nodeLookup, parentLookup);
+
+    // Minimal flow DOM so `updateNodeInternals` does not bail out early on the
+    // missing `.xyflow__viewport` and reads a real zoom from the transform.
+    const domNode = document.createElement('div');
+    const viewport = document.createElement('div');
+    viewport.className = 'xyflow__viewport';
+    viewport.style.transform = 'translate(0px, 0px) scale(1)';
+    domNode.appendChild(viewport);
+    document.body.appendChild(domNode);
+
+    const nodeElement = document.createElement('div');
+    nodeElement.style.width = '50px';
+    nodeElement.style.height = '50px';
+    document.body.appendChild(nodeElement);
+
+    const updates = new Map<string, InternalNodeUpdate>([
+      ['child', { id: 'child', nodeElement, force: true }],
+    ]);
+
+    expect(() =>
+      updateNodeInternals(updates, nodeLookup, parentLookup, domNode, [0, 0])
+    ).to.not.throw();
+
+    domNode.remove();
+    nodeElement.remove();
+  });
+});

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -452,9 +452,6 @@ export function updateNodeInternals<NodeType extends InternalNodeBase>(
       let { positionAbsolute } = node.internals;
 
       if (node.parentId && node.extent === 'parent') {
-        // The parent can be absent from `nodeLookup` (for example it was removed
-        // while a child's ResizeObserver callback still fires). Skip clamping
-        // instead of crashing on `getNodeDimensions(undefined)`. (#5835)
         const parentNode = nodeLookup.get(node.parentId);
         if (parentNode) {
           positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, parentNode);

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -452,7 +452,13 @@ export function updateNodeInternals<NodeType extends InternalNodeBase>(
       let { positionAbsolute } = node.internals;
 
       if (node.parentId && node.extent === 'parent') {
-        positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, nodeLookup.get(node.parentId)!);
+        // The parent can be absent from `nodeLookup` (for example it was removed
+        // while a child's ResizeObserver callback still fires). Skip clamping
+        // instead of crashing on `getNodeDimensions(undefined)`. (#5835)
+        const parentNode = nodeLookup.get(node.parentId);
+        if (parentNode) {
+          positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, parentNode);
+        }
       } else if (extent) {
         positionAbsolute = clampPosition(positionAbsolute, extent, dimensions);
       }


### PR DESCRIPTION
## Summary

Fixes #5835.

`updateNodeInternals` crashed with `TypeError: Cannot read properties of undefined (reading 'measured')` when a node's `parentId` referenced a parent absent from `nodeLookup` (e.g. the parent was removed while the child's `ResizeObserver` callback still fired). The crash happens inside a `ResizeObserver` callback, so React error boundaries cannot catch it.

`store.ts` passed `nodeLookup.get(node.parentId)!` (a non-null assertion) into `clampPositionToParent`, which called `getNodeDimensions(undefined)`. This skips clamping when the parent is missing — the fix suggested by the issue author.

## Testing done

- Added Cypress regression test `examples/react/cypress/components/utils/update-node-internals.cy.ts` (asserts no throw when the parent is missing).
- Standalone reproduction against built `@xyflow/system`: `getNodeDimensions(undefined)` throws the exact reported error; the guarded path does not throw.
- `typecheck` clean, `build` success, `lint` no new issues.

## Notes

Live repro in the issue. _AI disclosure: prepared with help of an AI coding agent (Claude); verified locally._