### PR TITLE
feat: add parent node update helper

### DIFF
--- a/.changeset/clean-pandas-learn.md
+++ b/.changeset/clean-pandas-learn.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/system': minor
+'@xyflow/react': minor
+'@xyflow/svelte': minor
+---
+
+Add updateParentNode helper for changing node parents while preserving absolute position.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -138,6 +138,8 @@ export {
   getIncomers,
   getOutgoers,
   getConnectedEdges,
+  updateParentNode,
+  type UpdateParentNodeParams,
 } from '@xyflow/system';
 
 export { addEdge, reconnectEdge } from './utils/edges';

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -142,4 +142,6 @@ export {
   getIncomers,
   getOutgoers,
   getConnectedEdges,
+  updateParentNode,
+  type UpdateParentNodeParams
 } from '@xyflow/system';

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -44,11 +44,22 @@ export const isEdgeBase = <EdgeType extends EdgeBase = EdgeBase>(element: unknow
  * @returns A boolean indicating whether the element is an Node
  */
 export const isNodeBase = <NodeType extends NodeBase = NodeBase>(element: unknown): element is NodeType =>
-    !!element && typeof element === 'object' && 'id' in element && 'position' in element && !('source' in element) && !('target' in element);
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'position' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 export const isInternalNodeBase = <NodeType extends InternalNodeBase = InternalNodeBase>(
   element: unknown
-): element is NodeType => !!element && typeof element === 'object' &&  'id' in element && 'internals' in element && !('source' in element) && !('target' in element);
+): element is NodeType =>
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'internals' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 /**
  * This util is used to tell you what nodes, if any, are connected to the given node
@@ -144,6 +155,73 @@ export const getNodePositionWithOrigin = (node: NodeBase, nodeOrigin: NodeOrigin
     y: node.position.y - offsetY,
   };
 };
+
+export type UpdateParentNodeParams<NodeType extends NodeBase = NodeBase> = {
+  nodeId: string;
+  parentNodeId: string | null;
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>;
+  nodeOrigin?: NodeOrigin;
+};
+
+function isDescendantNode<NodeType extends NodeBase>(
+  nodeId: string,
+  parentNodeId: string,
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>
+): boolean {
+  let currentNode = nodeLookup.get(parentNodeId);
+
+  while (currentNode?.parentId) {
+    if (currentNode.parentId === nodeId) {
+      return true;
+    }
+
+    currentNode = nodeLookup.get(currentNode.parentId);
+  }
+
+  return false;
+}
+
+/**
+ * Returns an updated user node with a new parent while keeping its absolute
+ * position on the canvas.
+ *
+ * @public
+ */
+export function updateParentNode<NodeType extends NodeBase = NodeBase>({
+  nodeId,
+  parentNodeId,
+  nodeLookup,
+  nodeOrigin = [0, 0],
+}: UpdateParentNodeParams<NodeType>): NodeType | undefined {
+  const node = nodeLookup.get(nodeId);
+
+  if (!node || parentNodeId === nodeId) {
+    return;
+  }
+
+  const parentNode = parentNodeId ? nodeLookup.get(parentNodeId) : undefined;
+
+  if (parentNodeId && (!parentNode || isDescendantNode(nodeId, parentNodeId, nodeLookup))) {
+    return;
+  }
+
+  const { width, height } = getNodeDimensions(node);
+  const origin = node.origin ?? nodeOrigin;
+  const parentPosition = parentNode?.internals.positionAbsolute ?? { x: 0, y: 0 };
+  const position = {
+    x: node.internals.positionAbsolute.x - parentPosition.x + width * origin[0],
+    y: node.internals.positionAbsolute.y - parentPosition.y + height * origin[1],
+  };
+  const nextNode = { ...node.internals.userNode, position };
+
+  if (parentNodeId) {
+    return { ...nextNode, parentId: parentNodeId };
+  }
+
+  delete nextNode.parentId;
+
+  return nextNode;
+}
 
 export type GetNodesBoundsParams<NodeType extends NodeBase = NodeBase> = {
   /**


### PR DESCRIPTION
Closes #5807.

Adds a small  helper in  for changing, adding, or removing a node parent while preserving the node's absolute canvas position. The helper returns an updated user node, so it can be used by React and Svelte callers with their existing node update flows.

It also guards against missing parents, self-parenting, and descendant parent cycles.

Verification:
- 
> @xyflow/system@0.0.79 typecheck /Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/system
> tsc --noEmit
- 
> @xyflow/react@12.11.2 typecheck /Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/react
> tsc --noEmit
- 
> @xyflow/svelte@1.6.2 typecheck /Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/svelte
> pnpm check


> @xyflow/svelte@1.6.2 check /Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/svelte
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json

Loading svelte-check in workspace: /Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/svelte
Getting Svelte diagnostics...

/Users/mac/Desktop/pr/repositories/submitted-prs/xyflow-parent-node-helper-20260708/packages/svelte/tsconfig.json:1:1
Warn: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions 


====================================
svelte-check found 0 errors and 1 warning in 1 file (0 errors, existing @types/node warning)
- 
- 
- 
- Checking formatting...
All matched files use Prettier code style!

Note: full package lint currently reports existing unrelated issues in files outside this change.