### PR TITLE
fix(system): include hidden intrinsic-sized nodes in fitView when includeHiddenNodes is set (#5841)

### DIFF
--- a/.changeset/fitview-include-hidden-intrinsic-nodes.md
+++ b/.changeset/fitview-include-hidden-intrinsic-nodes.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix `fitView` with `includeHiddenNodes` ignoring hidden nodes that declare an intrinsic size (`width`/`height`/`initialWidth`/`initialHeight`) but were never measured

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -339,7 +339,20 @@ function getFitViewNodes<
   const optionNodeIds = options?.nodes ? new Set(options.nodes.map((node) => node.id)) : null;
 
   nodeLookup.forEach((n) => {
-    const isVisible = n.measured.width && n.measured.height && (options?.includeHiddenNodes || !n.hidden);
+    let isVisible: boolean;
+
+    if (options?.includeHiddenNodes) {
+      /*
+       * when hidden nodes are included they were never rendered, so they have no
+       * measured size. Fall back to the declared dimensions (same fallback as
+       * nodeToBox) so a hidden node with an intrinsic size still contributes to
+       * the fit bounds instead of being dropped by a measured-only check. (#5841)
+       */
+      const { width, height } = getNodeDimensions(n);
+      isVisible = width > 0 && height > 0;
+    } else {
+      isVisible = Boolean(n.measured.width && n.measured.height && !n.hidden);
+    }
 
     if (isVisible && (!optionNodeIds || optionNodeIds.has(n.id))) {
       fitViewNodes.set(n.id, n);


### PR DESCRIPTION
## Summary

Fixes #5841.

`getFitViewNodes` decides which nodes to fit with:

```ts
const isVisible = n.measured.width && n.measured.height && (options?.includeHiddenNodes || !n.hidden);
```

The `n.measured.width && n.measured.height` gate excludes any node without measured dimensions. A hidden node is never rendered, so it is never measured — which means a hidden node that declares an **intrinsic size** (`width`/`height` or `initialWidth`/`initialHeight`) is dropped from the fit **even when `includeHiddenNodes: true` is passed**, contrary to what that option implies.

The bounds pipeline already knows how to size such a node: `nodeToBox` (via `getInternalNodesBounds`) computes a node's box with `node.measured?.width ?? node.width ?? node.initialWidth ?? 0`. Only the `getFitViewNodes` pre-filter, using a measured-only check, prevents the node from ever reaching it.

## Fix

When `includeHiddenNodes` is set, size the node with `getNodeDimensions(n)` — the same `measured → width → initialWidth` fallback `nodeToBox` uses — and include it if that yields a positive size. This is scoped deliberately:

- **`includeHiddenNodes: true`** → a hidden node with an intrinsic size is now included; a measured node is included as before; a truly size-less node (no measured and no declared dimensions) is still skipped (this avoids the open question in the issue about defaulting size-less nodes).
- **default path (no `includeHiddenNodes`)** → keeps its exact previous behavior (`n.measured.width && n.measured.height && !n.hidden`), so nothing changes for the common case.

## Verification

Truth table of the new gate (verified against the real `getNodeDimensions` fallback):

| node | `includeHiddenNodes` | before | after |
|---|---|---|---|
| hidden, `initialWidth/Height`, unmeasured | true | excluded ❌ | **included ✅** |
| hidden, `initialWidth/Height`, unmeasured | false | excluded | excluded (unchanged) |
| normal measured node | true/false | included | included (unchanged) |
| truly size-less node | true | excluded | excluded (unchanged) |

`getNodeDimensions` is already imported in this file; `tsc --noEmit` and `eslint` pass on the change.

I did not add an automated test because `getFitViewNodes` is an internal (non-exported) helper and the package has no unit-test setup for it — happy to add one (e.g. exporting it for a unit test, or a cypress flow test) in whatever form you prefer.
