### PR TITLE
feat(vue): export pure addEdge + reconnectEdge helpers

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -57,6 +57,7 @@ export * from './types';
  */
 export { applyChanges, applyEdgeChanges, applyNodeChanges } from './utils/changes';
 export { defaultEdgeTypes, defaultNodeTypes } from './utils/defaultNodesEdges';
+export { addEdge, reconnectEdge } from './utils/edges';
 export { ErrorCode, isErrorOfType, VueFlowError } from './utils/errors';
 export { connectionExists, isEdge, isInternalNode, isNode } from './utils/graph';
 

--- a/packages/vue/src/utils/edges.ts
+++ b/packages/vue/src/utils/edges.ts
@@ -1,0 +1,43 @@
+import type { AddEdgeOptions, Connection, EdgeBase, ReconnectEdgeOptions } from '@xyflow/system';
+import { addEdge as addEdgeSystem, createDevWarn, reconnectEdge as reconnectEdgeSystem } from '@xyflow/system';
+
+const defaultOnError = createDevWarn('Vue Flow', 'https://vueflow.dev/');
+
+/**
+ * Adds a `Connection` (or a full `Edge`) to an edges array and returns a new array — generating the
+ * edge id and skipping the add when an equivalent connection already exists. The pure helper to use
+ * in an `@connect` handler against a `v-model:edges` array, e.g.
+ * `edges.value = addEdge(connection, edges.value)`, with no store/instance access.
+ *
+ * Mirrors xyflow/react's + xyflow/svelte's `addEdge`.
+ */
+export function addEdge<EdgeType extends EdgeBase>(
+  edgeParams: EdgeType | Connection,
+  edges: EdgeType[],
+  options: AddEdgeOptions = {},
+): EdgeType[] {
+  return addEdgeSystem(edgeParams, edges, {
+    ...options,
+    onError: options.onError ?? defaultOnError,
+  });
+}
+
+/**
+ * Reconnects an existing edge to a new `Connection`, returning a new edges array. The pure,
+ * controlled counterpart to the store action `useVueFlow().reconnectEdge` — use it in an
+ * `@reconnect` handler against a `v-model:edges` array, e.g.
+ * `edges.value = reconnectEdge(oldEdge, newConnection, edges.value)`.
+ *
+ * Mirrors xyflow/react's `reconnectEdge`.
+ */
+export function reconnectEdge<EdgeType extends EdgeBase>(
+  oldEdge: EdgeType,
+  newConnection: Connection,
+  edges: EdgeType[],
+  options: ReconnectEdgeOptions = { shouldReplaceId: true },
+): EdgeType[] {
+  return reconnectEdgeSystem(oldEdge, newConnection, edges, {
+    ...options,
+    onError: options.onError ?? defaultOnError,
+  });
+}


### PR DESCRIPTION
## What

Adds two pure edge helpers to `@xyflow/vue`, mirroring xyflow/react's `packages/react/src/utils/edges.ts`:

```ts
import { addEdge, reconnectEdge } from '@xyflow/vue'

function onConnect(connection: Connection) {
  edges.value = addEdge(connection, edges.value)
}
function onReconnect(oldEdge: Edge, newConnection: Connection) {
  edges.value = reconnectEdge(oldEdge, newConnection, edges.value)
}
```

Both are thin wrappers over `@xyflow/system`'s `addEdge`/`reconnectEdge` (id generation, dedupe) with a Vue-flavoured default `onError` (`createDevWarn('Vue Flow', 'https://vueflow.dev/')`).

## Why

For a controlled flow (`v-model:nodes`/`v-model:edges`), the host component *renders* `<VueFlow>`, so it sits **outside** the store's provider context and can't call `useVueFlow().addEdges`. The only prior option was a template ref:

```ts
const flow = shallowRef<VueFlowInstance>()
function onConnect(c: Connection) { flow.value?.addEdges([c]) }
```

— a ref + optional chaining + array-wrapping, purely as a workaround. The pure helper removes all of that and matches the controlled-flow pattern React and Svelte already document. `@xyflow/vue` was the only framework package missing this (`@xyflow/system` already exports the underlying functions).

## Notes

- Vue already exposes `reconnectEdge` as a **store action** (`useVueFlow().reconnectEdge`, mutates the store). The new top-level `reconnectEdge` is the pure, controlled counterpart — same relationship as `addEdges` (instance action) vs `addEdge` (pure helper), just sharing the name. No export collision.
- Additive and non-breaking.

## Verification

- Build + `attw`/`publint` pass; `addEdge(connection, edges)` and `reconnectEdge(oldEdge, connection, edges)` both infer `Edge[]` from a consumer probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)