### PR TITLE
feat(vue): resolve setupVueFlow() on its own component level

### DIFF
--- a/packages/vue/src/composables/useStore.ts
+++ b/packages/vue/src/composables/useStore.ts
@@ -1,6 +1,5 @@
 import type { Edge, Node, VueFlowState } from '../types';
-import { inject } from 'vue';
-import { VueFlowStateKey } from '../context';
+import { injectFlowContext, VueFlowStateKey } from '../context';
 import { ErrorCode, VueFlowError } from '../utils/errors';
 
 /**
@@ -19,7 +18,7 @@ import { ErrorCode, VueFlowError } from '../utils/errors';
  * @returns the reactive state for the current context
  */
 export function useStore<NodeType extends Node = Node, EdgeType extends Edge = Edge>(): VueFlowState<NodeType, EdgeType> {
-  const state = inject(VueFlowStateKey, null) as VueFlowState<NodeType, EdgeType> | null;
+  const state = injectFlowContext(VueFlowStateKey) as VueFlowState<NodeType, EdgeType> | null;
 
   if (!state) {
     throw new VueFlowError(ErrorCode.USE_VUE_FLOW_OUTSIDE_PROVIDER);

--- a/packages/vue/src/composables/useVueFlow.ts
+++ b/packages/vue/src/composables/useVueFlow.ts
@@ -1,6 +1,5 @@
 import type { Edge, Node, VueFlowInstance } from '../types';
-import { inject } from 'vue';
-import { VueFlow } from '../context';
+import { injectFlowContext, VueFlow } from '../context';
 import { ErrorCode, VueFlowError } from '../utils/errors';
 
 /**
@@ -20,7 +19,7 @@ import { ErrorCode, VueFlowError } from '../utils/errors';
  * @returns the VueFlow instance for the current context
  */
 export function useVueFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(): VueFlowInstance<NodeType, EdgeType> {
-  const instance = inject(VueFlow, null) as VueFlowInstance<NodeType, EdgeType> | null;
+  const instance = injectFlowContext(VueFlow) as VueFlowInstance<NodeType, EdgeType> | null;
 
   if (!instance) {
     throw new VueFlowError(ErrorCode.USE_VUE_FLOW_OUTSIDE_PROVIDER);

--- a/packages/vue/src/context/index.ts
+++ b/packages/vue/src/context/index.ts
@@ -1,5 +1,6 @@
 import type { InjectionKey, ShallowRef } from 'vue';
 import type { FlowSlots, VueFlowInstance, VueFlowState } from '../types';
+import { getCurrentInstance, inject } from 'vue';
 
 /** the curated instance (`useVueFlow()`) */
 export const VueFlow: InjectionKey<VueFlowInstance> = Symbol('vueFlow');
@@ -10,3 +11,23 @@ export const NodeRef: InjectionKey<ShallowRef<HTMLDivElement | null>> = Symbol('
 export const EdgeId: InjectionKey<string> = Symbol('edgeId');
 export const EdgeRef: InjectionKey<ShallowRef<SVGElement | null>> = Symbol('edgeRef');
 export const Slots: InjectionKey<Readonly<FlowSlots>> = Symbol('slots');
+
+/**
+ * Resolve a provided flow-context value: the nearest ancestor's `provide` (via Vue's `inject`), falling
+ * back to the CURRENT component's own provides. `inject` only reads *ancestor* provides, so a component
+ * that both creates the store (`setupVueFlow()`) and consumes it (`useVueFlow()`/`useStore()`) in the
+ * same `setup` wouldn't otherwise see its own store — reading `getCurrentInstance().provides` closes that
+ * gap so `setupVueFlow()` resolves on its own level (as if a `<VueFlowProvider>` sat a level up).
+ */
+export function injectFlowContext<T>(key: InjectionKey<T>): T | null {
+  const fromAncestor = inject(key, null);
+
+  if (fromAncestor != null) {
+    return fromAncestor;
+  }
+
+  const self = getCurrentInstance();
+  const ownProvides = self?.provides as unknown as Record<symbol, T | undefined> | undefined;
+
+  return ownProvides?.[key] ?? null;
+}


### PR DESCRIPTION
useVueFlow()/useStore() now fall back to the current component's own provides (injectFlowContext) when inject() misses. Vue's inject only reads *ancestor* provides, so calling setupVueFlow() and then useVueFlow()/useNodesInitialized() in the SAME setup previously threw "called without a provider" — you had to wrap in <VueFlowProvider>. Reading getCurrentInstance().provides closes that gap, so setupVueFlow() works on its own level (the 1.x ergonomic, without the retired storage singleton). Ancestor still wins, so nested providers are unaffected.