### PR TITLE
fix(system): skip unresolvable ids in getNodesBounds instead of anchoring bounds to the origin

### DIFF
--- a/.changeset/getnodesbounds-skip-missing-nodes.md
+++ b/.changeset/getnodesbounds-skip-missing-nodes.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix `getNodesBounds` stretching the returned bounds to include the origin `(0, 0)` when one of the passed ids/nodes can't be resolved (e.g. a stale or already-removed id). Unresolvable entries are now skipped, matching `getInternalNodesBounds`.

--- a/.changeset/getnodesbounds-skip-missing-nodes.md
+++ b/.changeset/getnodesbounds-skip-missing-nodes.md
@@ -2,4 +2,4 @@
 "@xyflow/system": patch
 ---
 
-Fix `getNodesBounds` stretching the returned bounds to include the origin `(0, 0)` when one of the passed ids/nodes can't be resolved (e.g. a stale or already-removed id). Unresolvable entries are now skipped, matching `getInternalNodesBounds`.
+Fix `getNodesBounds` stretching the returned bounds to include the origin `(0, 0)` when one of the passed ids/nodes can't be resolved. 

--- a/examples/react/cypress/components/utils/get-nodes-bounds.cy.ts
+++ b/examples/react/cypress/components/utils/get-nodes-bounds.cy.ts
@@ -150,6 +150,31 @@ describe('getNodesBounds Testing', () => {
     expect(bounds.width).to.equal(100);
     expect(bounds.height).to.equal(230);
   });
+
+  it('ignores unresolvable ids instead of stretching the bounds to the origin', () => {
+    const nodeLookup: NodeLookup = new Map();
+    const parentLookup: ParentLookup = new Map();
+
+    const nodes: Node[] = [
+      {
+        id: '1',
+        data: { label: 'node' },
+        position: { x: 100, y: 100 },
+        measured: { width: 100, height: 50 },
+      },
+    ];
+
+    adoptUserNodes(nodes, nodeLookup, parentLookup);
+
+    // '2' is not in the lookup (e.g. a stale id after that node was removed)
+    const bounds = getNodesBounds(['1', '2'], { nodeLookup });
+
+    // bounds should match node '1' only, not be stretched to include (0, 0)
+    expect(bounds.x).to.equal(100);
+    expect(bounds.y).to.equal(100);
+    expect(bounds.width).to.equal(100);
+    expect(bounds.height).to.equal(50);
+  });
 });
 
 export {};

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -203,6 +203,7 @@ export const getNodesBounds = <NodeType extends NodeBase = NodeBase>(
     return { x: 0, y: 0, width: 0, height: 0 };
   }
 
+  let hasNode = false;
   const box = nodes.reduce(
     (currBox, nodeOrId) => {
       const isId = typeof nodeOrId === 'string';
@@ -216,13 +217,22 @@ export const getNodesBounds = <NodeType extends NodeBase = NodeBase>(
           : nodeOrId;
       }
 
-      const nodeBox = currentNode ? nodeToBox(currentNode, params.nodeOrigin) : { x: 0, y: 0, x2: 0, y2: 0 };
-      return getBoundsOfBoxes(currBox, nodeBox);
+      /*
+       * Skip ids/nodes that can't be resolved (e.g. a stale or already-removed id).
+       * Merging a phantom box at the origin would stretch the bounds to include
+       * (0, 0). This mirrors getInternalNodesBounds, which skips unmatched nodes.
+       */
+      if (!currentNode) {
+        return currBox;
+      }
+
+      hasNode = true;
+      return getBoundsOfBoxes(currBox, nodeToBox(currentNode, params.nodeOrigin));
     },
     { x: Infinity, y: Infinity, x2: -Infinity, y2: -Infinity }
   );
 
-  return boxToRect(box);
+  return hasNode ? boxToRect(box) : { x: 0, y: 0, width: 0, height: 0 };
 };
 
 export type GetInternalNodesBoundsParams<NodeType> = {


### PR DESCRIPTION
## The bug

`getNodesBounds` (public, exposed via `useReactFlow().getNodesBounds` / `useSvelteFlow`) merges a phantom box at the origin whenever a passed id/node can't be resolved from the `nodeLookup`:

```ts
// packages/system/src/utils/graph.ts
const nodeBox = currentNode ? nodeToBox(currentNode, params.nodeOrigin) : { x: 0, y: 0, x2: 0, y2: 0 };
return getBoundsOfBoxes(currBox, nodeBox);
```

Since `getBoundsOfBoxes` takes the `min`/`max` of the corners, that `{0,0,0,0}` box stretches the result to always include `(0, 0)`.

**Trigger:** call `getNodesBounds` with an id that isn't in the lookup — e.g. a stale id after a node was removed, or ids from state that's briefly out of sync.

```ts
// node '1' is at { x: 100, y: 100, width: 100, height: 50 }, '2' was removed
getNodesBounds(['1', '2'], { nodeLookup })
// before: { x: 0,   y: 0,   width: 200, height: 150 }   ← stretched to the origin
// after:  { x: 100, y: 100, width: 100, height: 50  }   ← correct (node '1' only)
```

With negatively-positioned nodes it's even more visible: a node at `(-200, -200)` plus one missing id returns `{ x: -200, y: -200, width: 200, height: 200 }` instead of the node's real `{ x: -200, y: -200, width: 50, height: 50 }`. This wrong rect then feeds `getViewportForBounds`, so `fitView`/`fitBounds` on such a set pans/zooms incorrectly.

## The fix

Skip entries that can't be resolved (return the accumulator unchanged) and return an empty rect when none resolve. This mirrors the sibling `getInternalNodesBounds`, which already skips unmatched nodes and returns `{ x: 0, y: 0, width: 0, height: 0 }` when nothing matches. Behavior is unchanged when every id resolves.

## Verification

- Built `@xyflow/system` and ran the real `getNodesBounds`:
  - `['1', '2']` (one stale id) → `{100,100,100,50}` with the fix, `{0,0,200,150}` without it.
  - `['1']` (no missing) → unchanged.
  - `['x', 'y']` (all missing) → `{0,0,0,0}` (no `Infinity` leakage).
- Added a regression test to `examples/react/cypress/components/utils/get-nodes-bounds.cy.ts` (`ignores unresolvable ids instead of stretching the bounds to the origin`) that fails without this change and passes with it.
- `tsc --noEmit` and `eslint` pass on the changed file.

Found by auditing the bounds/dimension helpers after #5851 — same class of "unresolved node" inconsistency as #5845 (missing parent guard) and #5851 (measured-dimension fallback).
