### PR TITLE
fix(vue): account for nodeOrigin in keyboard node movement

### DIFF
--- a/packages/vue/src/composables/useUpdateNodePositions.ts
+++ b/packages/vue/src/composables/useUpdateNodePositions.ts
@@ -1,7 +1,6 @@
 import type { XYPosition } from '@xyflow/system';
 import type { NodeDragItem } from '../types';
-import { getNodeDimensions } from '@xyflow/system';
-import { calcNextPosition } from '../utils';
+import { calculateNodePosition, getNodeDimensions, snapPosition } from '@xyflow/system';
 import { useStore } from './useStore';
 import { useVueFlow } from './useVueFlow';
 
@@ -11,7 +10,7 @@ import { useVueFlow } from './useVueFlow';
  * @internal
  */
 export function useUpdateNodePositions() {
-  const { getSelectedNodes, updateNodePositions, getInternalNode, emits } = useVueFlow();
+  const { getSelectedNodes, updateNodePositions, getInternalNode } = useVueFlow();
   const store = useStore();
 
   return (positionDiff: XYPosition, isShiftPressed = false) => {
@@ -33,27 +32,33 @@ export function useUpdateNodePositions() {
           continue;
         }
 
-        const nextPosition = {
+        let nextPosition = {
           x: internalNode.internals.positionAbsolute.x + positionDiffX,
           y: internalNode.internals.positionAbsolute.y + positionDiffY,
         };
 
-        const { position } = calcNextPosition(
-          internalNode,
+        if (store.snapToGrid) {
+          nextPosition = snapPosition(nextPosition, store.snapGrid);
+        }
+
+        // mirror xyflow/react's `useMoveSelectedNodes`: the origin-aware `calculateNodePosition` derives the
+        // new `position` AND `positionAbsolute` (accounting for `nodeOrigin`, extent + parent). The previous
+        // `calcNextPosition` ignored `nodeOrigin` and reused the stale `positionAbsolute`, so with a
+        // non-default origin the offset re-applied on every key press — the node drifted by the origin offset.
+        const { position, positionAbsolute } = calculateNodePosition({
+          nodeId: node.id,
           nextPosition,
-          emits.error,
-          store.nodeExtent,
-          node.parentId ? getInternalNode(node.parentId) : undefined,
-        );
+          nodeLookup: store.nodeLookup,
+          nodeExtent: store.nodeExtent,
+          nodeOrigin: store.nodeOrigin,
+        });
 
         nodeUpdates.push({
           id: node.id,
           position,
           distance: { x: positionDiff.x, y: positionDiff.y },
           measured: getNodeDimensions(internalNode),
-          internals: {
-            positionAbsolute: { x: internalNode.internals.positionAbsolute.x, y: internalNode.internals.positionAbsolute.y },
-          },
+          internals: { positionAbsolute },
         });
       }
     }


### PR DESCRIPTION
## What

Arrow-key node movement (`useUpdateNodePositions`) used a custom `calcNextPosition` that **ignores `nodeOrigin`** and reused the node's **stale `positionAbsolute`**. With a non-default origin the origin offset re-applied on every key press, so a selected node drifted by `origin * dimensions` each press — regardless of arrow direction — and further than the intended step.

## Repro

A flow with `:node-origin="[0.5, 0]"` (e.g. the "add node on edge drop" example): select a node, press any arrow key. Observed: x jumps **left by ~half the node width every press** (up/down also drag x left); y moves correctly. Overview-style flows with the default origin are unaffected (offset 0).

Measured on a 150px-wide node (`node-origin [0.5,0]`, start rendered x −75): `→` gave −145, −215 (−70/press) instead of −70, −65 (+5/press).

## Fix

Mirror xyflow/react's `useMoveSelectedNodes`: use the origin-aware `calculateNodePosition` from `@xyflow/system` (which derives both `position` **and** `positionAbsolute`, accounting for origin, extent + parent) and push the **recomputed** `positionAbsolute` instead of the stale one. Also snap the next position when `snapToGrid` is set (react does too). `calcNextPosition` was only used here, so it's now unused (left in place; can be removed as follow-up cleanup).

## Verification

`@xyflow/vue` has no unit-test harness (`test: exit 0`), so verified by build + E2E: built the package, swapped it into a running example with `node-origin="[0.5, 0]"`, and confirmed arrow keys now move `→ +5, ← −5, ↑ −5, ↓ +5` with no x drift (previously −70/press). Root-caused against react parity (react's `calculateNodePosition` + `positionAbsolute` write-back vs vue's origin-blind `calcNextPosition` + stale `positionAbsolute`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)