### PR TITLE
perf(react): skip minimap re-renders when its geometry is unchanged

### DIFF
--- a/.changeset/minimap-selector-value-equality.md
+++ b/.changeset/minimap-selector-value-equality.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Stop the `<MiniMap />` from re-rendering on every store update. Its selector builds new `viewBB`/`boundingRect` objects on each call, so the default `shallow` equality always treated them as changed and the minimap re-rendered on unrelated changes such as node selection. It now compares those rects by value, so it only re-renders when its geometry actually changes.

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { memo, useEffect, useRef, type MouseEvent, useCallback, CSSProperties } from 'react';
 import cc from 'classcat';
-import { shallow } from 'zustand/shallow';
 import { getInternalNodesBounds, getBoundsOfRects, XYMinimap, type Rect, type XYMinimapInstance } from '@xyflow/system';
 
 import { useStore, useStoreApi } from '../../hooks/useStore';
@@ -40,6 +39,22 @@ const selector = (s: ReactFlowState) => {
   };
 };
 
+type MiniMapSlice = ReturnType<typeof selector>;
+
+const rectEqual = (a: Rect, b: Rect) => a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+
+// the selector builds new viewBB/boundingRect objects every call, so the default shallow equality always
+// treats them as changed; comparing the rects by value lets the minimap skip re-renders when nothing moved
+const areEqual = (a: MiniMapSlice, b: MiniMapSlice) =>
+  rectEqual(a.viewBB, b.viewBB) &&
+  rectEqual(a.boundingRect, b.boundingRect) &&
+  a.rfId === b.rfId &&
+  a.panZoom === b.panZoom &&
+  a.translateExtent === b.translateExtent &&
+  a.flowWidth === b.flowWidth &&
+  a.flowHeight === b.flowHeight &&
+  a.ariaLabelConfig === b.ariaLabelConfig;
+
 const ARIA_LABEL_KEY = 'react-flow__minimap-desc';
 function MiniMapComponent<NodeType extends Node = Node>({
   style,
@@ -72,7 +87,7 @@ function MiniMapComponent<NodeType extends Node = Node>({
   const svg = useRef<SVGSVGElement>(null);
   const { boundingRect, viewBB, rfId, panZoom, translateExtent, flowWidth, flowHeight, ariaLabelConfig } = useStore(
     selector,
-    shallow
+    areEqual
   );
   const elementWidth = (style?.width as number) ?? defaultWidth;
   const elementHeight = (style?.height as number) ?? defaultHeight;


### PR DESCRIPTION
## What this does

`MiniMap` subscribes to the store with `useStore(selector, shallow)`, and the selector builds new objects on every call:

```ts
const selector = (s) => {
  const viewBB = { x: ..., y: ..., width: ..., height: ... };
  return {
    viewBB,
    boundingRect: s.nodeLookup.size > 0 ? getBoundsOfRects(getInternalNodesBounds(...), viewBB) : viewBB,
    ...
  };
};
```

`viewBB` and `boundingRect` are fresh objects each call, so zustand's `shallow` (which reference-compares values one level deep) always treats them as changed. The equality check can never bail out, so the minimap re-renders on every `store.setState`, including changes that do not affect it such as node selection. Each of those renders recomputes the node bounds (`getInternalNodesBounds` over the whole `nodeLookup`) and reconciles the SVG.

This replaces `shallow` with an equality function that compares the two rects by value and the remaining (stable-reference) fields the way `shallow` already did. Same pattern `SelectionListener` and `NodeToolbar` already use.

## No behavior change

The minimap still re-renders whenever its geometry changes (pan, zoom, resize, node bounds growing or shrinking). It no longer re-renders when the store changes in a way that leaves its geometry identical. Per-node color and selection still update because `MiniMapNode` has its own subscription, independent of the parent.

## Numbers

Measured on the Basic example (4 nodes, `<MiniMap />`), driving the real `store.setState` path one update at a time with the equality function swapped at runtime, counting `MiniMap` renders. 10 cycles is 20 store updates per interaction (dev StrictMode doubles the render count, both columns equally).

| interaction (20 store updates) | before (shallow) | after (value compare) |
|---|---|---|
| select / deselect a node (geometry unchanged) | 40 | 0 |
| pan back and forth (viewport changes) | 40 | 40 |

Selection-driven renders go to zero; genuine viewport updates are untouched.

## Verification

- `tsc`, eslint and prettier clean, the package builds.
- Confirmed in the browser that selecting a node renders the parent `MiniMap` 0 times while the minimap node's `selected` class still toggles, so there is no visual change.
