### PR TITLE
perf(system): cache pane extent so wheel zoom doesn't force a synchronous layout

### DIFF
--- a/.changeset/cache-zoom-pane-extent.md
+++ b/.changeset/cache-zoom-pane-extent.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Cache the zoom pane extent so wheel zoom no longer forces a synchronous layout. d3-zoom's `defaultExtent` reads `clientWidth`/`clientHeight` on every wheel event; backing the extent with a `ResizeObserver`-refreshed cache moves that read off the hot path and removes the per-wheel forced reflow. Behavior is unchanged.

--- a/.changeset/cache-zoom-pane-extent.md
+++ b/.changeset/cache-zoom-pane-extent.md
@@ -2,4 +2,4 @@
 "@xyflow/system": patch
 ---
 
-Cache the zoom pane extent so wheel zoom no longer forces a synchronous layout. d3-zoom's `defaultExtent` reads `clientWidth`/`clientHeight` on every wheel event; backing the extent with a `ResizeObserver`-refreshed cache moves that read off the hot path and removes the per-wheel forced reflow. Behavior is unchanged.
+Cache the zoom pane extent so panning and pinching no longer force a synchronous layout. d3-zoom's `defaultExtent` reads `clientWidth`/`clientHeight` on every pan and pinch scroll event; backing the extent with a `ResizeObserver`-refreshed cache moves that read off the hot path and removes the per-event forced reflow. Behavior is unchanged.

--- a/.changeset/cache-zoom-pane-extent.md
+++ b/.changeset/cache-zoom-pane-extent.md
@@ -2,4 +2,4 @@
 "@xyflow/system": patch
 ---
 
-Cache the zoom pane extent so panning and pinching no longer force a synchronous layout. d3-zoom's `defaultExtent` reads `clientWidth`/`clientHeight` on every pan and pinch scroll event; backing the extent with a `ResizeObserver`-refreshed cache moves that read off the hot path and removes the per-event forced reflow. Behavior is unchanged.
+Cache the zoom pane extent so panning and pinching no longer force a synchronous layout.

--- a/packages/system/src/xypanzoom/XYPanZoom.ts
+++ b/packages/system/src/xypanzoom/XYPanZoom.ts
@@ -54,7 +54,36 @@ export function XYPanZoom({
     isPanScrolling: false,
   };
   const bbox = domNode.getBoundingClientRect();
-  const d3ZoomInstance = zoom().scaleExtent([minZoom, maxZoom]).translateExtent(translateExtent);
+
+  /*
+   * Cache the pane extent and refresh it from a ResizeObserver instead of letting d3-zoom fall back
+   * to its defaultExtent, which reads `clientWidth`/`clientHeight` and so forces a synchronous layout
+   * on every wheel event. The observer is intentionally never disconnected: destroy() is also called
+   * to pause zooming while a user selection is active, so disconnecting there would leave the cache
+   * stale — it becomes unreachable (and is garbage collected) once the pane unmounts.
+   */
+  let cachedExtent: CoordinateExtent = [
+    [0, 0],
+    [bbox.width, bbox.height],
+  ];
+  const extentResizeObserver =
+    typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (entry) {
+            cachedExtent = [
+              [0, 0],
+              [entry.contentRect.width, entry.contentRect.height],
+            ];
+          }
+        })
+      : null;
+  extentResizeObserver?.observe(domNode);
+
+  const d3ZoomInstance = zoom()
+    .extent(() => cachedExtent)
+    .scaleExtent([minZoom, maxZoom])
+    .translateExtent(translateExtent);
   const d3Selection = select(domNode).call(d3ZoomInstance);
 
   setViewportConstrained(

--- a/packages/system/src/xypanzoom/XYPanZoom.ts
+++ b/packages/system/src/xypanzoom/XYPanZoom.ts
@@ -56,11 +56,11 @@ export function XYPanZoom({
   const bbox = domNode.getBoundingClientRect();
 
   /*
-   * Cache the pane extent and refresh it from a ResizeObserver instead of letting d3-zoom fall back
-   * to its defaultExtent, which reads `clientWidth`/`clientHeight` and so forces a synchronous layout
-   * on every wheel event. The observer is intentionally never disconnected: destroy() is also called
-   * to pause zooming while a user selection is active, so disconnecting there would leave the cache
-   * stale — it becomes unreachable (and is garbage collected) once the pane unmounts.
+   * Cache the pane extent and refresh it from a ResizeObserver. Otherwise d3-zoom falls back to its
+   * defaultExtent, which reads clientWidth/clientHeight and forces a synchronous layout while panning
+   * and pinching. The observer is never disconnected on purpose: destroy() also runs to pause zooming
+   * during a user selection, so disconnecting there would leave the cache stale. It becomes unreachable
+   * and is garbage collected with the pane on unmount.
    */
   let cachedExtent: CoordinateExtent = [
     [0, 0],


### PR DESCRIPTION
## Problem

`XYPanZoom` creates its d3-zoom behavior without an `.extent()` accessor, so d3-zoom falls back to its `defaultExtent`, which reads `clientWidth`/`clientHeight` of the pane. Reading those properties forces the browser to flush pending layout (a synchronous reflow). On the `panOnScroll` and pinch paths d3-zoom reads the extent on **every scroll event** (through `translateBy`/`scaleTo`); on the default wheel-zoom path it reads it once per gesture.

## Fix

Cache the pane extent and refresh it from a `ResizeObserver` (which reads layout once per resize, off the hot path), then pass `.extent(() => cachedExtent)` to the zoom behavior. d3-zoom now uses the cached value instead of reading `clientWidth`/`clientHeight` per event. The constrain/centroid math is unchanged because the cached extent stays in sync with the pane via the observer.

The observer is intentionally never disconnected: `destroy()` is also called to pause zooming while a user selection is active, so disconnecting there would leave the cache stale. The observer becomes unreachable (and is garbage collected) once the pane unmounts.

## Impact

This removes a forced-layout read from the pan/pinch hot path. A/B on the example app with the real library: 1000 `panOnScroll` wheel events over a 400-node canvas produced 2000 `clientWidth` + 2000 `clientHeight` forced reads on the baseline and 0 after the change.

The wall-clock benefit is conditional on layout being dirty when that read happens, so it depends on the workload:

- A transform-only pan keeps layout clean, so the eliminated reads were already cheap. A plain gesture shows no measurable change, even with very heavy nodes (measured: ~800 custom nodes / ~35k elements, baseline and patched within noise).
- The win shows up when the surrounding app invalidates layout each frame (a global class / CSS-var toggle, a font or container-size change, `onlyRenderVisibleElements` churn, etc.). Then each baseline `clientWidth` read forces a synchronous reflow of the canvas; on the heavy tree above with layout dirtied every frame that reflow measured ~49 ms per event, versus zero after the change.

So this is best read as removing a forced-layout access from the hot path: free when layout is clean, and large savings exactly in the heavy, layout-churning case. No behavior change; pan/zoom, zoom-to-cursor, and translate-extent constraints are unaffected.

## Notes

- `ResizeObserver` is feature-detected (`typeof ResizeObserver !== 'undefined'`) so SSR / non-DOM environments fall back to the initial `getBoundingClientRect()` extent.
- Changeset included (`@xyflow/system` patch).
