### PR TITLE
perf(system): reduce pan-on-scroll gesture work

### DIFF
--- a/.changeset/faster-pan-scroll-pinch.md
+++ b/.changeset/faster-pan-scroll-pinch.md
@@ -2,4 +2,4 @@
 '@xyflow/system': patch
 ---
 
-Reduce pinch-zoom work when pan-on-scroll is enabled by reusing the pane origin and end timer for each wheel gesture.
+Reduce pan-on-scroll and pinch-zoom work by reusing the pane origin and coalescing gesture-end timers.

--- a/.changeset/faster-pan-scroll-pinch.md
+++ b/.changeset/faster-pan-scroll-pinch.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Reduce pinch-zoom work when pan-on-scroll is enabled by reusing the pane origin and end timer for each wheel gesture.

--- a/packages/system/src/xypanzoom/XYPanZoom.ts
+++ b/packages/system/src/xypanzoom/XYPanZoom.ts
@@ -150,6 +150,7 @@ export function XYPanZoom({
     const wheelHandler = isPanOnScroll
       ? createPanOnScrollHandler({
           zoomPanValues,
+          domNode,
           noWheelClassName,
           d3Selection,
           d3Zoom: d3ZoomInstance,

--- a/packages/system/src/xypanzoom/eventhandler.ts
+++ b/packages/system/src/xypanzoom/eventhandler.ts
@@ -84,6 +84,30 @@ export function createPanOnScrollHandler({
 }: PanOnScrollParams) {
   let pinchPointerOrigin: [number, number] | undefined;
   let pinchPointerOriginDeadline = 0;
+  let panScrollEndDeadline = 0;
+  let panScrollEndEvent: MouseEvent | TouchEvent | null = null;
+  let panScrollEndViewport: ReturnType<typeof transformToViewport> | undefined;
+
+  const flushPanScrollEnd = () => {
+    const remaining = panScrollEndDeadline - Date.now();
+
+    if (remaining > 0) {
+      zoomPanValues.panScrollTimeout = setTimeout(flushPanScrollEnd, remaining);
+      return;
+    }
+
+    zoomPanValues.panScrollTimeout = undefined;
+    const event = panScrollEndEvent;
+    const viewport = panScrollEndViewport;
+    panScrollEndEvent = null;
+    panScrollEndViewport = undefined;
+
+    if (viewport) {
+      onPanZoomEnd?.(event, viewport);
+    }
+
+    zoomPanValues.isPanScrolling = false;
+  };
 
   return (event: any) => {
     if (isWrappedWithClass(event, noWheelClassName)) {
@@ -139,8 +163,6 @@ export function createPanOnScrollHandler({
 
     const nextViewport = transformToViewport(d3Selection.property('__zoom'));
 
-    clearTimeout(zoomPanValues.panScrollTimeout);
-
     /*
      * for pan on scroll we need to handle the event calls on our own
      * we can't use the start, zoom and end events from d3-zoom
@@ -154,11 +176,17 @@ export function createPanOnScrollHandler({
       onPanZoom?.(event, nextViewport);
     }
 
-    zoomPanValues.panScrollTimeout = setTimeout(() => {
-      onPanZoomEnd?.(event, nextViewport);
+    const scheduleEnd = panScrollEndEvent === null;
+    panScrollEndDeadline = Date.now() + wheelGestureTimeout;
+    panScrollEndEvent = event;
+    panScrollEndViewport = nextViewport;
 
-      zoomPanValues.isPanScrolling = false;
-    }, wheelGestureTimeout);
+    if (scheduleEnd) {
+      if (zoomPanValues.panScrollTimeout !== undefined) {
+        clearTimeout(zoomPanValues.panScrollTimeout);
+      }
+      zoomPanValues.panScrollTimeout = setTimeout(flushPanScrollEnd, wheelGestureTimeout);
+    }
   };
 }
 

--- a/packages/system/src/xypanzoom/eventhandler.ts
+++ b/packages/system/src/xypanzoom/eventhandler.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { D3ZoomEvent } from 'd3-zoom';
-import { pointer } from 'd3-selection';
 
 import {
   PanOnScrollMode,
@@ -14,10 +13,22 @@ import {
 } from '../types';
 import { isRightClickPan, isWrappedWithClass, transformToViewport, wheelDelta } from './utils';
 import { isMacOs } from '../utils';
-import { ZoomPanValues } from './XYPanZoom';
+import type { ZoomPanValues } from './XYPanZoom';
+
+const wheelGestureTimeout = 150;
+
+type PendingPanZoomEnd = {
+  callback: OnPanZoom | undefined;
+  deadline: number;
+  event: MouseEvent | TouchEvent | null;
+  viewport: ReturnType<typeof transformToViewport>;
+};
+
+const pendingPanZoomEnds = new WeakMap<ZoomPanValues, PendingPanZoomEnd>();
 
 export type PanOnScrollParams = {
   zoomPanValues: ZoomPanValues;
+  domNode: Element;
   noWheelClassName: string;
   d3Selection: D3SelectionInstance;
   d3Zoom: D3ZoomInstance;
@@ -60,6 +71,7 @@ export type PanZoomEndParams = {
 
 export function createPanOnScrollHandler({
   zoomPanValues,
+  domNode,
   noWheelClassName,
   d3Selection,
   d3Zoom,
@@ -70,6 +82,9 @@ export function createPanOnScrollHandler({
   onPanZoom,
   onPanZoomEnd,
 }: PanOnScrollParams) {
+  let pinchPointerOrigin: [number, number] | undefined;
+  let pinchPointerOriginDeadline = 0;
+
   return (event: any) => {
     if (isWrappedWithClass(event, noWheelClassName)) {
       if (event.ctrlKey) {
@@ -84,7 +99,14 @@ export function createPanOnScrollHandler({
 
     // macos sets ctrlKey=true for pinch gesture on a trackpad
     if (event.ctrlKey && zoomOnPinch) {
-      const point = pointer(event);
+      const now = Date.now();
+      if (!pinchPointerOrigin || now >= pinchPointerOriginDeadline) {
+        const rect = domNode.getBoundingClientRect();
+        pinchPointerOrigin = [rect.left + domNode.clientLeft, rect.top + domNode.clientTop];
+      }
+      pinchPointerOriginDeadline = now + wheelGestureTimeout;
+
+      const point = [event.clientX - pinchPointerOrigin[0], event.clientY - pinchPointerOrigin[1]];
       const pinchDelta = wheelDelta(event);
       const zoom = currentZoom * Math.pow(2, pinchDelta);
       // @ts-ignore
@@ -136,7 +158,7 @@ export function createPanOnScrollHandler({
       onPanZoomEnd?.(event, nextViewport);
 
       zoomPanValues.isPanScrolling = false;
-    }, 150);
+    }, wheelGestureTimeout);
   };
 }
 
@@ -215,6 +237,8 @@ export function createPanZoomEndHandler({
   onPanZoomEnd,
   onPaneContextMenu,
 }: PanZoomEndParams) {
+  const pendingPanZoomEnd = getPendingPanZoomEnd(zoomPanValues);
+
   return (event: D3ZoomEvent<HTMLDivElement, any>) => {
     if (event.sourceEvent?.internal) {
       return;
@@ -238,14 +262,77 @@ export function createPanZoomEndHandler({
       const viewport = transformToViewport(event.transform);
       zoomPanValues.prevViewport = viewport;
 
-      clearTimeout(zoomPanValues.timerId);
-      zoomPanValues.timerId = setTimeout(
-        () => {
-          onPanZoomEnd?.(event.sourceEvent as MouseEvent | TouchEvent, viewport);
-        },
-        // we need a setTimeout for panOnScroll to suppress multiple end events fired during scroll
-        panOnScroll ? 150 : 0
-      );
+      if (panOnScroll) {
+        schedulePanZoomEnd(
+          zoomPanValues,
+          pendingPanZoomEnd,
+          onPanZoomEnd,
+          event.sourceEvent as MouseEvent | TouchEvent,
+          viewport
+        );
+      } else {
+        clearTimeout(zoomPanValues.timerId);
+        pendingPanZoomEnd.callback = undefined;
+        zoomPanValues.timerId = setTimeout(() => {
+          zoomPanValues.timerId = undefined;
+          onPanZoomEnd(event.sourceEvent as MouseEvent | TouchEvent, viewport);
+        }, 0);
+      }
     }
   };
+}
+
+function schedulePanZoomEnd(
+  zoomPanValues: ZoomPanValues,
+  pending: PendingPanZoomEnd,
+  callback: OnPanZoom,
+  event: MouseEvent | TouchEvent,
+  viewport: ReturnType<typeof transformToViewport>
+) {
+  if (zoomPanValues.timerId !== undefined && pending.callback === undefined) {
+    clearTimeout(zoomPanValues.timerId);
+    zoomPanValues.timerId = undefined;
+  }
+
+  pending.callback = callback;
+  pending.deadline = Date.now() + wheelGestureTimeout;
+  pending.event = event;
+  pending.viewport = viewport;
+
+  if (zoomPanValues.timerId === undefined) {
+    zoomPanValues.timerId = setTimeout(() => flushPanZoomEnd(zoomPanValues, pending), wheelGestureTimeout);
+  }
+}
+
+function flushPanZoomEnd(zoomPanValues: ZoomPanValues, pending: PendingPanZoomEnd) {
+  const remaining = pending.deadline - Date.now();
+
+  if (remaining > 0) {
+    zoomPanValues.timerId = setTimeout(() => flushPanZoomEnd(zoomPanValues, pending), remaining);
+    return;
+  }
+
+  zoomPanValues.timerId = undefined;
+  const callback = pending.callback;
+  const event = pending.event;
+  const viewport = pending.viewport;
+  pending.callback = undefined;
+  pending.event = null;
+  callback?.(event, viewport);
+}
+
+function getPendingPanZoomEnd(zoomPanValues: ZoomPanValues): PendingPanZoomEnd {
+  let pending = pendingPanZoomEnds.get(zoomPanValues);
+
+  if (!pending) {
+    pending = {
+      callback: undefined,
+      deadline: 0,
+      event: null,
+      viewport: { x: 0, y: 0, zoom: 0 },
+    };
+    pendingPanZoomEnds.set(zoomPanValues, pending);
+  }
+
+  return pending;
 }


### PR DESCRIPTION
## Summary

When `panOnScroll` is enabled, wheel gestures previously repeated avoidable native work on every event:

- the manual pinch path used d3-selection's `pointer`, which read the pane's bounding rect on every ctrl-wheel tick;
- d3 emitted an end event for every pinch `scaleTo`, making xyflow clear and recreate its trailing `onPanZoomEnd` timer on every tick;
- the direct scroll-pan path independently cleared and recreated its own trailing end timer on every tick.

This change caches the pane origin for each 150 ms pinch gesture and coalesces both end paths with deadline-based trailing timers. The latest event and viewport are still delivered once, 150 ms after the final tick. D3 end state remains private per pan/zoom instance in a `WeakMap`.

## Measurement

Call-count probes over the real handlers produced:

| Operation during a 100-event gesture | Before | After |
| --- | ---: | ---: |
| Pinch pane rect reads | 100 | 1 |
| Pinch/D3 end timer sets before idle | 100 | 1 |
| Pinch/D3 end timer clears | 100 | 0 |
| Direct pan end timer sets before idle | 100 | 1 |
| Direct pan end timer clears | 100 | 0 |
| End callbacks | 1 | 1 |

A timer wakes and re-arms against the latest deadline during a long gesture. Pointer coordinates and the final viewport were unchanged, and a new gesture after the idle window gets a fresh timer and remeasures the pane origin.

This was motivated by a production profile where the pinch path's repeated pane reads and timer churn accounted for about 308 ms of main-thread self time across a slow zoom gesture. The direct pan timer improvement is a follow-up found during downstream review; it was not part of that 308 ms measurement.

## Validation

- `pnpm --filter @xyflow/system typecheck`
- ESLint and Prettier on the changed files
- `pnpm --filter @xyflow/system build`
- React pane Playwright suite in Chromium: 8/8 passed
- Browser timer probe: two 100-event pan gestures produced one timer per gesture and zero clears

The package-wide lint command also reports two existing `no-unnecessary-type-assertion` errors in `src/utils/edges/positions.ts` on unmodified main.
