### PR TITLE
feat(vue): add setupVueFlow() composable

### DIFF
--- a/packages/vue/src/composables/setupVueFlow.ts
+++ b/packages/vue/src/composables/setupVueFlow.ts
@@ -1,0 +1,34 @@
+import type { Edge, FlowOptions, Node, VueFlowInstance } from '../types';
+import { useCreateVueFlow } from './useCreateVueFlow';
+
+/**
+ * Create a VueFlow store, `provide` it to the current component's subtree, and return the instance — the
+ * same API as {@link useVueFlow}. The Vue-native alternative to wrapping in `<VueFlowProvider>`: call it
+ * in the component that renders `<VueFlow>` and you get the store's actions/getters/hooks in that same
+ * `setup`, while the rendered `<VueFlow>` (and any `useVueFlow()`/`useStore()` below it) reuse the provided
+ * store instead of creating their own.
+ *
+ * Must run in a component `setup` (it calls `provide`). Delegates to the same store factory as
+ * `<VueFlowProvider>`, so one call scopes one store — host a single `<VueFlow>` per setup.
+ *
+ * @public
+ * @param options - initial flow options (`id`, initial nodes/edges, defaults, …)
+ * @returns the VueFlow instance (same shape `useVueFlow()` returns)
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { setupVueFlow, VueFlow } from '@xyflow/vue'
+ *
+ * const { addEdges, fitView } = setupVueFlow()
+ * </script>
+ *
+ * <template>
+ *   <VueFlow v-model:nodes="nodes" v-model:edges="edges" />
+ * </template>
+ * ```
+ */
+export function setupVueFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
+  options?: FlowOptions<NodeType, EdgeType>,
+): VueFlowInstance<NodeType, EdgeType> {
+  return useCreateVueFlow<NodeType, EdgeType>(options).instance as unknown as VueFlowInstance<NodeType, EdgeType>;
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -44,6 +44,7 @@ export { useNodeId } from './composables/useNodeId';
 export { useNodesData } from './composables/useNodesData';
 export { useNodesInitialized } from './composables/useNodesInitialized';
 
+export { setupVueFlow } from './composables/setupVueFlow';
 export { useStore } from './composables/useStore';
 export { useVueFlow } from './composables/useVueFlow';
 export { default as VueFlow } from './container/VueFlow/VueFlow.vue';


### PR DESCRIPTION
A Vue-native alternative to <VueFlowProvider>: create + provide the store AND return the useVueFlow() instance in one call, so the component that renders <VueFlow> gets actions/getters/hooks in the same setup (no wrapper component, no separate useVueFlow() call). Delegates to the existing store factory, so a descendant <VueFlow> reuses the provided store.