### PR TITLE
feat(vue): add updateParentNode helper + useVueFlow().updateParentNode action

### DIFF
--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -534,3 +534,70 @@ export async function getElementsToRemove<NodeType extends NodeBase = NodeBase, 
 
   return onBeforeDeleteResult;
 }
+
+export type UpdateParentNodeParams<NodeType extends NodeBase = NodeBase> = {
+  nodeId: string;
+  parentNodeId: string | null;
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>;
+  nodeOrigin?: NodeOrigin;
+};
+
+function isDescendantNode<NodeType extends NodeBase>(
+  nodeId: string,
+  parentNodeId: string,
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
+): boolean {
+  let currentNode = nodeLookup.get(parentNodeId);
+
+  while (currentNode?.parentId) {
+    if (currentNode.parentId === nodeId) {
+      return true;
+    }
+
+    currentNode = nodeLookup.get(currentNode.parentId);
+  }
+
+  return false;
+}
+
+/**
+ * Returns an updated user node with a new parent while keeping its absolute
+ * position on the canvas.
+ *
+ * @public
+ */
+export function updateParentNode<NodeType extends NodeBase = NodeBase>({
+  nodeId,
+  parentNodeId,
+  nodeLookup,
+  nodeOrigin = [0, 0],
+}: UpdateParentNodeParams<NodeType>): NodeType | undefined {
+  const node = nodeLookup.get(nodeId);
+
+  if (!node || parentNodeId === nodeId) {
+    return;
+  }
+
+  const parentNode = parentNodeId ? nodeLookup.get(parentNodeId) : undefined;
+
+  if (parentNodeId && (!parentNode || isDescendantNode(nodeId, parentNodeId, nodeLookup))) {
+    return;
+  }
+
+  const { width, height } = getNodeDimensions(node);
+  const origin = node.origin ?? nodeOrigin;
+  const parentPosition = parentNode?.internals.positionAbsolute ?? { x: 0, y: 0 };
+  const position = {
+    x: node.internals.positionAbsolute.x - parentPosition.x + width * origin[0],
+    y: node.internals.positionAbsolute.y - parentPosition.y + height * origin[1],
+  };
+  const nextNode = { ...node.internals.userNode, position };
+
+  if (parentNodeId) {
+    return { ...nextNode, parentId: parentNodeId };
+  }
+
+  delete nextNode.parentId;
+
+  return nextNode;
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -85,6 +85,7 @@ export {
   isNodeBase,
   pointToRendererPoint,
   rendererPointToPoint,
+  updateParentNode,
 } from '@xyflow/system';
 
 export {
@@ -123,6 +124,7 @@ export {
   type SetCenterOptions,
   type SetViewport,
   type SnapGrid,
+  type UpdateParentNodeParams,
   type Viewport,
   type ViewportHelperFunctionOptions,
   type XYPosition,

--- a/packages/vue/src/store/actions.ts
+++ b/packages/vue/src/store/actions.ts
@@ -30,6 +30,7 @@ import {
   nodeToRect,
   panBy as panBySystem,
   updateAbsolutePositions,
+  updateParentNode as updateParentNodeBase,
 } from '@xyflow/system';
 import { computed, markRaw, toRaw } from 'vue';
 import { useViewportHelper } from '../composables';
@@ -836,6 +837,21 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     commitNodes(next);
   };
 
+  const updateParentNode: Actions<NodeType>['updateParentNode'] = (id, parentId) => {
+    // The system helper does the position math (keep the node put on screen) + guards against cycles /
+    // missing nodes; we just feed it the store's lookup + origin and re-adopt the returned user node.
+    const next = updateParentNodeBase<NodeType>({
+      nodeId: id,
+      parentNodeId: parentId,
+      nodeLookup,
+      nodeOrigin: state.nodeOrigin,
+    });
+
+    if (next) {
+      updateNode(id, next, { replace: true });
+    }
+  };
+
   const startConnection: Actions<NodeType>['startConnection'] = (startHandle, position, isClick = false) => {
     if (isClick) {
       state.connectionClickStartHandle = startHandle;
@@ -1055,6 +1071,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     updateEdgeData,
     updateNode,
     updateNodeData,
+    updateParentNode,
     applyEdgeChanges,
     applyNodeChanges,
     addSelectedNodes,

--- a/packages/vue/src/types/store.ts
+++ b/packages/vue/src/types/store.ts
@@ -269,6 +269,13 @@ export type UpdateNodeData<NodeType extends Node = Node> = (
   options?: { replace: boolean },
 ) => void;
 
+/**
+ * Re-parents a node while keeping its absolute position on the canvas. Imperative counterpart of the pure
+ * `updateParentNode` helper (same name, like `reconnectEdge`) — reads the node lookup + node origin from the
+ * store and applies the result, so you only pass the node and its new parent (`null` detaches it).
+ */
+export type UpdateParentNode = (id: string, parentId: string | null) => void;
+
 export type IsNodeIntersecting<NodeType extends Node = Node> = (node: (Partial<NodeType> & { id: NodeType['id'] }) | Rect, area: Rect, partially?: boolean) => boolean;
 
 export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = Edge>
@@ -303,6 +310,8 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   updateNode: UpdateNode<NodeType>;
   /** updates the data of a node */
   updateNodeData: UpdateNodeData<NodeType>;
+  /** re-parents a node while keeping its absolute position (see {@link UpdateParentNode}) */
+  updateParentNode: UpdateParentNode;
   /** applies default edge change handler */
   applyEdgeChanges: (changes: EdgeChange<EdgeType>[]) => EdgeType[];
   /** applies default node change handler; returns the resulting user nodes */


### PR DESCRIPTION
Ports xyflow/xyflow#5870 to @xyflow/system: `updateParentNode({ nodeId, parentNodeId, nodeLookup, nodeOrigin })` returns an updated user node re-parented (or detached, `parentNodeId: null`) while keeping its absolute position, guarding against self-parenting and cycles. Re-exported from @xyflow/vue (with `UpdateParentNodeParams`), matching the react/svelte exports.

Also adds an imperative `useVueFlow().updateParentNode(id, parentId)` that reads the store's node lookup + node origin, calls the pure helper, and applies the result via `updateNode` — so callers don't wire up the lookup themselves. Same-name pure-vs-imperative pairing as `reconnectEdge`/`addEdge`.