### PR TITLE
fix(system): clamp extent:'parent' child to an unmeasured parent with an intrinsic size

### DIFF
--- a/.changeset/extent-parent-unmeasured-parent.md
+++ b/.changeset/extent-parent-unmeasured-parent.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/system": patch
+---
+
+Fix a child node with `extent: 'parent'` not being clamped to its parent when the parent declares an intrinsic size (`width`/`initialWidth`) but hasn't been measured yet. `calculateNodePosition` now uses the same `getNodeDimensions` fallback as `clampPositionToParent`.

--- a/.changeset/extent-parent-unmeasured-parent.md
+++ b/.changeset/extent-parent-unmeasured-parent.md
@@ -1,5 +1,7 @@
 ---
+"@xyflow/react": patch
+"@xyflow/svelte": patch
 "@xyflow/system": patch
 ---
 
-Fix a child node with `extent: 'parent'` not being clamped to its parent when the parent declares an intrinsic size (`width`/`initialWidth`) but hasn't been measured yet. `calculateNodePosition` now uses the same `getNodeDimensions` fallback as `clampPositionToParent`.
+Fix `extent: 'parent'` not immediately resolving when parent has `width` or `initialWidth`.

--- a/examples/react/cypress/components/utils/calculate-node-position.cy.ts
+++ b/examples/react/cypress/components/utils/calculate-node-position.cy.ts
@@ -1,0 +1,44 @@
+import { adoptUserNodes, calculateNodePosition, type NodeLookup, type ParentLookup } from '@xyflow/system';
+import type { Node } from '@xyflow/react';
+
+describe('calculateNodePosition', () => {
+  it("clamps a child with extent 'parent' to a parent that has an intrinsic size but is not measured yet", () => {
+    const nodeLookup: NodeLookup = new Map();
+    const parentLookup: ParentLookup = new Map();
+
+    const nodes: Node[] = [
+      {
+        id: 'parent',
+        data: { label: 'parent' },
+        position: { x: 0, y: 0 },
+        // intrinsic size, but no measured dimensions yet (e.g. before measuring / SSR)
+        initialWidth: 200,
+        initialHeight: 100,
+      },
+      {
+        id: 'child',
+        data: { label: 'child' },
+        position: { x: 0, y: 0 },
+        measured: { width: 50, height: 50 },
+        parentId: 'parent',
+        extent: 'parent',
+      },
+    ];
+
+    adoptUserNodes(nodes, nodeLookup, parentLookup);
+
+    const { positionAbsolute } = calculateNodePosition({
+      nodeId: 'child',
+      nextPosition: { x: 500, y: 500 },
+      nodeLookup,
+    });
+
+    // The child must stay inside the parent: max x = 200 - 50, max y = 100 - 50.
+    // Before the fix the parent's unmeasured size was ignored and the child
+    // escaped to { x: 500, y: 500 }.
+    expect(positionAbsolute.x).to.equal(150);
+    expect(positionAbsolute.y).to.equal(50);
+  });
+});
+
+export {};

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -427,8 +427,13 @@ export function calculateNodePosition<NodeType extends NodeBase>({
     if (!parentNode) {
       onError?.('005', errorMessages['error005']());
     } else {
-      const parentWidth = parentNode.measured.width;
-      const parentHeight = parentNode.measured.height;
+      /*
+       * use the measured -> width -> initialWidth fallback (via getNodeDimensions)
+       * so a child with extent: 'parent' is still clamped to a parent that
+       * declares an intrinsic size but hasn't been measured yet. This keeps the
+       * drag path consistent with clampPositionToParent (the reconcile path).
+       */
+      const { width: parentWidth, height: parentHeight } = getNodeDimensions(parentNode);
 
       if (parentWidth && parentHeight) {
         extent = [

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -44,11 +44,22 @@ export const isEdgeBase = <EdgeType extends EdgeBase = EdgeBase>(element: unknow
  * @returns A boolean indicating whether the element is an Node
  */
 export const isNodeBase = <NodeType extends NodeBase = NodeBase>(element: unknown): element is NodeType =>
-    !!element && typeof element === 'object' && 'id' in element && 'position' in element && !('source' in element) && !('target' in element);
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'position' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 export const isInternalNodeBase = <NodeType extends InternalNodeBase = InternalNodeBase>(
   element: unknown
-): element is NodeType => !!element && typeof element === 'object' &&  'id' in element && 'internals' in element && !('source' in element) && !('target' in element);
+): element is NodeType =>
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'internals' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 /**
  * This util is used to tell you what nodes, if any, are connected to the given node
@@ -212,8 +223,8 @@ export const getNodesBounds = <NodeType extends NodeBase = NodeBase>(
         currentNode = isId
           ? params.nodeLookup.get(nodeOrId)
           : !isInternalNodeBase(nodeOrId)
-          ? params.nodeLookup.get(nodeOrId.id)
-          : nodeOrId;
+            ? params.nodeLookup.get(nodeOrId.id)
+            : nodeOrId;
       }
 
       const nodeBox = currentNode ? nodeToBox(currentNode, params.nodeOrigin) : { x: 0, y: 0, x2: 0, y2: 0 };
@@ -333,7 +344,7 @@ export const getConnectedEdges = <NodeType extends NodeBase = NodeBase, EdgeType
 
 function getFitViewNodes<
   Params extends NodeLookup<InternalNodeBase<NodeBase>>,
-  Options extends FitViewOptionsBase<NodeBase>
+  Options extends FitViewOptionsBase<NodeBase>,
 >(nodeLookup: Params, options?: Options) {
   const fitViewNodes: NodeLookup = new Map();
   const optionNodeIds = options?.nodes ? new Set(options.nodes.map((node) => node.id)) : null;
@@ -364,7 +375,7 @@ function getFitViewNodes<
 
 export async function fitViewport<
   Params extends FitViewParamsBase<NodeBase>,
-  Options extends FitViewOptionsBase<NodeBase>
+  Options extends FitViewOptionsBase<NodeBase>,
 >(
   { nodes, width, height, panZoom, minZoom, maxZoom }: Params,
   options?: Omit<Options, 'nodes' | 'includeHiddenNodes'>
@@ -427,12 +438,6 @@ export function calculateNodePosition<NodeType extends NodeBase>({
     if (!parentNode) {
       onError?.('005', errorMessages['error005']());
     } else {
-      /*
-       * use the measured -> width -> initialWidth fallback (via getNodeDimensions)
-       * so a child with extent: 'parent' is still clamped to a parent that
-       * declares an intrinsic size but hasn't been measured yet. This keeps the
-       * drag path consistent with clampPositionToParent (the reconcile path).
-       */
       const { width: parentWidth, height: parentHeight } = getNodeDimensions(parentNode);
 
       if (parentWidth && parentHeight) {

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -44,22 +44,11 @@ export const isEdgeBase = <EdgeType extends EdgeBase = EdgeBase>(element: unknow
  * @returns A boolean indicating whether the element is an Node
  */
 export const isNodeBase = <NodeType extends NodeBase = NodeBase>(element: unknown): element is NodeType =>
-  !!element &&
-  typeof element === 'object' &&
-  'id' in element &&
-  'position' in element &&
-  !('source' in element) &&
-  !('target' in element);
+    !!element && typeof element === 'object' && 'id' in element && 'position' in element && !('source' in element) && !('target' in element);
 
 export const isInternalNodeBase = <NodeType extends InternalNodeBase = InternalNodeBase>(
   element: unknown
-): element is NodeType =>
-  !!element &&
-  typeof element === 'object' &&
-  'id' in element &&
-  'internals' in element &&
-  !('source' in element) &&
-  !('target' in element);
+): element is NodeType => !!element && typeof element === 'object' &&  'id' in element && 'internals' in element && !('source' in element) && !('target' in element);
 
 /**
  * This util is used to tell you what nodes, if any, are connected to the given node
@@ -223,8 +212,8 @@ export const getNodesBounds = <NodeType extends NodeBase = NodeBase>(
         currentNode = isId
           ? params.nodeLookup.get(nodeOrId)
           : !isInternalNodeBase(nodeOrId)
-            ? params.nodeLookup.get(nodeOrId.id)
-            : nodeOrId;
+          ? params.nodeLookup.get(nodeOrId.id)
+          : nodeOrId;
       }
 
       const nodeBox = currentNode ? nodeToBox(currentNode, params.nodeOrigin) : { x: 0, y: 0, x2: 0, y2: 0 };
@@ -344,7 +333,7 @@ export const getConnectedEdges = <NodeType extends NodeBase = NodeBase, EdgeType
 
 function getFitViewNodes<
   Params extends NodeLookup<InternalNodeBase<NodeBase>>,
-  Options extends FitViewOptionsBase<NodeBase>,
+  Options extends FitViewOptionsBase<NodeBase>
 >(nodeLookup: Params, options?: Options) {
   const fitViewNodes: NodeLookup = new Map();
   const optionNodeIds = options?.nodes ? new Set(options.nodes.map((node) => node.id)) : null;
@@ -375,7 +364,7 @@ function getFitViewNodes<
 
 export async function fitViewport<
   Params extends FitViewParamsBase<NodeBase>,
-  Options extends FitViewOptionsBase<NodeBase>,
+  Options extends FitViewOptionsBase<NodeBase>
 >(
   { nodes, width, height, panZoom, minZoom, maxZoom }: Params,
   options?: Omit<Options, 'nodes' | 'includeHiddenNodes'>


### PR DESCRIPTION
## The bug

`calculateNodePosition` (the drag path) builds the "parent" extent for a child with `extent: 'parent'` from `parentNode.measured` directly:

```ts
// packages/system/src/utils/graph.ts
const parentWidth = parentNode.measured.width;
const parentHeight = parentNode.measured.height;
if (parentWidth && parentHeight) {
  extent = [[parentX, parentY], [parentX + parentWidth, parentY + parentHeight]];
}
```

If the parent declares an **intrinsic size** (`width` / `initialWidth`) but hasn't been measured yet, `measured.width`/`height` are `undefined`, the `if` is skipped, the extent stays undefined, and the child is **not clamped to the parent** — it can be dragged outside of it.

The reconcile path (`clampPositionToParent`, used by `adoptUserNodes` / `updateNodeInternals`) already sizes the parent with `getNodeDimensions(parent)` (the `measured → width → initialWidth` fallback), so the two paths were inconsistent.

## The fix

Use `getNodeDimensions(parentNode)` for the parent extent in `calculateNodePosition` too. `getNodeDimensions` is already imported in this file.

- Parent with `initialWidth`/`width` but no `measured` → **now clamped** (was: child escaped).
- Parent already measured → unchanged.
- Parent with no size at all → still not clamped (can't clamp to an unknown size; `getNodeDimensions` returns `0`, so the `if` stays false).

## Verification

Driving the real `calculateNodePosition` (built `@xyflow/system`) with a child at `extent: 'parent'` dragged to `{ x: 500, y: 500 }`:

| parent | before | after |
|---|---|---|
| `initialWidth: 200, initialHeight: 100`, unmeasured | `{ 500, 500 }` (escaped) | `{ 150, 50 }` (clamped) |
| `width: 200, height: 100`, unmeasured | `{ 500, 500 }` | `{ 150, 50 }` |
| `measured: { 200, 100 }` | `{ 150, 50 }` | `{ 150, 50 }` (unchanged) |
| no size | `{ 500, 500 }` | `{ 500, 500 }` (unchanged) |

Added a regression test (`examples/react/cypress/components/utils/calculate-node-position.cy.ts`) for the intrinsic-but-unmeasured parent case. `tsc --noEmit` and `eslint` pass.

Found by auditing the dimension/clamp helpers — same `measured`-fallback class as #5851.
