### PR TITLE
feat(vue): default <Panel> position to top-left, matching xyflow/react

### DIFF
--- a/packages/vue/src/components/Panel/Panel.vue
+++ b/packages/vue/src/components/Panel/Panel.vue
@@ -3,7 +3,7 @@ import type { PanelProps } from '../../types/panel';
 import { computed } from 'vue';
 import { storeToRefs, useStore } from '../../composables';
 
-const props = defineProps<PanelProps>();
+const props = withDefaults(defineProps<PanelProps>(), { position: 'top-left' });
 
 const { userSelectionActive } = storeToRefs(useStore());
 

--- a/packages/vue/src/types/panel.ts
+++ b/packages/vue/src/types/panel.ts
@@ -1,7 +1,8 @@
 import type { PanelPosition } from '@xyflow/system';
 
 export interface PanelProps {
-  position: PanelPosition;
+  /** the position of the panel; defaults to `top-left` (mirrors xyflow/react) */
+  position?: PanelPosition;
   /** accessible label for the panel container, applied as `aria-label` (used by `<Controls>`) */
   label?: string | null;
 }


### PR DESCRIPTION
## Problem

`@xyflow/vue`'s `<Panel>` required an explicit `position` prop, so `<Panel>content</Panel>` (no position) was a type error. xyflow/react defaults `position = 'top-left'` and types it optional — vue should match for parity (several react examples, e.g. `hidden`, use a bare `<Panel>`).

## Fix

- `PanelProps.position` → optional (`position?: PanelPosition`)
- default it via `withDefaults(defineProps<PanelProps>(), { position: 'top-left' })`

`<Controls>` always passes an explicit position, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)