### PR TITLE
fix(vue): anchor the connection line to the handle center, matching xyflow/react

### DIFF
--- a/packages/vue/src/components/ConnectionLine/index.ts
+++ b/packages/vue/src/components/ConnectionLine/index.ts
@@ -62,7 +62,10 @@ const ConnectionLine = defineComponent({
 
       const fromHandle = (startHandleId ? handleBounds.find(d => d.id === startHandleId) : handleBounds[0]) ?? null;
       const fromPosition = fromHandle?.position ?? Position.Top;
-      const { x: fromX, y: fromY } = getHandlePosition(fromNode.value, fromHandle, fromPosition);
+      // `center: true` — the connection line starts from the handle's CENTER, matching xyflow/react+system
+      // (`XYHandle` computes `connection.from` with center=true). Without it a large handle (e.g. one that
+      // covers the whole node, as in the "easy connect" example) would anchor to its `position` edge.
+      const { x: fromX, y: fromY } = getHandlePosition(fromNode.value, fromHandle, fromPosition, true);
 
       let toHandle: HandleElement | null = null;
       if (toNode.value) {
@@ -89,9 +92,10 @@ const ConnectionLine = defineComponent({
         return null;
       }
 
-      // snap the line end to the hovered handle when there is one; otherwise follow the raw pointer
+      // snap the line end to the hovered handle's CENTER (center=true, like the from-handle above and the
+      // system's closest-handle match) when there is one; otherwise follow the raw pointer
       const { x: toX, y: toY }
-        = toHandle && toNode.value ? getHandlePosition(toNode.value, toHandle, toPosition) : pointer.value;
+        = toHandle && toNode.value ? getHandlePosition(toNode.value, toHandle, toPosition, true) : pointer.value;
 
       const type = connectionLineOptions.value.type ?? ConnectionLineType.Bezier;
 


### PR DESCRIPTION
## Problem

The connection line (the temporary line shown while dragging a new connection) anchors to the **edge** of the source/target handle instead of its **center**. With a normal dot-sized handle this is invisible (center ≈ edge), but when the whole node is a handle — the "easy connect" pattern — the line visibly starts from the node's right/left edge rather than its center, diverging from xyflow/react.

## Root cause

`packages/vue/src/components/ConnectionLine/index.ts` recomputes the endpoints with:

```ts
getHandlePosition(fromNode, fromHandle, fromPosition)        // from
getHandlePosition(toNode, toHandle, toPosition)              // to (when snapped to a handle)
```

`getHandlePosition(node, handle, fallback, center = false)` returns the `position` edge when `center` is falsy. `@xyflow/system` + xyflow/react always resolve connection endpoints with `center: true`:

- `XYHandle` computes `connection.from` via `getHandlePosition(fromInternalNode, fromHandle, Position.Left, true)`
- closest-handle matching (`getClosestHandle`, `getHandle`) uses `center: true`

So react's connection line starts from the handle's geometric center; vue's started from the edge.

## Fix

Pass `center: true` for both endpoints, matching react/system. Since `center: true` ignores the position arg for the coordinate, the existing `fromPosition`/`toPosition` (still used for path curvature) are unaffected.

## Verification

`easy-connect` example (full-node handles), measured mid-drag:
- **Before:** line start = node right-center
- **After:** line start = node center (`484,130` = exact node center, vs `640,130` right-center) — matches react side-by-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)