### PR TITLE
fix(react): keep held keys tracked so repeated combinations fire in `useKeyPress`

### DIFF
--- a/.changeset/usekeypress-repeated-combinations.md
+++ b/.changeset/usekeypress-repeated-combinations.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Fix `useKeyPress` not detecting repeated key combinations while a modifier is held down, so shortcuts like `Meta+z` keep firing without releasing `Meta` in between.

--- a/packages/react/src/hooks/useKeyPress.ts
+++ b/packages/react/src/hooks/useKeyPress.ts
@@ -130,10 +130,13 @@ export function useKeyPress(
 
         if (isMatchingKey(keyCodes, pressedKeys.current, true)) {
           setKeyPressed(false);
-          pressedKeys.current.clear();
-        } else {
-          pressedKeys.current.delete(event[keyOrCode]);
         }
+
+        /*
+         * only the released key is removed so that keys which are still held down stay tracked,
+         * otherwise a combination like 'Meta+z' could not be triggered again while 'Meta' is kept pressed
+         */
+        pressedKeys.current.delete(event[keyOrCode]);
 
         // fix for Mac: when cmd key is pressed, keyup is not triggered for any other key, see: https://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key
         if (event.key === 'Meta') {


### PR DESCRIPTION
Fixes #2248

## The bug

With `useKeyPress("Meta+z")`, holding `Meta` and tapping `z` repeatedly only fires once. The
combination cannot be triggered again until `Meta` is also released.

## Cause

In `upHandler`, when the released key completes a watched combination, the whole `pressedKeys`
set is cleared:

```ts
if (isMatchingKey(keyCodes, pressedKeys.current, true)) {
  setKeyPressed(false);
  pressedKeys.current.clear();   // also drops keys that are still physically held
} else {
  pressedKeys.current.delete(event[keyOrCode]);
}
```

Releasing `z` therefore also forgets `Meta`. The next `z` keydown leaves `pressedKeys` as
`{z}`, which no longer matches `Meta+z`.

## Fix

Always remove only the key that was actually released, so keys still held down remain tracked.
The `Meta` special case below it is kept untouched, because on macOS no `keyup` is emitted for
other keys while `Meta` is down and the set still has to be flushed when `Meta` is released.

This is deliberately *not* the variant suggested in the issue thread that moved the `delete`
out of the branch while dropping that `Meta` flush - that combination is what previously
caused the "no key press works until the blur handler refires" regression.

## Test plan

I modelled the `pressedKeys` / `isMatchingKey` state machine and replayed event sequences
against the old and new `upHandler`. `T`/`F` is the hook result, `{...}` is `pressedKeys`.

**Issue case** - hold `Meta`, tap `z` twice, combo `Meta+z`:

```
before  d:Meta=>F{Meta}  d:z=>T{Meta,z}  u:z=>F{}      d:z=>F{z}       <- second press lost
after   d:Meta=>F{Meta}  d:z=>T{Meta,z}  u:z=>F{Meta}  d:z=>T{Meta,z}  <- fires again
```

Other sequences, all unchanged or improved:

| Scenario | Before | After |
| --- | --- | --- |
| `Control+d` tapped twice while holding `Control` | second press lost | fires again |
| three-key `Control+Shift+k`, release only `k` | second press lost | fires again |
| single key `a` repeated | works | works |
| full release, then re-press | works | works |
| release modifier first, keep letter | works | works |
| macOS: no `keyup` for `z` while `Meta` held, then release `Meta` | set flushed | set flushed |
| unrelated key noise between modifier and letter | works | works |

Also ran:

- `pnpm --filter=@xyflow/react run typecheck` - passes.
- `pnpm --filter=@xyflow/react run lint` - same 2 pre-existing errors before and after this
  change (in `Handle/index.tsx` and `useReactFlow.ts`); `useKeyPress.ts` reports none.

A changeset is included.