### PR TITLE
fix(vue): resolve NodeResizeControl's node id from context

### DIFF
--- a/packages/vue/src/components/NodeResizer/ResizeControl.vue
+++ b/packages/vue/src/components/NodeResizer/ResizeControl.vue
@@ -3,8 +3,9 @@ import type { NodeDimensionChange, NodePositionChange } from '@xyflow/system';
 import type { NodeChange } from '../../types';
 import type { NodeResizerEmits, ResizeControlProps } from './types';
 import { evaluateAbsolutePosition, handleExpandParent, XYResizer } from '@xyflow/system';
-import { computed, shallowRef, toRef, watchEffect } from 'vue';
+import { computed, inject, shallowRef, toRef, watchEffect } from 'vue';
 import { storeToRefs, useStore, useVueFlow } from '../../composables';
+import { NodeId } from '../../context';
 import { ResizeControlVariant } from './types';
 import { DefaultPositions, StylingProperty } from './utils';
 
@@ -28,6 +29,12 @@ const { transform, nodeOrigin, snapGrid, snapToGrid, vueFlowRef, noDragClassName
 
 const resizeControlRef = shallowRef<HTMLDivElement>();
 
+// mirror NodeResizer: fall back to the node context id so a bare `<NodeResizeControl>` inside a custom
+// node resolves its node without an explicit `node-id` prop (matches xyflow/react's `useNodeId()` fallback)
+const contextNodeId = inject(NodeId, null);
+
+const nodeId = toRef(() => (typeof props.nodeId === 'string' ? props.nodeId : contextNodeId ?? undefined));
+
 const controlPosition = toRef(() => props.position ?? DefaultPositions[props.variant]);
 
 const positionClassNames = computed(() => controlPosition.value.split('-'));
@@ -35,13 +42,13 @@ const positionClassNames = computed(() => controlPosition.value.split('-'));
 const controlStyle = toRef(() => (props.color ? { [StylingProperty[props.variant]]: props.color } : {}));
 
 watchEffect((onCleanup) => {
-  if (!resizeControlRef.value || !props.nodeId) {
+  if (!resizeControlRef.value || !nodeId.value) {
     return;
   }
 
   const resizerInstance = XYResizer({
     domNode: resizeControlRef.value,
-    nodeId: props.nodeId,
+    nodeId: nodeId.value,
     getStoreItems: () => ({
       nodeLookup,
       transform: transform.value,
@@ -52,7 +59,7 @@ watchEffect((onCleanup) => {
     }),
     onChange: (changes, childChanges) => {
       const nodeChanges: NodeChange[] = [];
-      const node = nodeLookup.get(props.nodeId!);
+      const node = nodeLookup.get(nodeId.value!);
 
       // resolved x/y for the resized node; clamped below when the node expands its parent
       let nextX = changes.x;
@@ -94,7 +101,7 @@ watchEffect((onCleanup) => {
           y: nextY ?? node?.position.y ?? 0,
         };
         nodeChanges.push({
-          id: props.nodeId!,
+          id: nodeId.value!,
           type: 'position',
           position,
           positionAbsolute: position,
@@ -103,7 +110,7 @@ watchEffect((onCleanup) => {
 
       if (typeof changes.width !== 'undefined' || typeof changes.height !== 'undefined') {
         nodeChanges.push({
-          id: props.nodeId!,
+          id: nodeId.value!,
           type: 'dimensions',
           setAttributes: true,
           resizing: true,
@@ -130,7 +137,7 @@ watchEffect((onCleanup) => {
     onEnd: ({ width, height }) => {
       triggerEmits.nodesChange([
         {
-          id: props.nodeId!,
+          id: nodeId.value!,
           type: 'dimensions',
           resizing: false,
           dimensions: { width, height },


### PR DESCRIPTION
## Problem

A bare `<NodeResizeControl>` placed inside a custom node **cannot resize** — dragging its handle does nothing.

`ResizeControl` (what `NodeResizeControl` is) only reads `props.nodeId` and bails out of initializing its `XYResizer` when it's absent:

```ts
watchEffect(() => {
  if (!resizeControlRef.value || !props.nodeId) return;  // ← always bails inside a custom node
  const resizerInstance = XYResizer({ /* … */ });
});
```

Inside a custom node the user doesn't pass `node-id` (they expect it from context, like in xyflow/react where `NodeResizeControl` calls `useNodeId()`). So `props.nodeId` is `undefined`, the effect returns early, and **no d3-drag listeners are ever attached** to the control.

`NodeResizer` already handles this — it injects the `NodeId` context and passes the resolved id to its `ResizeControl`s (which is why the standalone `<NodeResizer />` works). `ResizeControl` just never got the same fallback.

## Fix

Resolve the node id from the injected `NodeId` context when `nodeId` isn't passed as a prop, mirroring `NodeResizer`:

```ts
const contextNodeId = inject(NodeId, null);
const nodeId = toRef(() => (typeof props.nodeId === 'string' ? props.nodeId : contextNodeId ?? undefined));
```

and use `nodeId.value` throughout the effect (guard, `XYResizer` config, and the emitted node changes).

## Verification

Reproduced in the node-resizer example (a custom node using `<NodeResizeControl>` with a custom icon):

- **Before:** the control has no `mousedown.drag` d3 listener (`__on` is `undefined`) and the node does not resize.
- **After:** the control attaches `mousedown.drag` just like the default `NodeResizer` handles, and dragging it resizes the node (verified live: 129×100 → 240×182), with no change to `NodeResizer` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)