### PR TITLE
fix(vue): keep edges whose endpoint node is missing instead of dropping them

### DIFF
--- a/.changeset/keep-edges-with-missing-nodes.md
+++ b/.changeset/keep-edges-with-missing-nodes.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/vue": patch
+---
+
+`setEdges`/`addEdges` no longer drop edges whose source or target node isn't in the store. Previously `validateEdges` discarded any edge with a missing endpoint at commit time, which silently deleted edges and made the order of `setNodes`/`setEdges` matter — adding edges before their nodes lost them. Edges are now kept and `EdgeWrapper` skips drawing them (emitting the existing `EDGE_SOURCE_MISSING`/`EDGE_TARGET_MISSING` dev warning) until both nodes exist, matching `@xyflow/react` & `@xyflow/svelte`. The `isValidConnection` gate still runs whenever both endpoint nodes are resolvable.

--- a/packages/vue/src/utils/store.ts
+++ b/packages/vue/src/utils/store.ts
@@ -286,18 +286,13 @@ export function validateEdges<EdgeType extends Edge = Edge>(
     const sourceNode = getInternalNode(edge.source);
     const targetNode = getInternalNode(edge.target);
 
-    if (!sourceNode && !targetNode) {
-      onError(new VueFlowError(ErrorCode.EDGE_SOURCE_TARGET_MISSING, edge.id, edge.source, edge.target));
-      continue;
-    }
-
-    if (!sourceNode) {
-      onError(new VueFlowError(ErrorCode.EDGE_SOURCE_MISSING, edge.id, edge.source));
-      continue;
-    }
-
-    if (!targetNode) {
-      onError(new VueFlowError(ErrorCode.EDGE_TARGET_MISSING, edge.id, edge.target));
+    // Keep edges whose endpoint node isn't in the store (yet) instead of dropping them: `EdgeWrapper`'s
+    // render-time guard already warns and skips drawing the edge until both nodes exist. This matches
+    // xyflow/react & xyflow/svelte — `setEdges`/`addEdges` are non-destructive, so callers don't have
+    // to add the referenced nodes before the edges. `isValidConnection` needs the resolved nodes, so it
+    // can't run in this case.
+    if (!sourceNode || !targetNode) {
+      validEdges.push(edge);
       continue;
     }
 


### PR DESCRIPTION
validateEdges discarded any edge with a missing source/target node at setEdges/addEdges commit time. That silently deleted edges and made the order of setNodes/setEdges significant — adding edges before their nodes lost them.

EdgeWrapper already guards the render path (warns via EDGE_SOURCE_MISSING/EDGE_TARGET_MISSING and skips drawing) exactly like @xyflow/react's EdgeWrapper, so the commit-time drop was both redundant and a divergence from react/svelte, which keep such edges in state and render them once the node appears.

validateEdges now keeps edges with an unresolved endpoint (deferring the warning to the render guard) and only runs isValidConnection when both nodes resolve. This makes setEdges/addEdges non-destructive and order-independent.