### PR TITLE
fix(system): always pair onPanZoomEnd with onPanZoomStart on pan-on-scroll (#5840)

### DIFF
--- a/.changeset/pan-on-scroll-end-event.md
+++ b/.changeset/pan-on-scroll-end-event.md
@@ -2,4 +2,4 @@
 "@xyflow/system": patch
 ---
 
-Fix `onPanZoomEnd` not firing (and `onPanZoomStart` being skipped on the next gesture) after a single pan-on-scroll wheel tick
+Always fire `onPanZoomEnd` when `onPanZoomStart` was fired due to a pan-on-scroll wheel tick

--- a/.changeset/pan-on-scroll-end-event.md
+++ b/.changeset/pan-on-scroll-end-event.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix `onPanZoomEnd` not firing (and `onPanZoomStart` being skipped on the next gesture) after a single pan-on-scroll wheel tick

--- a/packages/system/src/xypanzoom/eventhandler.ts
+++ b/packages/system/src/xypanzoom/eventhandler.ts
@@ -130,13 +130,20 @@ export function createPanOnScrollHandler({
       onPanZoomStart?.(event, nextViewport);
     } else {
       onPanZoom?.(event, nextViewport);
-
-      zoomPanValues.panScrollTimeout = setTimeout(() => {
-        onPanZoomEnd?.(event, nextViewport);
-
-        zoomPanValues.isPanScrolling = false;
-      }, 150);
     }
+
+    /*
+     * (re)arm the end timeout on every wheel tick, not only on subsequent ones.
+     * Otherwise a single isolated wheel tick fires onPanZoomStart but never
+     * schedules the end, so onPanZoomEnd is never called and isPanScrolling
+     * stays true forever - which also makes the next gesture skip its own
+     * onPanZoomStart. (#5840)
+     */
+    zoomPanValues.panScrollTimeout = setTimeout(() => {
+      onPanZoomEnd?.(event, nextViewport);
+
+      zoomPanValues.isPanScrolling = false;
+    }, 150);
   };
 }
 

--- a/packages/system/src/xypanzoom/eventhandler.ts
+++ b/packages/system/src/xypanzoom/eventhandler.ts
@@ -132,13 +132,6 @@ export function createPanOnScrollHandler({
       onPanZoom?.(event, nextViewport);
     }
 
-    /*
-     * (re)arm the end timeout on every wheel tick, not only on subsequent ones.
-     * Otherwise a single isolated wheel tick fires onPanZoomStart but never
-     * schedules the end, so onPanZoomEnd is never called and isPanScrolling
-     * stays true forever - which also makes the next gesture skip its own
-     * onPanZoomStart. (#5840)
-     */
     zoomPanValues.panScrollTimeout = setTimeout(() => {
       onPanZoomEnd?.(event, nextViewport);
 


### PR DESCRIPTION
## Summary

Fixes #5840.

`createPanOnScrollHandler` handles the pan-zoom start/zoom/end callbacks itself (it can't rely on d3-zoom's events for pan-on-scroll). It scheduled the "end" timeout **only in the subsequent-tick (`else`) branch**:

```ts
if (!zoomPanValues.isPanScrolling) {
  zoomPanValues.isPanScrolling = true;
  onPanZoomStart?.(event, nextViewport);
} else {
  onPanZoom?.(event, nextViewport);
  zoomPanValues.panScrollTimeout = setTimeout(() => {   // ← only armed here
    onPanZoomEnd?.(event, nextViewport);
    zoomPanValues.isPanScrolling = false;
  }, 150);
}
```

So a **single isolated wheel tick** (one scroll notch with no follow-up) fires `onPanZoomStart` but never schedules the end timeout. `onPanZoomEnd` is therefore never called and `isPanScrolling` stays `true` forever. The next gesture then takes the `else` branch on its very first tick, skipping its own `onPanZoomStart` — permanently misaligning start/end pairs.

## Fix

Move the end-timeout scheduling out of the `else` branch so it is (re)armed on **every** wheel tick. `clearTimeout` is already called at the top of each tick, so multi-tick gestures still emit a single `onPanZoomEnd` 150 ms after the last tick, while a single tick now also gets its matching end.

## Verification

Driving the real `createPanOnScrollHandler` (mocked `d3Selection`/`d3Zoom`, real timers) with two separate single-tick gestures:

| | event sequence | `isPanScrolling` after |
|---|---|---|
| before | `START zoom END` | (first gesture never ended, second never started) |
| after  | `START END START END` | `false` |

The sequence is wrong before the change and correctly paired after it.

I did not add an automated test: `@xyflow/system` has no unit-test setup for the event handlers, and the existing cypress wheel-event tests are flagged as unreliable in the repo (`view-props.cy.tsx`: "the event is somehow broken… works fine when using the mouse"). Happy to add a test in whatever form you prefer.
