### PR TITLE
fix(system): allow panning from selection rectangles

### DIFF
--- a/.changeset/calm-pans-move.md
+++ b/.changeset/calm-pans-move.md
@@ -1,5 +1,7 @@
 ---
 '@xyflow/system': patch
+'@xyflow/react': patch
+'@xyflow/svelte': patch
 ---
 
-Allow middle-mouse viewport panning to start from a React Flow multi-selection rectangle.
+Allow middle-mouse viewport panning to start from a selection rectangle.

--- a/.changeset/calm-pans-move.md
+++ b/.changeset/calm-pans-move.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/system': patch
+---
+
+Allow middle-mouse viewport panning to start from a React Flow multi-selection rectangle.

--- a/packages/system/src/xypanzoom/filter.ts
+++ b/packages/system/src/xypanzoom/filter.ts
@@ -36,7 +36,9 @@ export function createFilter({
     if (
       event.button === 1 &&
       event.type === 'mousedown' &&
-      (isWrappedWithClass(event, `${lib}-flow__node`) || isWrappedWithClass(event, `${lib}-flow__edge`))
+      (isWrappedWithClass(event, `${lib}-flow__node`) ||
+        isWrappedWithClass(event, `${lib}-flow__edge`) ||
+        isWrappedWithClass(event, `${lib}-flow__nodesselection-rect`))
     ) {
       return true;
     }

--- a/packages/system/src/xypanzoom/filter.ts
+++ b/packages/system/src/xypanzoom/filter.ts
@@ -38,7 +38,8 @@ export function createFilter({
       event.type === 'mousedown' &&
       (isWrappedWithClass(event, `${lib}-flow__node`) ||
         isWrappedWithClass(event, `${lib}-flow__edge`) ||
-        isWrappedWithClass(event, `${lib}-flow__nodesselection-rect`))
+        isWrappedWithClass(event, `${lib}-flow__selection`) ||
+        isWrappedWithClass(event, `${lib}-flow__nodesselection`))
     ) {
       return true;
     }

--- a/tests/playwright/e2e/nodes.spec.ts
+++ b/tests/playwright/e2e/nodes.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Locator } from '@playwright/test';
 
 import { FRAMEWORK } from './constants';
+import { getTransform } from './utils';
 
 test.describe('Nodes', () => {
   test.beforeEach(async ({ page }) => {
@@ -43,6 +44,42 @@ test.describe('Nodes', () => {
       await expect(nodes.nth(2)).toHaveClass(/selected/);
 
       await expect(nodeSelection).toBeInViewport();
+    });
+
+    test('panning from a multi-selection rectangle with the middle mouse button', async ({ page }) => {
+      test.skip(FRAMEWORK !== 'react', 'The React selection rectangle has its own drag handler');
+
+      const nodes = page.locator('.react-flow__node');
+      const selection = page.locator('.react-flow__nodesselection-rect');
+      const viewport = page.locator('.react-flow__viewport');
+
+      await expect(nodes.first()).toHaveCSS('visibility', 'visible');
+      const nodeBox = await nodes.first().boundingBox();
+
+      await page.keyboard.down('Shift');
+      await page.mouse.move(nodeBox!.x - 150, nodeBox!.y - 25);
+      await page.mouse.down();
+      await page.mouse.move(nodeBox!.x + 275, nodeBox!.y + 200);
+      await page.mouse.up();
+      await page.keyboard.up('Shift');
+
+      await expect(selection).toBeInViewport();
+      const selectionBox = await selection.boundingBox();
+      const transformsBefore = await getTransform(viewport);
+      const selectionCenter = {
+        x: selectionBox!.x + selectionBox!.width / 2,
+        y: selectionBox!.y + selectionBox!.height / 2,
+      };
+
+      await page.mouse.move(selectionCenter.x, selectionCenter.y);
+      await page.mouse.down({ button: 'middle' });
+      await page.mouse.move(selectionCenter.x + 100, selectionCenter.y + 100);
+      await page.mouse.up({ button: 'middle' });
+
+      const transformsAfter = await getTransform(viewport);
+
+      expect(transformsAfter.translateX).not.toBe(transformsBefore.translateX);
+      expect(transformsAfter.translateY).not.toBe(transformsBefore.translateY);
     });
 
     test('selectable=false prevents selection', async ({ page }) => {


### PR DESCRIPTION
## Summary

- allow middle-mouse viewport panning to start from a React Flow multi-selection rectangle
- cover the interaction with a Playwright regression test
- add a patch changeset for `@xyflow/system`

Fixes #5878

## Testing

- React nodes Playwright suite in Chromium (16 passed)
- `tsc --noEmit` for `@xyflow/system` and `@xyflow/react`
- ESLint for `packages/system/src/xypanzoom/filter.ts`
- Prettier check for all changed files
