### PR TITLE
fix(react): make useKeyPress work with combinations of three or more keys

### DIFF
--- a/.changeset/usekeypress-multi-key-combination.md
+++ b/.changeset/usekeypress-multi-key-combination.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix `useKeyPress` never firing for key combinations of three or more keys (e.g. `'Meta+Shift+s'`). Only the first `+` was replaced when splitting the combination, so the remaining keys were parsed as a single unmatchable key.

--- a/.changeset/usekeypress-multi-key-combination.md
+++ b/.changeset/usekeypress-multi-key-combination.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Fix `useKeyPress` never firing for key combinations of three or more keys (e.g. `'Meta+Shift+s'`). Only the first `+` was replaced when splitting the combination, so the remaining keys were parsed as a single unmatchable key.
+Allow key combinations of three or more keys (e.g. `'Meta+Shift+s'`) for `useKeyPress`.

--- a/packages/react/src/hooks/useKeyPress.ts
+++ b/packages/react/src/hooks/useKeyPress.ts
@@ -87,7 +87,7 @@ export function useKeyPress(
          * then we replace '\n\n' with '\n+', this way we can also support the combination 'key++'
          * in the end we simply split on '\n' to get the key array
          */
-        .map((kc) => kc.replace('+', '\n').replace('\n\n', '\n+').split('\n'));
+        .map((kc) => kc.replace(/\+/g, '\n').replace('\n\n', '\n+').split('\n'));
       const keysFlat = keys.reduce((res: Keys, item) => res.concat(...item), []);
 
       return [keys, keysFlat];


### PR DESCRIPTION
## The bug

`useKeyPress` splits a key combination string on `+`:

```ts
// packages/react/src/hooks/useKeyPress.ts
/*
 * we first replace all '+' with '\n'  which we will use to split the keys on
 * then we replace '\n\n' with '\n+', this way we can also support the combination 'key++'
 * in the end we simply split on '\n' to get the key array
 */
.map((kc) => kc.replace('+', '\n').replace('\n\n', '\n+').split('\n'));
```

The comment says *"replace **all** `+`"*, but `String.prototype.replace` with a **string** pattern only replaces the **first** occurrence. So only the first `+` becomes a separator:

```
'Meta+Shift+s'  ->  ['Meta', 'Shift+s']
```

`'Shift+s'` can never equal an event's `key` or `code`, so `isMatchingKey`'s `keys.every(k => pressedKeys.has(k))` never succeeds and **the hook never fires for combinations of three or more keys**. Two-key combinations work by accident.

This also silently disabled the `.replace('\n\n', '\n+')` step that follows: a `'\n\n'` sequence can only ever appear if two consecutive `+` were both replaced, which requires a global replace. That step is currently unreachable dead code — which is itself evidence that a global replace was intended (it exists to support `'key++'`).

## The fix

Use a global regex, exactly as the comment describes.

## Verification

| input | before | after |
|---|---|---|
| `'Meta+Shift+s'` | `['Meta', 'Shift+s']` ❌ never fires | `['Meta', 'Shift', 's']` ✅ |
| `'Control+Alt+Delete'` | `['Control', 'Alt+Delete']` ❌ | `['Control', 'Alt', 'Delete']` ✅ |
| `'Meta+Shift++'` | `['Meta', 'Shift++']` ❌ | `['Meta', 'Shift', '+']` ✅ |
| `'a++'` (the `+` key) | `['a', '+']` | `['a', '+']` (unchanged) |
| `'Shift+a'` | `['Shift', 'a']` | `['Shift', 'a']` (unchanged) |

Two-key combinations and the `'key++'` case are unaffected; only 3+ key combinations change (from broken to working). `tsc --noEmit` and `eslint` pass.

Svelte Flow is not affected — `KeyHandler.svelte` uses a different mechanism.

I didn't add an automated test: the parsing happens inside the hook's `useMemo` (not separately exported), and the repo's keyboard tests live in the e2e/Playwright suites rather than the cypress component tests. Happy to add one in whatever form you prefer.
