### PR TITLE
perf(react): apply the viewport transform imperatively instead of re-rendering per frame

### DIFF
--- a/.changeset/viewport-imperative-transform.md
+++ b/.changeset/viewport-imperative-transform.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Apply the viewport pan/zoom transform imperatively so the `Viewport` component renders once instead of re-rendering on every pan/zoom frame. DOM output and update cadence are unchanged.

--- a/.changeset/viewport-imperative-transform.md
+++ b/.changeset/viewport-imperative-transform.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Apply the viewport pan/zoom transform imperatively so the `Viewport` component renders once instead of re-rendering on every pan/zoom frame. DOM output and update cadence are unchanged.
+Apply the viewport pan/zoom transform imperatively so the `Viewport` component only renders once.

--- a/packages/react/src/container/Viewport/index.tsx
+++ b/packages/react/src/container/Viewport/index.tsx
@@ -1,19 +1,57 @@
-import type { ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
+import type { Transform } from '@xyflow/system';
 
-import { useStore } from '../../hooks/useStore';
-import type { ReactFlowState } from '../../types';
+import { useStoreApi } from '../../hooks/useStore';
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 
-const selector = (s: ReactFlowState) => `translate(${s.transform[0]}px,${s.transform[1]}px) scale(${s.transform[2]})`;
+const toTransformString = (transform: Transform) =>
+  `translate(${transform[0]}px,${transform[1]}px) scale(${transform[2]})`;
 
 type ViewportProps = {
   children: ReactNode;
 };
 
 export function Viewport({ children }: ViewportProps) {
-  const transform = useStore(selector);
+  const store = useStoreApi();
+  const viewportRef = useRef<HTMLDivElement>(null);
+  // seed the transform for first paint and SSR without subscribing, so we don't re-render on pan/zoom
+  const [initialTransform] = useState(() => store.getState().transform);
+
+  // transform changes every pan/zoom frame, so write it to the DOM directly to keep React out of the hot path
+  useIsomorphicLayoutEffect(() => {
+    let prevTransform: Transform | null = null;
+
+    const applyTransform = () => {
+      const transform = store.getState().transform;
+
+      // store.subscribe fires on every update, so only touch the DOM when x, y or zoom actually changed
+      if (
+        prevTransform &&
+        transform[0] === prevTransform[0] &&
+        transform[1] === prevTransform[1] &&
+        transform[2] === prevTransform[2]
+      ) {
+        return;
+      }
+
+      prevTransform = transform;
+
+      if (viewportRef.current) {
+        viewportRef.current.style.transform = toTransformString(transform);
+      }
+    };
+
+    applyTransform();
+
+    return store.subscribe(applyTransform);
+  }, [store]);
 
   return (
-    <div className="react-flow__viewport xyflow__viewport react-flow__container" style={{ transform }}>
+    <div
+      ref={viewportRef}
+      className="react-flow__viewport xyflow__viewport react-flow__container"
+      style={{ transform: toTransformString(initialTransform) }}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## What this does

`Viewport` subscribes to the transform through `useStore` and re-renders on every viewport change just to set one inline style:

```ts
const selector = (s) => `translate(${s.transform[0]}px,${s.transform[1]}px) scale(${s.transform[2]})`;
const transform = useStore(selector);
```

So a sustained pan or zoom is one render of this component per frame (its children already bail, their element reference is stable across transform changes). This replaces the subscription with `useStoreApi` + a ref + `store.subscribe`, writing `el.style.transform` directly. The component renders once on mount and never re-renders on pan or zoom again.

The pieces that keep it a strict no-op:

- The initial transform is seeded once with a lazy `useState(() => store.getState().transform)`, so first paint and SSR are correct without a live subscription.
- `store.subscribe` fires on every store update, so a guard tracks the previous `[x, y, zoom]` and only writes when it actually changed (the same equality the selector string had).
- `useIsomorphicLayoutEffect` applies the first write before paint on the client (no flash) and is skipped on the server (no `useLayoutEffect` SSR warning). The seeded prop already makes the server HTML correct.
- The subscription's unsubscribe is the effect cleanup, so StrictMode double invoke and a concurrent re-subscribe are safe.

Every viewport change path (pan, wheel and pinch zoom, `fitView` including animated, `setViewport`, `zoomIn` / `zoomOut`, minimap drag) goes through `store.setState({ transform })` in `ZoomPane.onTransformChange`, so the single subscription covers all of them.

## No behavior change

Same className, same element, same transform string format. The DOM output is byte identical and the update cadence is unchanged, only the React work behind it is gone.

The one thing to check with an imperative DOM write is that React does not fight the value on a later re-render. It does not here: the `style` prop is frozen to the seeded value, so if `Viewport` re-renders for an unrelated reason React diffs seed against seed, finds no change, and never re-touches `style.transform`. I confirmed this directly, after driving the transform to a distinctive value and forcing `Viewport` to re-render, the DOM transform stayed put with no snap back to the seed.

This is zustand's documented "transient updates" pattern (use `subscribe` to react to often changing state without forcing a re-render), composed from React's ref escape hatches (refs for values that should not trigger a render, and refs for direct DOM access).

## Numbers

Measured on the stress grid, driving the real `store.setState({ transform })` path one frame at a time under `flushSync`, with a React `<Profiler>` to isolate the Viewport's own render and `Emulation.setCPUThrottlingRate` for the lower end device case. Median over trials.

| per pan/zoom frame | before | after |
|---|---|---|
| Viewport renders / commits | 1 | 0 |
| main thread removed, M4 | | ~15 us/frame (~3 us of it React render) |
| main thread removed, 4x CPU throttle | | ~65 us/frame (~17 us of it React render) |

This is a small per frame win on purpose. The children already bailed, so what is removed is one component's render and commit, not the subtree. Its value is that it is free, it happens on every pan and zoom frame of every flow, and it is O(1) in graph size: the Viewport's render time stayed flat (~3 to 6 us/frame) from 100 to 2025 nodes because the subtree bails. The cost that does scale with graph size on a transform change is the per entity store fan-out, which is separate work, not this PR.

A side benefit is cleaner profiling. With the Viewport committing once per frame, a React DevTools Profiler recording of a pan or zoom is one Viewport commit per frame of noise that you have to look past. After this it drops to zero, so the flame chart and commit list show the work that actually matters during a gesture instead of a constant Viewport commit. That made isolating the real per frame cost in the numbers above a lot easier.

## Verification

- `tsc` and eslint clean, the package builds.
- Cypress e2e asserts `.react-flow__viewport` `transform` before and after drag and zoom in `basic.cy.ts`. Those DOM assertions pass unchanged, since the imperative write keeps the same style string.
- Checked under StrictMode (double invoke safe via cleanup) and the forced re-render / no snap back case above.
