### PR TITLE
fix(vue): apply numeric node style width/height (react parity)

### DIFF
--- a/packages/vue/src/components/Nodes/NodeWrapper.ts
+++ b/packages/vue/src/components/Nodes/NodeWrapper.ts
@@ -166,6 +166,16 @@ const NodeWrapper = defineComponent({
       // reactive AND would cache stale width/height onto the user object across renders)
       const styles = { ...node?.style };
 
+      // xyflow/react auto-appends `px` to numeric CSS dimensions; Vue's `:style` binding does not, so a
+      // react-style `style: { width: 380 }` would be dropped as invalid CSS. Coerce numeric `style` width/
+      // height to px for parity (string values like `'50%'` are left untouched).
+      if (typeof styles.width === 'number') {
+        styles.width = `${styles.width}px`;
+      }
+      if (typeof styles.height === 'number') {
+        styles.height = `${styles.height}px`;
+      }
+
       // mirror xyflow/react's `getNodeInlineStyleDimensions`: before the node is measured (no handle bounds
       // yet — e.g. first paint / SSR) fall back through `initialWidth`/`initialHeight`; once measured, only
       // an explicit `width`/`height` overrides the natural measured size.


### PR DESCRIPTION
## What

`NodeWrapper`'s `getStyle` pxifies top-level `node.width`/`node.height`, but spreads `node.style` verbatim. `@xyflow/react` relies on React auto-appending `px` to numeric CSS dimensions, so `style: { width: 380 }` sizes a node there. Vue's `:style` binding does **not** auto-append units, so a numeric `style.width` is invalid CSS and gets silently dropped — the node falls back to its content size.

Impact:
- Porting any `@xyflow/react` example that sizes nodes via `style` breaks in `@xyflow/vue`. Concretely, the **Overview** example's `group` container (`style: { width: 380, height: 180 }`) renders at ~0 size and its `tools`/`resizer` sub-nodes collapse to content size instead of 80×80.
- `@xyflow/vue`'s own Overview example (`examples/vue/src/Overview`) sets `style: { …, width: 180 }` on a node and relies on it applying.

## Fix

Coerce numeric `style.width`/`style.height` to `px` in `getStyle`, mirroring the existing top-level width/height handling. String values (`'50%'`, `'180px'`, …) are left untouched.

```ts
const styles = { ...node?.style };

if (typeof styles.width === 'number') {
  styles.width = `${styles.width}px`;
}
if (typeof styles.height === 'number') {
  styles.height = `${styles.height}px`;
}
```

## Verification

`@xyflow/vue` has no unit-test harness (`test: exit 0`), so verified by build + empirical repro:
- `pnpm --filter @xyflow/vue build` clean (tsdown + dts + attw).
- Repro'd the bug directly: a node with numeric `style: { width: 380 }` renders with no width in the DOM `style` attribute (Vue drops it); the same node with top-level `width: 380` (which `getStyle` already pxifies) renders `width: 380px` and sizes correctly. This fix routes numeric `style.width/height` through that same proven path.

Note: this only coerces `width`/`height` (the node-sizing case). React auto-appends `px` to many numeric CSS props; broadening this to match React fully could be a follow-up, but `width`/`height` is the dimension bug in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)