### PR TITLE
fix(css): define --xy-node-color-default in base.css for base.css-only usage

### DIFF
--- a/packages/system/src/styles/base.css
+++ b/packages/system/src/styles/base.css
@@ -1,4 +1,5 @@
 .xy-flow {
+  --xy-node-color-default: light-dark(CanvasText, #f8f8f8);
   --xy-node-border-default: 1px solid #bbb;
   --xy-node-border-selected-default: 1px solid #555;
 


### PR DESCRIPTION
base.css applies `color: var(--xy-node-color, var(--xy-node-color-default))` on the built-in node types, but the fallback was only assigned in style.css. Consumers importing base.css alone (structural styling, no theme) rendered node text as inherited black instead of a color-scheme-aware value. xyflow/react's base.css defines it (dark override #f8f8f8); this restores parity using the fork's light-dark() convention, matching the value style.css already uses.