### PR TITLE
Fix Control key pane panning

### DIFF
--- a/.changeset/tidy-pans-listen.md
+++ b/.changeset/tidy-pans-listen.md
@@ -1,0 +1,7 @@
+---
+'@xyflow/react': patch
+'@xyflow/svelte': patch
+'@xyflow/system': patch
+---
+
+Allow `Control` to activate pane panning with a primary-button drag.

--- a/examples/react/src/generic-tests/pane/activation-keys.ts
+++ b/examples/react/src/generic-tests/pane/activation-keys.ts
@@ -1,0 +1,38 @@
+export default {
+  flowProps: {
+    zoomOnScroll: false,
+    panOnDrag: [1],
+    panActivationKeyCode: 'Control',
+    fitView: true,
+    nodes: [
+      {
+        id: '1',
+        data: { label: '1' },
+        position: { x: 0, y: 0 },
+        type: 'input',
+      },
+      {
+        id: '2',
+        data: { label: '2' },
+        position: { x: -100, y: 100 },
+      },
+      {
+        id: '3',
+        data: { label: '3' },
+        position: { x: 100, y: 100 },
+      },
+    ],
+    edges: [
+      {
+        id: 'first-edge',
+        source: '1',
+        target: '2',
+      },
+      {
+        id: 'second-edge',
+        source: '1',
+        target: '3',
+      },
+    ],
+  },
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/pane/activation-keys.ts
+++ b/examples/svelte/src/generic-tests/pane/activation-keys.ts
@@ -2,9 +2,9 @@ export default {
 	flowProps: {
 		zoomOnScroll: false,
 		// zoomActivationKey: 'Space',
-		// panOnDrag: false,
+		panOnDrag: [1],
 		// panOnScroll: false,
-		panActivationKey: 'Space',
+		panActivationKey: 'Control',
 		fitView: true,
 		nodes: [
 			{

--- a/packages/react/src/container/FlowRenderer/index.tsx
+++ b/packages/react/src/container/FlowRenderer/index.tsx
@@ -92,6 +92,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
       zoomOnScroll={zoomOnScroll}
       zoomOnPinch={zoomOnPinch}
       panOnScroll={panOnScroll}
+      panActivationKeyPressed={panActivationKeyPressed}
       panOnScrollSpeed={panOnScrollSpeed}
       panOnScrollMode={panOnScrollMode}
       zoomOnDoubleClick={zoomOnDoubleClick}

--- a/packages/react/src/container/ZoomPane/index.tsx
+++ b/packages/react/src/container/ZoomPane/index.tsx
@@ -15,6 +15,7 @@ type ZoomPaneProps = Omit<
   'deleteKeyCode' | 'selectionKeyCode' | 'multiSelectionKeyCode' | 'noDragClassName' | 'disableKeyboardA11y'
 > & {
   isControlledViewport: boolean;
+  panActivationKeyPressed: boolean;
 };
 
 const selector = (s: ReactFlowState) => ({
@@ -28,6 +29,7 @@ export function ZoomPane({
   zoomOnScroll = true,
   zoomOnPinch = true,
   panOnScroll = false,
+  panActivationKeyPressed,
   panOnScrollSpeed = 0.5,
   panOnScrollMode = PanOnScrollMode.Free,
   zoomOnDoubleClick = true,
@@ -74,7 +76,7 @@ export function ZoomPane({
         translateExtent,
         viewport: defaultViewport,
         onDraggingChange: (paneDragging) =>
-          store.setState((prevState) => prevState.paneDragging === paneDragging ? prevState : { paneDragging }),
+          store.setState((prevState) => (prevState.paneDragging === paneDragging ? prevState : { paneDragging })),
         onPanZoomStart: (event, vp) => {
           const { onViewportChangeStart, onMoveStart } = store.getState();
           onMoveStart?.(event, vp);
@@ -112,6 +114,7 @@ export function ZoomPane({
       zoomOnScroll,
       zoomOnPinch,
       panOnScroll,
+      panActivationKeyPressed,
       panOnScrollSpeed,
       panOnScrollMode,
       zoomOnDoubleClick,
@@ -132,6 +135,7 @@ export function ZoomPane({
     zoomOnScroll,
     zoomOnPinch,
     panOnScroll,
+    panActivationKeyPressed,
     panOnScrollSpeed,
     panOnScrollMode,
     zoomOnDoubleClick,

--- a/packages/svelte/src/lib/actions/zoom/index.ts
+++ b/packages/svelte/src/lib/actions/zoom/index.ts
@@ -26,6 +26,7 @@ type ZoomParams = {
   panOnDrag: boolean | number[];
   panOnScrollSpeed: number;
   panOnScrollMode: PanOnScrollMode;
+  panActivationKeyPressed: boolean;
   zoomActivationKeyPressed: boolean;
   preventScrolling: boolean;
   // last two instances of 'classname' being used

--- a/packages/svelte/src/lib/container/Zoom/Zoom.svelte
+++ b/packages/svelte/src/lib/container/Zoom/Zoom.svelte
@@ -62,6 +62,7 @@
     panOnDrag: panOnDragActive,
     panOnScrollSpeed,
     panOnScrollMode,
+    panActivationKeyPressed: store.panActivationKeyPressed,
     zoomActivationKeyPressed: store.zoomActivationKeyPressed,
     preventScrolling: typeof preventScrolling === 'boolean' ? preventScrolling : true,
     noPanClassName: store.noPanClass,

--- a/packages/system/src/types/panzoom.ts
+++ b/packages/system/src/types/panzoom.ts
@@ -30,6 +30,7 @@ export type PanZoomUpdateOptions = {
   noPanClassName: string;
   onPaneContextMenu?: (event: MouseEvent) => void;
   preventScrolling: boolean;
+  panActivationKeyPressed?: boolean;
   panOnScroll: boolean;
   panOnDrag: boolean | number[];
   panOnScrollMode: PanOnScrollMode;

--- a/packages/system/src/xypanzoom/XYPanZoom.ts
+++ b/packages/system/src/xypanzoom/XYPanZoom.ts
@@ -130,6 +130,7 @@ export function XYPanZoom({
     zoomOnPinch,
     zoomOnScroll,
     zoomOnDoubleClick,
+    panActivationKeyPressed = false,
     zoomActivationKeyPressed,
     lib,
     onTransformChange,
@@ -198,6 +199,7 @@ export function XYPanZoom({
     d3ZoomInstance.on('end', panZoomEndHandler);
 
     const filter = createFilter({
+      panActivationKeyPressed,
       zoomActivationKeyPressed,
       panOnDrag,
       zoomOnScroll,

--- a/packages/system/src/xypanzoom/filter.ts
+++ b/packages/system/src/xypanzoom/filter.ts
@@ -2,6 +2,7 @@
 import { isWrappedWithClass } from './utils';
 
 export type FilterParams = {
+  panActivationKeyPressed: boolean;
   zoomActivationKeyPressed: boolean;
   zoomOnScroll: boolean;
   zoomOnPinch: boolean;
@@ -16,6 +17,7 @@ export type FilterParams = {
 };
 
 export function createFilter({
+  panActivationKeyPressed,
   zoomActivationKeyPressed,
   zoomOnScroll,
   zoomOnPinch,
@@ -97,7 +99,9 @@ export function createFilter({
     const buttonAllowed =
       (Array.isArray(panOnDrag) && panOnDrag.includes(event.button)) || !event.button || event.button <= 1;
 
-    // default filter for d3-zoom
-    return (!event.ctrlKey || isWheelEvent) && buttonAllowed;
+    // d3-zoom rejects Ctrl-modified mouse drags by default because Ctrl+wheel is
+    // commonly used for pinch zooming. Allow the drag when Control is the
+    // configured pan activation key, while retaining the wheel safeguard.
+    return (!event.ctrlKey || isWheelEvent || panActivationKeyPressed) && buttonAllowed;
   };
 }

--- a/tests/playwright/e2e/pane.spec.ts
+++ b/tests/playwright/e2e/pane.spec.ts
@@ -172,12 +172,32 @@ test.describe('Pane non-default', () => {
   });
 });
 
-// test.describe('Pane activation keys', () => {
-//   test.beforeEach(async ({ page }) => {
-//     // Go to the starting url before each test.
-//     await page.goto('/tests/generic/pane/activation-keys');
+test.describe('Pane activation keys', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/generic/pane/activation-keys');
+    await page.waitForSelector('[data-id="first-edge"]', { timeout: 5000 });
+  });
 
-//     // Wait till the edges are rendered
-//     await page.waitForSelector('[data-id="first-edge"]', { timeout: 5000 });
-//   });
-// });
+  test('Control and primary-button drag pans the pane', async ({ page }) => {
+    const pane = page.locator(`.${FRAMEWORK}-flow__pane`);
+    const viewport = page.locator(`.${FRAMEWORK}-flow__viewport`);
+    const paneBox = await pane.boundingBox();
+    const transformsBefore = await getTransform(viewport);
+    const movementPx = 100;
+
+    await page.keyboard.down('Control');
+    await pane.hover();
+    await page.mouse.down();
+    await page.mouse.move(
+      paneBox!.x + paneBox!.width * 0.5 + movementPx,
+      paneBox!.y + paneBox!.height * 0.5 + movementPx
+    );
+    await page.mouse.up();
+    await page.keyboard.up('Control');
+
+    const transformsAfter = await getTransform(viewport);
+
+    expect(movementPx - Math.floor(transformsAfter.translateX - transformsBefore.translateX)).toBeLessThan(1);
+    expect(movementPx - Math.floor(transformsAfter.translateY - transformsBefore.translateY)).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
Fixes #5923

## Summary

- propagate the active pan activation key state from React Flow and Svelte Flow into the shared XY pan/zoom filter
- allow primary-button dragging when Control is the configured and active pan key
- retain the existing Ctrl-wheel/pinch safeguard
- add shared Playwright coverage for React and Svelte plus a patch changeset

## Root cause

The shared d3-zoom filter rejects all Ctrl-modified mouse events. React Flow and Svelte Flow already convert an active pan activation key into an enabled panOnDrag value, but the filter still rejects the mousedown before panning can start.

## Verification

- pnpm build
- pnpm typecheck
- changed-file ESLint and Prettier checks
- React Chromium: Control and primary-button drag pans the pane
- Svelte Chromium: Control and primary-button drag pans the pane