### PR TITLE
fix(vue): rebuild connectionLookup from committed edges, not the stale v-model getter

### DIFF
--- a/packages/vue/src/store/actions.ts
+++ b/packages/vue/src/store/actions.ts
@@ -187,8 +187,12 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     state.edges = next;
 
     // the connection lookup derives 1:1 from the edges array — rebuilding it here keeps every write
-    // path (setEdges/applyEdgeChanges/reconnectEdge/$reset) consistent by construction
-    updateConnectionLookup(state.connectionLookup, state.edges);
+    // path (setEdges/applyEdgeChanges/reconnectEdge/$reset) consistent by construction. Feed it `next`
+    // (the array we just committed), NOT the `state.edges` getter: edges are backed by a `defineModel`
+    // v-model ref whose writes round-trip through the parent asynchronously, so the getter still reads
+    // the pre-commit value on this tick — reading it here would rebuild the lookup from stale edges and
+    // leave `useNodeConnections` empty until the next commit (the reported one-frame connection lag).
+    updateConnectionLookup(state.connectionLookup, next);
   }
 
   /**


### PR DESCRIPTION
## Problem

`useNodeConnections` updates a frame late — in practice only after an unrelated re-render (e.g. selecting the node). This breaks anything derived from it: the **connection-limit** example never disables its handle after the first edge, because `isConnectable` (`connections.length < limit`) keeps reading `0`.

## Root cause

`commitEdges` did:

```ts
state.edges = next;
updateConnectionLookup(state.connectionLookup, state.edges); // <- stale getter
```

Edges are backed by a `defineModel` v-model ref. Writing `state.edges = next` emits `update:edges` and only reflects once the parent round-trips the prop back (next tick). So on the same tick, the `state.edges` getter still returns the **pre-commit** value. `updateConnectionLookup` therefore `clear()`s the lookup and rebuilds it from stale (usually empty) edges, leaving it empty until the *next* commit.

This is why:
- `edgeLookup` was always correct (it's synced from the local `next` array), while `connectionLookup` lagged.
- a *second* `addEdges` appeared to "fix" it — by then the model had round-tripped, so the getter was current.

## Fix

Feed `updateConnectionLookup` the local `next` array we just committed, mirroring how `commitNodes` adopts its local array into `nodeLookup`:

```ts
state.edges = next;
updateConnectionLookup(state.connectionLookup, next);
```

## Verification

Reproduced and fixed against a fresh build (traced `commitEdges`: `next=1` but `state.edges=0` on the same tick). After the fix, adding an edge into a limited handle populates `connectionLookup` (`['1','1-source','2','2-target']`), `connections.length → 1`, and `isConnectable → false` synchronously on the reactive flush — the handle loses `connectable`/`connectionindicator` with **no** re-selection needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)