### PR TITLE
Deprecate unit-less padding

### DIFF
--- a/.changeset/funny-pianos-glow.md
+++ b/.changeset/funny-pianos-glow.md
@@ -1,0 +1,8 @@
+---
+"@xyflow/svelte": minor
+"@xyflow/react": minor
+"@xyflow/system": patch
+---
+
+Deprecate passing a padding to fitView without a unit (%,px)
+  

--- a/packages/react/src/hooks/useViewportHelper.ts
+++ b/packages/react/src/hooks/useViewportHelper.ts
@@ -67,7 +67,7 @@ const useViewportHelper = (): ViewportHelperFunctions => {
       },
       fitBounds: async (bounds, options) => {
         const { width, height, minZoom, maxZoom, panZoom } = store.getState();
-        const viewport = getViewportForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? 0.1);
+        const viewport = getViewportForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? '5%');
 
         if (!panZoom) {
           return false;

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -77,7 +77,7 @@ const getInitialState = ({
       height,
       minZoom,
       maxZoom,
-      fitViewOptions?.padding ?? 0.1
+      fitViewOptions?.padding ?? '5%'
     );
     transform = [x, y, zoom];
   }

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -53,8 +53,10 @@ import type {
  * ReactFlow component props.
  * @public
  */
-export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends Edge = Edge>
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onError'> {
+export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends Edge = Edge> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onError'
+> {
   /**
    * An array of nodes to render in a controlled flow.
    * @default []
@@ -572,7 +574,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    * call.
    * @example
    * const fitViewOptions = {
-   *  padding: 0.1,
+   *  padding: '5%',
    *  includeHiddenNodes: false,
    *  minZoom: 0.1,
    *  maxZoom: 1,

--- a/packages/svelte/src/lib/container/SvelteFlow/types.ts
+++ b/packages/svelte/src/lib/container/SvelteFlow/types.ts
@@ -138,7 +138,7 @@ export type SvelteFlowProps<
      * Options to be used in combination with fitView
      * @example
      * const fitViewOptions = {
-     *  padding: 0.1,
+     *  padding: '5%',
      *  includeHiddenNodes: false,
      *  minZoom: 0.1,
      *  maxZoom: 1,

--- a/packages/svelte/src/lib/hooks/useSvelteFlow.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useSvelteFlow.svelte.ts
@@ -377,7 +377,7 @@ export function useSvelteFlow<NodeType extends Node = Node, EdgeType extends Edg
         store.height,
         store.minZoom,
         store.maxZoom,
-        options?.padding ?? 0.1
+        options?.padding ?? '5%'
       );
 
       await store.panZoom.setViewport(viewport, {

--- a/packages/svelte/src/lib/store/initial-store.svelte.ts
+++ b/packages/svelte/src/lib/store/initial-store.svelte.ts
@@ -102,7 +102,7 @@ function getInitialViewport<NodeType extends Node = Node>(
     const bounds = getInternalNodesBounds(nodeLookup, {
       filter: (node) => !!((node.width || node.initialWidth) && (node.height || node.initialHeight))
     });
-    return getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);
+    return getViewportForBounds(bounds, width, height, 0.5, 2, '5%');
   } else {
     return initialViewport ?? { x: 0, y: 0, zoom: 1 };
   }

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -168,17 +168,27 @@ export type FitViewParamsBase<NodeType extends NodeBase> = {
 };
 
 export type PaddingUnit = 'px' | '%';
-export type PaddingWithUnit = `${number}${PaddingUnit}` | number;
+
+/**
+ * Padding as a string with a unit, e.g. `'10%'` or `'20px'`.
+ */
+export type PaddingWithUnit = `${number}${PaddingUnit}`;
+
+/**
+ * @deprecated Unitless number paddings for fitView are deprecated and will be removed in the next major version. Use a string with a unit instead, e.g. `'10%'` or `'20px'`.
+ */
+export type DeprecatedPaddingValue = number;
 
 export type Padding =
   | PaddingWithUnit
+  | DeprecatedPaddingValue
   | {
-      top?: PaddingWithUnit;
-      right?: PaddingWithUnit;
-      bottom?: PaddingWithUnit;
-      left?: PaddingWithUnit;
-      x?: PaddingWithUnit;
-      y?: PaddingWithUnit;
+      top?: PaddingWithUnit | DeprecatedPaddingValue;
+      right?: PaddingWithUnit | DeprecatedPaddingValue;
+      bottom?: PaddingWithUnit | DeprecatedPaddingValue;
+      left?: PaddingWithUnit | DeprecatedPaddingValue;
+      x?: PaddingWithUnit | DeprecatedPaddingValue;
+      y?: PaddingWithUnit | DeprecatedPaddingValue;
     };
 
 /**
@@ -250,7 +260,7 @@ export type SetCenterOptions = ViewportHelperFunctionOptions & {
  * @inline
  */
 export type FitBoundsOptions = ViewportHelperFunctionOptions & {
-  padding?: number;
+  padding?: Padding;
 };
 
 export type OnViewportChange = (viewport: Viewport) => void;

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -223,9 +223,7 @@ function parsePadding(padding: PaddingWithUnit | DeprecatedPaddingValue, viewpor
     }
   }
 
-  console.error(
-    `The padding value "${padding}" is invalid. Please provide a string with a valid unit (px or %).`
-  );
+  console.error(`The padding value "${padding}" is invalid. Please provide a string with a valid unit (px or %).`);
   return 0;
 }
 
@@ -242,6 +240,7 @@ function parsePaddings(
   width: number,
   height: number
 ): { top: number; bottom: number; left: number; right: number; x: number; y: number } {
+  didWarnUnitlessPadding = false;
   if (typeof padding === 'string' || typeof padding === 'number') {
     const paddingY = parsePadding(padding, height);
     const paddingX = parsePadding(padding, width);

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -12,6 +12,7 @@ import type {
   NodeLookup,
   Padding,
   PaddingWithUnit,
+  DeprecatedPaddingValue,
 } from '../types';
 import { type Viewport } from '../types';
 import { getNodePositionWithOrigin, isInternalNodeBase } from './graph';
@@ -186,6 +187,8 @@ export const rendererPointToPoint = ({ x, y }: XYPosition, [tx, ty, tScale]: Tra
   };
 };
 
+let didWarnUnitlessPadding = false;
+
 /**
  * Parses a single padding value to a number
  * @internal
@@ -193,8 +196,16 @@ export const rendererPointToPoint = ({ x, y }: XYPosition, [tx, ty, tScale]: Tra
  * @param viewport - Width or height of the viewport
  * @returns The padding in pixels
  */
-function parsePadding(padding: PaddingWithUnit, viewport: number): number {
+function parsePadding(padding: PaddingWithUnit | DeprecatedPaddingValue, viewport: number): number {
   if (typeof padding === 'number') {
+    if (process.env.NODE_ENV === 'development' && !didWarnUnitlessPadding) {
+      didWarnUnitlessPadding = true;
+      console.warn(
+        '[DEPRECATED] Unitless padding values for `fitView`/`getViewportForBounds` are deprecated and will be removed in the next major version. Use a string with a unit instead, e.g. "10%" or "20px".'
+      );
+    }
+
+    // Legacy unitless formula — kept for backwards compatibility until the next major version
     return Math.floor((viewport - viewport / (1 + padding)) * 0.5);
   }
 
@@ -213,7 +224,7 @@ function parsePadding(padding: PaddingWithUnit, viewport: number): number {
   }
 
   console.error(
-    `The padding value "${padding}" is invalid. Please provide a number or a string with a valid unit (px or %).`
+    `The padding value "${padding}" is invalid. Please provide a string with a valid unit (px or %).`
   );
   return 0;
 }
@@ -245,10 +256,10 @@ function parsePaddings(
   }
 
   if (typeof padding === 'object') {
-    const top = parsePadding(padding.top ?? padding.y ?? 0, height);
-    const bottom = parsePadding(padding.bottom ?? padding.y ?? 0, height);
-    const left = parsePadding(padding.left ?? padding.x ?? 0, width);
-    const right = parsePadding(padding.right ?? padding.x ?? 0, width);
+    const top = parsePadding(padding.top ?? padding.y ?? '0px', height);
+    const bottom = parsePadding(padding.bottom ?? padding.y ?? '0px', height);
+    const left = parsePadding(padding.left ?? padding.x ?? '0px', width);
+    const right = parsePadding(padding.right ?? padding.x ?? '0px', width);
     return { top, right, bottom, left, x: left + right, y: top + bottom };
   }
 
@@ -294,12 +305,12 @@ function calculateAppliedPaddings(bounds: Rect, x: number, y: number, zoom: numb
  * @param height  - Height of the viewport.
  * @param minZoom - Minimum zoom level of the resulting viewport.
  * @param maxZoom - Maximum zoom level of the resulting viewport.
- * @param padding - Padding around the bounds.
+ * @param padding - Padding around the bounds. Prefer a string with a unit (`'10%'` or `'20px'`). Unitless numbers are deprecated.
  * @returns A transformed {@link Viewport} that encloses the given bounds which you can pass to e.g. {@link setViewport}.
  * @example
  * const { x, y, zoom } = getViewportForBounds(
  * { x: 0, y: 0, width: 100, height: 100},
- * 1200, 800, 0.5, 2);
+ * 1200, 800, 0.5, 2, '10%');
  */
 export const getViewportForBounds = (
   bounds: Rect,

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -44,11 +44,22 @@ export const isEdgeBase = <EdgeType extends EdgeBase = EdgeBase>(element: unknow
  * @returns A boolean indicating whether the element is an Node
  */
 export const isNodeBase = <NodeType extends NodeBase = NodeBase>(element: unknown): element is NodeType =>
-    !!element && typeof element === 'object' && 'id' in element && 'position' in element && !('source' in element) && !('target' in element);
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'position' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 export const isInternalNodeBase = <NodeType extends InternalNodeBase = InternalNodeBase>(
   element: unknown
-): element is NodeType => !!element && typeof element === 'object' &&  'id' in element && 'internals' in element && !('source' in element) && !('target' in element);
+): element is NodeType =>
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'internals' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 /**
  * This util is used to tell you what nodes, if any, are connected to the given node
@@ -212,8 +223,8 @@ export const getNodesBounds = <NodeType extends NodeBase = NodeBase>(
         currentNode = isId
           ? params.nodeLookup.get(nodeOrId)
           : !isInternalNodeBase(nodeOrId)
-          ? params.nodeLookup.get(nodeOrId.id)
-          : nodeOrId;
+            ? params.nodeLookup.get(nodeOrId.id)
+            : nodeOrId;
       }
 
       const nodeBox = currentNode ? nodeToBox(currentNode, params.nodeOrigin) : { x: 0, y: 0, x2: 0, y2: 0 };
@@ -333,7 +344,7 @@ export const getConnectedEdges = <NodeType extends NodeBase = NodeBase, EdgeType
 
 function getFitViewNodes<
   Params extends NodeLookup<InternalNodeBase<NodeBase>>,
-  Options extends FitViewOptionsBase<NodeBase>
+  Options extends FitViewOptionsBase<NodeBase>,
 >(nodeLookup: Params, options?: Options) {
   const fitViewNodes: NodeLookup = new Map();
   const optionNodeIds = options?.nodes ? new Set(options.nodes.map((node) => node.id)) : null;
@@ -364,7 +375,7 @@ function getFitViewNodes<
 
 export async function fitViewport<
   Params extends FitViewParamsBase<NodeBase>,
-  Options extends FitViewOptionsBase<NodeBase>
+  Options extends FitViewOptionsBase<NodeBase>,
 >(
   { nodes, width, height, panZoom, minZoom, maxZoom }: Params,
   options?: Omit<Options, 'nodes' | 'includeHiddenNodes'>
@@ -383,7 +394,7 @@ export async function fitViewport<
     height,
     options?.minZoom ?? minZoom,
     options?.maxZoom ?? maxZoom,
-    options?.padding ?? 0.1
+    options?.padding ?? '5%'
   );
 
   await panZoom.setViewport(viewport, {


### PR DESCRIPTION
Creating a new type that is deprecated for additional visibility was an idea made by our digital colleague.
I am okay with it, but it is also optional. 

Changing the default fitView padding value from 0.5 to 5%. Is this actually a breaking change?

