### PR TITLE
feat(vue): add built-in group node type

### DIFF
--- a/packages/vue/src/components/Nodes/GroupNode.ts
+++ b/packages/vue/src/components/Nodes/GroupNode.ts
@@ -1,0 +1,14 @@
+import type { FunctionalComponent } from 'vue';
+import type { BuiltInNode, NodeProps } from '../../types';
+
+// A group node renders nothing — it's just a styled container (the `.vue-flow__node-group` class).
+// Mirrors xyflow/react's built-in `group: () => null`.
+const GroupNode: FunctionalComponent<NodeProps<BuiltInNode>> = function () {
+  return null;
+};
+
+GroupNode.props = ['sourcePosition', 'targetPosition', 'isConnectable', 'data'];
+GroupNode.inheritAttrs = false;
+GroupNode.compatConfig = { MODE: 3 };
+
+export default GroupNode;

--- a/packages/vue/src/components/Nodes/index.ts
+++ b/packages/vue/src/components/Nodes/index.ts
@@ -1,4 +1,5 @@
 export { default as DefaultNode } from './DefaultNode';
+export { default as GroupNode } from './GroupNode';
 export { default as InputNode } from './InputNode';
 export { default as NodeWrapper } from './NodeWrapper';
 export { default as OutputNode } from './OutputNode';

--- a/packages/vue/src/types/components.ts
+++ b/packages/vue/src/types/components.ts
@@ -35,7 +35,7 @@ export interface DefaultEdgeTypes {
   smoothstep: typeof SmoothStepEdge;
 }
 
-export type DefaultNodeTypes = { [key in 'input' | 'output' | 'default']: NodeComponent<BuiltInNode> };
+export type DefaultNodeTypes = { [key in 'input' | 'output' | 'default' | 'group']: NodeComponent<BuiltInNode> };
 
 /** these props are passed to edge texts */
 export interface EdgeTextProps {

--- a/packages/vue/src/utils/defaultNodesEdges.ts
+++ b/packages/vue/src/utils/defaultNodesEdges.ts
@@ -6,6 +6,7 @@ import SmoothStepEdge from '../components/Edges/SmoothStepEdge';
 import StepEdge from '../components/Edges/StepEdge';
 import StraightEdge from '../components/Edges/StraightEdge';
 import DefaultNode from '../components/Nodes/DefaultNode';
+import GroupNode from '../components/Nodes/GroupNode';
 import InputNode from '../components/Nodes/InputNode';
 import OutputNode from '../components/Nodes/OutputNode';
 
@@ -13,6 +14,7 @@ export const defaultNodeTypes: DefaultNodeTypes = {
   input: InputNode,
   default: DefaultNode,
   output: OutputNode,
+  group: GroupNode,
 };
 
 export const defaultEdgeTypes: DefaultEdgeTypes = {


### PR DESCRIPTION
Mirror xyflow/react's built-in `group: () => null`: register a GroupNode that renders nothing so `type: 'group'` nodes are styled bare containers (via the `.vue-flow__node-group` class) instead of falling back to the default node component (label + handles). `BuiltInNode` already included `'group'`; this wires up the component + `defaultNodeTypes` + the `DefaultNodeTypes` union.