### PR TITLE
feat(vue): warn on duplicate node/edge ids via onError

### DIFF
--- a/packages/vue/src/store/actions.ts
+++ b/packages/vue/src/store/actions.ts
@@ -40,6 +40,7 @@ import {
   createEdgeRemoveChange,
   createNodeRemoveChange,
   createSelectionChange,
+  ErrorCode,
   getSelectionChanges,
   isDef,
   isInternalNode,
@@ -47,6 +48,7 @@ import {
   reconnectEdgeAction,
   updateConnectionLookup,
   validateEdges,
+  VueFlowError,
 } from '../utils';
 import { storeOptionsToSkip, useState } from './state';
 
@@ -163,9 +165,18 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // targeted sync instead of clear+refill: clearing a `reactive(Map)` invalidates every edge
     // subscriber even when a single edge changed
     const rawEdgeLookup = toRaw(edgeLookup);
+    const seenEdgeIds = new Set<string>();
 
     for (let i = 0; i < next.length; i++) {
       const edge = (next[i] = markRaw(toRaw(next[i])));
+      // a duplicate id silently overwrites the earlier edge in the id-keyed lookup (last wins) — surface it
+      // so the otherwise-invisible data bug is debuggable; behaviour is unchanged (we still adopt it)
+      if (seenEdgeIds.has(edge.id)) {
+        state.hooks.error.trigger(new VueFlowError(ErrorCode.EDGE_DUPLICATE_ID, edge.id));
+      }
+      else {
+        seenEdgeIds.add(edge.id);
+      }
       if (rawEdgeLookup.get(edge.id) !== edge) {
         edgeLookup.set(edge.id, edge);
       }

--- a/packages/vue/src/utils/errors.ts
+++ b/packages/vue/src/utils/errors.ts
@@ -6,12 +6,14 @@ export enum ErrorCode {
   NODE_MISSING_PARENT = 'NODE_MISSING_PARENT',
   NODE_TYPE_MISSING = 'NODE_TYPE_MISSING',
   NODE_EXTENT_INVALID = 'NODE_EXTENT_INVALID',
+  NODE_DUPLICATE_ID = 'NODE_DUPLICATE_ID',
   EDGE_INVALID = 'EDGE_INVALID',
   EDGE_NOT_FOUND = 'EDGE_NOT_FOUND',
   EDGE_SOURCE_MISSING = 'EDGE_SOURCE_MISSING',
   EDGE_TARGET_MISSING = 'EDGE_TARGET_MISSING',
   EDGE_TYPE_MISSING = 'EDGE_TYPE_MISSING',
   EDGE_SOURCE_TARGET_MISSING = 'EDGE_SOURCE_TARGET_MISSING',
+  EDGE_DUPLICATE_ID = 'EDGE_DUPLICATE_ID',
 
   USE_VUE_FLOW_OUTSIDE_PROVIDER = 'USE_VUE_FLOW_OUTSIDE_PROVIDER',
 }
@@ -26,6 +28,7 @@ const messages = {
     `Node is missing a parent\nNode id: ${id}\nParent id: ${parentId}`,
   [ErrorCode.NODE_TYPE_MISSING]: (type: string) => `Node type is missing\nType: ${type}`,
   [ErrorCode.NODE_EXTENT_INVALID]: (id: string) => `Only child nodes can use a parent extent\nNode id: ${id}`,
+  [ErrorCode.NODE_DUPLICATE_ID]: (id: string) => `Node id is not unique — a later node overwrites the earlier one in the lookup\nNode id: ${id}`,
   [ErrorCode.EDGE_INVALID]: (id: string) => `An edge needs a source and a target\nEdge id: ${id}`,
   [ErrorCode.EDGE_SOURCE_MISSING]: (id: string, source: string) =>
     `Edge source is missing\nEdge id: ${id} \nSource id: ${source}`,
@@ -34,6 +37,7 @@ const messages = {
   [ErrorCode.EDGE_TYPE_MISSING]: (type: string) => `Edge type is missing\nType: ${type}`,
   [ErrorCode.EDGE_SOURCE_TARGET_MISSING]: (id: string, source: string, target: string) =>
     `Edge source or target is missing\nEdge id: ${id} \nSource id: ${source} \nTarget id: ${target}`,
+  [ErrorCode.EDGE_DUPLICATE_ID]: (id: string) => `Edge id is not unique — a later edge overwrites the earlier one in the lookup\nEdge id: ${id}`,
   [ErrorCode.EDGE_NOT_FOUND]: (id: string) => `Edge not found\nEdge id: ${id}`,
   [ErrorCode.USE_VUE_FLOW_OUTSIDE_PROVIDER]: () =>
     `useVueFlow() was called without a <VueFlow> or <VueFlowProvider> ancestor (or outside a component setup). Render one of them above the call, or wrap your components in <VueFlowProvider> to share a store.`,

--- a/packages/vue/src/utils/store.ts
+++ b/packages/vue/src/utils/store.ts
@@ -126,6 +126,7 @@ export function adoptNodes<NodeType extends Node = Node>(
   options?: CreateInternalNodesOptions,
 ): { nodes: NodeType[]; hasSelectedNodes: boolean } {
   const validNodes: NodeType[] = [];
+  const seenNodeIds = new Set<string>();
   for (let i = 0; i < nodes.length; ++i) {
     const node = nodes[i];
 
@@ -134,6 +135,15 @@ export function adoptNodes<NodeType extends Node = Node>(
         new VueFlowError(ErrorCode.NODE_INVALID, (node as undefined | Record<any, any>)?.id ?? `[ID UNKNOWN|INDEX ${i}]`),
       );
       continue;
+    }
+
+    // a duplicate id silently overwrites the earlier node in the id-keyed lookup (last wins) — surface it
+    // so the otherwise-invisible data bug is debuggable; behaviour is unchanged (we still adopt it)
+    if (seenNodeIds.has(node.id)) {
+      triggerError(new VueFlowError(ErrorCode.NODE_DUPLICATE_ID, node.id));
+    }
+    else {
+      seenNodeIds.add(node.id);
     }
 
     // `markRaw` the user node so Vue never deep-proxies it (the perf goal — large `data` objects stay


### PR DESCRIPTION
## Problem

Nodes and edges are keyed by `id` in the lookups, so a **duplicate id silently overwrites** the earlier one (last wins) with no warning — an invisible, hard-to-debug data bug. None of react/svelte/vue currently surface it.

## Fix

Emit through the existing `ErrorCode`/`onError` mechanism, like the other model validations (missing source/target, invalid node, …):

- **`NODE_DUPLICATE_ID`** — from `adoptNodes` (the full-set commit point for nodes).
- **`EDGE_DUPLICATE_ID`** — from `commitEdges` (the full-set commit point for edges, so it also catches an *added* edge colliding with an existing id — `validateEdges` only sees the incoming batch).

Behaviour is unchanged: the duplicate is still adopted and the lookup keeps its last-wins semantics (matching xyflow/react's Map-based store). This only adds the warning, and the check piggybacks on loops that already iterate the arrays (O(1) extra per element on the existing hot path).

## Verification

Via the `onError` hook in a live example: duplicate ids within a `setNodes`/`setEdges` array fire `NODE_DUPLICATE_ID` / `EDGE_DUPLICATE_ID`; a normal `setNodes` and `addNodes(existing-id)` (a no-op) do not. `EDGE_TARGET_MISSING` used as a working control.

Note: this is currently vue-only — react/svelte have the same silent-overwrite gap, so it's a candidate to lift into `@xyflow/system` for all three if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)