### PR TITLE
Fix touch panning when drag selection is enabled

### DIFF
--- a/.changeset/tame-panes-touch.md
+++ b/.changeset/tame-panes-touch.md
@@ -3,4 +3,4 @@
 '@xyflow/svelte': patch
 ---
 
-Prefer touch panning over drag selection when `selectionOnDrag` is combined with mouse-button-specific `panOnDrag` settings.
+Fix selection box appearing when dragging the pane via touch. Prefer touch panning over drag selection when `selectionOnDrag` is combined with mouse-button-specific `panOnDrag` settings.

--- a/.changeset/tame-panes-touch.md
+++ b/.changeset/tame-panes-touch.md
@@ -1,0 +1,6 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+---
+
+Prefer touch panning over drag selection when `selectionOnDrag` is combined with mouse-button-specific `panOnDrag` settings.

--- a/examples/react/src/generic-tests/pane/non-defaults.ts
+++ b/examples/react/src/generic-tests/pane/non-defaults.ts
@@ -1,6 +1,8 @@
 export default {
   flowProps: {
     panOnScroll: true,
+    panOnDrag: [1, 2],
+    selectionOnDrag: true,
     defaultViewport: { x: 1.23, y: 9.87, zoom: 1.234 },
     autoPanOnConnect: false,
     autoPanOnNodeDrag: false,

--- a/examples/svelte/src/generic-tests/pane/non-defaults.ts
+++ b/examples/svelte/src/generic-tests/pane/non-defaults.ts
@@ -1,6 +1,8 @@
 export default {
 	flowProps: {
 		panOnScroll: true,
+		panOnDrag: [1, 2],
+		selectionOnDrag: true,
 		initialViewport: { x: 1.23, y: 9.87, zoom: 1.234 },
 		autoPanOnConnect: false,
 		autoPanOnNodeDrag: false,

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -141,6 +141,12 @@ export function Pane({
   // We are using capture here in order to prevent other pointer events
   // to be able to create a selection above a node or an edge
   const onPointerDownCapture = (event: ReactPointerEvent): void => {
+    // Mouse button arrays only restrict mouse input. Let touch panning handle this gesture
+    // unless the user explicitly activated selection with the selection key.
+    if (event.pointerType === 'touch' && panOnDrag !== false && !selectionKeyPressed) {
+      return;
+    }
+
     const { domNode, transform } = store.getState();
     containerBounds.current = domNode?.getBoundingClientRect();
     if (!containerBounds.current) return;

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -445,6 +445,7 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   /**
    * Enabling this prop allows users to pan the viewport by clicking and dragging.
    * You can also set this prop to an array of numbers to limit which mouse buttons can activate panning.
+   * Mouse button arrays do not disable touch panning; set this prop to `false` to disable all drag panning.
    * @default true
    * @example [0, 2] // allows panning with the left and right mouse buttons
    * [0, 1, 2, 3, 4] // allows panning with all mouse buttons

--- a/packages/svelte/src/lib/container/Pane/Pane.svelte
+++ b/packages/svelte/src/lib/container/Pane/Pane.svelte
@@ -96,6 +96,12 @@
 
   // We start the selection process when the user clicks down on the pane
   function onPointerDownCapture(event: PointerEvent) {
+    // Mouse button arrays only restrict mouse input. Let touch panning handle this gesture
+    // unless the user explicitly activated selection with the selection key.
+    if (event.pointerType === 'touch' && panOnDragActive !== false && !store.selectionKeyPressed) {
+      return;
+    }
+
     containerBounds = container?.getBoundingClientRect();
     if (!containerBounds) return;
 

--- a/packages/svelte/src/lib/container/SvelteFlow/types.ts
+++ b/packages/svelte/src/lib/container/SvelteFlow/types.ts
@@ -327,6 +327,7 @@ export type SvelteFlowProps<
     /**
      * Enabling this prop allows users to pan the viewport by clicking and dragging.
      * You can also set this prop to an array of numbers to limit which mouse buttons can activate panning.
+     * Mouse button arrays do not disable touch panning; set this prop to `false` to disable all drag panning.
      * @default true
      * @example [0, 2] // allows panning with the left and right mouse buttons
      * [0, 1, 2, 3, 4] // allows panning with all mouse buttons

--- a/tests/playwright/e2e/pane.spec.ts
+++ b/tests/playwright/e2e/pane.spec.ts
@@ -1,7 +1,49 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 
 import { FRAMEWORK } from './constants';
 import { getTransform } from './utils';
+
+type Point = { x: number; y: number };
+
+async function getPaneDragPoints(pane: Locator) {
+  const bounds = await pane.boundingBox();
+  if (!bounds) {
+    throw new Error('Could not measure the pane for the drag gesture.');
+  }
+
+  const start = { x: bounds.x + bounds.width * 0.75, y: bounds.y + bounds.height * 0.75 };
+  return { start, end: { x: start.x - 80, y: start.y - 80 } };
+}
+
+async function withTouchDrag(page: Page, start: Point, end: Point, assertions: () => Promise<void>) {
+  const client = await page.context().newCDPSession(page);
+
+  try {
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ ...start, id: 0 }],
+    });
+
+    for (let step = 1; step <= 4; step++) {
+      const progress = step / 4;
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [
+          {
+            x: start.x + (end.x - start.x) * progress,
+            y: start.y + (end.y - start.y) * progress,
+            id: 0,
+          },
+        ],
+      });
+    }
+
+    await assertions();
+  } finally {
+    await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+    await client.detach();
+  }
+}
 
 test.describe('Pane default', () => {
   test.beforeEach(async ({ page }) => {
@@ -168,6 +210,76 @@ test.describe('Pane non-default', () => {
       expect(viewportTransform.translateX).toBe(1.23);
       expect(viewportTransform.translateY).toBe(9.87);
       expect(viewportTransform.scale).toBe(1.234);
+    });
+
+    test.describe('touch input', () => {
+      // Model a hybrid touchscreen computer without switching to a mobile browser profile.
+      test.use({ hasTouch: true });
+
+      test('touch drag pans when primary mouse drag is reserved for selection', async ({ page, browserName }) => {
+        test.skip(browserName !== 'chromium', 'CDP touch input is only available in Chromium.');
+
+        const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+        const viewport = page.locator(`.${FRAMEWORK}-flow__viewport`);
+        const selection = page.locator(`.${FRAMEWORK}-flow__selection`);
+
+        await expect(pane).toBeAttached();
+
+        const { start, end } = await getPaneDragPoints(pane);
+        const transformBefore = await getTransform(viewport);
+
+        await withTouchDrag(page, start, end, async () => {
+          await expect.poll(async () => (await getTransform(viewport)).translateX).not.toBe(transformBefore.translateX);
+          await expect(selection).toHaveCount(0);
+        });
+      });
+
+      test('selection key keeps touch drag in selection mode', async ({ page, browserName }) => {
+        test.skip(browserName !== 'chromium', 'CDP touch input is only available in Chromium.');
+
+        const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+        const viewport = page.locator(`.${FRAMEWORK}-flow__viewport`);
+        const selection = page.locator(`.${FRAMEWORK}-flow__selection`);
+
+        await expect(pane).toBeAttached();
+
+        const { start, end } = await getPaneDragPoints(pane);
+        const transformBefore = await getTransform(viewport);
+
+        await page.keyboard.down('Shift');
+        await expect(pane).toHaveClass(/selection/);
+
+        try {
+          await withTouchDrag(page, start, end, async () => {
+            await expect(selection).toBeVisible();
+            expect(await getTransform(viewport)).toEqual(transformBefore);
+          });
+        } finally {
+          await page.keyboard.up('Shift');
+        }
+      });
+    });
+
+    test('primary mouse drag still creates a selection marquee', async ({ page }) => {
+      const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+      const viewport = page.locator(`.${FRAMEWORK}-flow__viewport`);
+      const selection = page.locator(`.${FRAMEWORK}-flow__selection`);
+
+      await expect(pane).toBeAttached();
+
+      const { start, end } = await getPaneDragPoints(pane);
+      const transformBefore = await getTransform(viewport);
+
+      await page.mouse.move(start.x, start.y);
+      await page.mouse.down();
+
+      try {
+        await page.mouse.move(end.x, end.y, { steps: 4 });
+        await expect(selection).toBeVisible();
+        expect(await getTransform(viewport)).toEqual(transformBefore);
+      } finally {
+        await page.mouse.up();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- let the existing touch-pan gesture win over pane selection capture when drag panning is enabled
- preserve explicit selection-key behavior and primary-mouse marquee selection
- keep React and Svelte behavior in sync
- clarify that `panOnDrag` button arrays restrict mouse input, not touch input

## Why

When `selectionOnDrag` is enabled and `panOnDrag` is a mouse-button array such as `[1, 2]`, a primary touch currently starts both viewport panning and a marquee selection. The system filter intentionally treats button arrays as mouse-only for touch panning (see #4229), so the Pane should not capture the same touch as a selection unless the selection key is explicitly active.

This uses the gesture's actual `pointerType`, so hybrid touchscreen computers keep normal mouse and pen behavior.

## Behavior

- touch + enabled `panOnDrag` + no selection key: pan without marquee
- touch + selection key: marquee selection
- primary mouse button excluded from `panOnDrag`: marquee selection
- `panOnDrag={false}` and pen behavior remain unchanged

## Tests

- added a desktop-profile, touch-enabled Playwright regression for the conflict
- verified the regression fails on the pre-fix code with one unexpected selection marquee
- added coverage for selection-key touch behavior and primary-mouse behavior
- React pane suite: 29 passed, 4 skipped
- Svelte pane suite: 29 passed, 4 skipped
- React and Svelte package typechecks, builds, and changed-file lint/format checks pass

Related to #2709.