### PR TITLE
Remove unitless padding

### DIFF
--- a/.changeset/thick-baboons-kiss.md
+++ b/.changeset/thick-baboons-kiss.md
@@ -1,0 +1,8 @@
+---
+"@xyflow/svelte": major
+"@xyflow/react": major
+"@xyflow/system": patch
+---
+
+Require fitView paddings to have a unit ('100px', '10%')
+  

--- a/packages/react/src/hooks/useViewportHelper.ts
+++ b/packages/react/src/hooks/useViewportHelper.ts
@@ -67,7 +67,7 @@ const useViewportHelper = (): ViewportHelperFunctions => {
       },
       fitBounds: async (bounds, options) => {
         const { width, height, minZoom, maxZoom, panZoom } = store.getState();
-        const viewport = getViewportForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? 0.1);
+        const viewport = getViewportForBounds(bounds, width, height, minZoom, maxZoom, options?.padding ?? '10%');
 
         if (!panZoom) {
           return false;

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -80,7 +80,7 @@ const getInitialState = ({
       height,
       minZoom,
       maxZoom,
-      fitViewOptions?.padding ?? 0.1
+      fitViewOptions?.padding ?? '10%'
     );
     transform = [x, y, zoom];
   }

--- a/packages/svelte/src/lib/hooks/useSvelteFlow.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useSvelteFlow.svelte.ts
@@ -377,7 +377,7 @@ export function useSvelteFlow<NodeType extends Node = Node, EdgeType extends Edg
         store.height,
         store.minZoom,
         store.maxZoom,
-        options?.padding ?? 0.1
+        options?.padding ?? '10%'
       );
 
       await store.panZoom.setViewport(viewport, {

--- a/packages/svelte/src/lib/store/initial-store.svelte.ts
+++ b/packages/svelte/src/lib/store/initial-store.svelte.ts
@@ -100,7 +100,7 @@ function getInitialViewport<NodeType extends Node = Node>(
     const bounds = getInternalNodesBounds(nodeLookup, {
       filter: (node) => !!((node.width || node.initialWidth) && (node.height || node.initialHeight))
     });
-    return getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);
+    return getViewportForBounds(bounds, width, height, 0.5, 2, '10%');
   } else {
     return initialViewport ?? { x: 0, y: 0, zoom: 1 };
   }

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -168,7 +168,7 @@ export type FitViewParamsBase<NodeType extends NodeBase> = {
 };
 
 export type PaddingUnit = 'px' | '%';
-export type PaddingWithUnit = `${number}${PaddingUnit}` | number;
+export type PaddingWithUnit = `${number}${PaddingUnit}`;
 
 export type Padding =
   | PaddingWithUnit
@@ -250,7 +250,7 @@ export type SetCenterOptions = ViewportHelperFunctionOptions & {
  * @inline
  */
 export type FitBoundsOptions = ViewportHelperFunctionOptions & {
-  padding?: number;
+  padding?: PaddingWithUnit;
 };
 
 export type OnViewportChange = (viewport: Viewport) => void;

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -201,28 +201,29 @@ export const rendererPointToPoint = ({ x, y }: XYPosition, [tx, ty, tScale]: Tra
  * @param viewport - Width or height of the viewport
  * @returns The padding in pixels
  */
-function parsePadding(padding: PaddingWithUnit, viewport: number): number {
-  if (typeof padding === 'number') {
-    return Math.floor((viewport - viewport / (1 + padding)) * 0.5);
+function parsePadding(padding: PaddingWithUnit | undefined, viewport: number): number {
+  if (typeof padding === 'undefined') {
+    return 0;
   }
 
-  if (typeof padding === 'string' && padding.endsWith('px')) {
-    const paddingValue = parseFloat(padding);
-    if (!Number.isNaN(paddingValue)) {
-      return Math.floor(paddingValue);
+  if (typeof padding === 'string') {
+    if (padding.endsWith('px')) {
+      const paddingValue = parseFloat(padding);
+      if (!Number.isNaN(paddingValue)) {
+        return Math.floor(paddingValue);
+      }
+    }
+
+    if (padding.endsWith('%')) {
+      const paddingValue = parseFloat(padding);
+      if (!Number.isNaN(paddingValue)) {
+        return Math.floor(viewport * paddingValue * 0.01);
+      }
     }
   }
 
-  if (typeof padding === 'string' && padding.endsWith('%')) {
-    const paddingValue = parseFloat(padding);
-    if (!Number.isNaN(paddingValue)) {
-      return Math.floor(viewport * paddingValue * 0.01);
-    }
-  }
+  console.error(`The padding value "${padding}" is invalid. Please provide a string with a valid unit (px or %).`);
 
-  console.error(
-    `The padding value "${padding}" is invalid. Please provide a number or a string with a valid unit (px or %).`
-  );
   return 0;
 }
 
@@ -253,10 +254,10 @@ function parsePaddings(
   }
 
   if (typeof padding === 'object') {
-    const top = parsePadding(padding.top ?? padding.y ?? 0, height);
-    const bottom = parsePadding(padding.bottom ?? padding.y ?? 0, height);
-    const left = parsePadding(padding.left ?? padding.x ?? 0, width);
-    const right = parsePadding(padding.right ?? padding.x ?? 0, width);
+    const top = parsePadding(padding.top ?? padding.y, height);
+    const bottom = parsePadding(padding.bottom ?? padding.y, height);
+    const left = parsePadding(padding.left ?? padding.x, width);
+    const right = parsePadding(padding.right ?? padding.x, width);
     return { top, right, bottom, left, x: left + right, y: top + bottom };
   }
 

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -44,11 +44,22 @@ export const isEdgeBase = <EdgeType extends EdgeBase = EdgeBase>(element: unknow
  * @returns A boolean indicating whether the element is an Node
  */
 export const isNodeBase = <NodeType extends NodeBase = NodeBase>(element: unknown): element is NodeType =>
-    !!element && typeof element === 'object' && 'id' in element && 'position' in element && !('source' in element) && !('target' in element);
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'position' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 export const isInternalNodeBase = <NodeType extends InternalNodeBase = InternalNodeBase>(
   element: unknown
-): element is NodeType => !!element && typeof element === 'object' &&  'id' in element && 'internals' in element && !('source' in element) && !('target' in element);
+): element is NodeType =>
+  !!element &&
+  typeof element === 'object' &&
+  'id' in element &&
+  'internals' in element &&
+  !('source' in element) &&
+  !('target' in element);
 
 /**
  * This util is used to tell you what nodes, if any, are connected to the given node
@@ -383,7 +394,7 @@ export async function fitViewport<
     height,
     options?.minZoom ?? minZoom,
     options?.maxZoom ?? maxZoom,
-    options?.padding ?? 0.1
+    options?.padding ?? '10%'
   );
 
   await panZoom.setViewport(viewport, {


### PR DESCRIPTION
Possibly keep unit-less paddings, but interpret them as px values? One path might be confusing for people migrating the other path might be confusing for people trying to pass a number to it.
