### PR TITLE
fix(system): keep self-loop edge selection set in onConnect

### DIFF
--- a/.changeset/selfloop-edge-selection.md
+++ b/.changeset/selfloop-edge-selection.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix self-loop edges created in `onConnect` not keeping their `selected` state. Completing a connection on the same node no longer fires a node click that clears the new edge's selection.

--- a/examples/react/src/generic-tests/edges/selfloop.ts
+++ b/examples/react/src/generic-tests/edges/selfloop.ts
@@ -1,0 +1,16 @@
+/*
+ * Test setup for issue #5833 (self-loop edge selection).
+ * Keeps the default nodeDragThreshold (1) so node selection runs through the
+ * click handler - the code path where the bug occurs. (nodes/general sets it to
+ * 0, which routes selection through XYDrag and hides the bug.)
+ */
+export default {
+  flowProps: {
+    fitView: true,
+    nodes: [
+      { id: 'A', data: { label: 'A' }, position: { x: 0, y: 0 } },
+      { id: 'B', data: { label: 'B' }, position: { x: 200, y: 150 } },
+    ],
+    edges: [],
+  },
+} satisfies FlowConfig;

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -225,6 +225,18 @@ function onPointerDown<NodeType extends NodeBase = NodeBase, EdgeType extends Ed
       if (edgeUpdaterType) {
         onReconnectEnd?.(event, finalConnectionState);
       }
+
+      /*
+       * When a connection starts and ends on the same node (a self-loop), the
+       * browser fires a click on that node because pointerdown and pointerup
+       * share it as a common ancestor. That click would select the node and
+       * clear the selection of the freshly created edge. Swallow the click that
+       * immediately follows the connection so it doesn't change the selection.
+       */
+      const preventNextClick = (clickEvent: Event) => clickEvent.stopPropagation();
+      doc.addEventListener('click', preventNextClick, { capture: true, once: true });
+      // remove it again in case no click follows (e.g. connection to another node)
+      setTimeout(() => doc.removeEventListener('click', preventNextClick, { capture: true }), 0);
     }
 
     cancelConnection();

--- a/tests/playwright/e2e/nodes.spec.ts
+++ b/tests/playwright/e2e/nodes.spec.ts
@@ -264,6 +264,28 @@ test.describe('Nodes', () => {
 
       await expect(page.locator(`.${FRAMEWORK}-flow__edge`)).toHaveCount(2);
     });
+
+    test('creating a self-loop does not select the source node (#5833)', async ({ page }) => {
+      // dedicated harness with the default nodeDragThreshold (the bug lives in the click path)
+      await page.goto('/tests/generic/edges/selfloop');
+
+      const sourceHandle = page.locator(`.${FRAMEWORK}-flow__handle.source`).and(page.locator('[data-nodeid="A"]'));
+      const targetHandle = page.locator(`.${FRAMEWORK}-flow__handle.target`).and(page.locator('[data-nodeid="A"]'));
+      const node = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="A"]'));
+
+      await expect(node).toHaveCSS('visibility', 'visible');
+      await expect(page.locator(`.${FRAMEWORK}-flow__edge`)).toHaveCount(0);
+
+      await sourceHandle.hover();
+      await page.mouse.down();
+      await targetHandle.hover();
+      await page.mouse.up();
+
+      // the self-loop edge is created
+      await expect(page.locator(`.${FRAMEWORK}-flow__edge`)).toHaveCount(1);
+      // ...and creating it must not select the node, which would clear the edge's selection
+      await expect(node).not.toHaveClass(/selected/);
+    });
   });
 
   test('hidden=true hides the node', async ({ page }) => {


### PR DESCRIPTION
Fixes #5833

## Problem
A self-loop edge (source === target) created in `onConnect` with `selected: true` is not selected right after creation, while a normal edge between two nodes is.

## Cause
A connection that starts and ends on the same node fires a `click` on that node, because `pointerdown` and `pointerup` share it as a common ancestor. That click selects the node and clears the selection of the edge that was just created in `onConnect`.

## Fix
Swallow the click that immediately follows a connection in `XYHandle.onPointerUp` (capture phase, once). The change lives in `@xyflow/system`, so it covers both React Flow and Svelte Flow.

## Test
Added an e2e test asserting that creating a self-loop does not select the source node. The full Playwright e2e suite passes locally.


### Verification
- `tsc` (system + react) and eslint clean on the changed file
- Full Playwright e2e suite green (44/44), including a new regression test asserting a self-loop connection doesn't select the source node
- Reproduced the bug and confirmed the fix in the dev server (before: gray / unselected, after: selected) for both a normal edge and a self-loop