### PR TITLE
Forward missing handle errors to the current onError callback

### DIFF
--- a/.changeset/fresh-edges-report.md
+++ b/.changeset/fresh-edges-report.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Forward missing-handle errors to the current `onError` callback after node measurement.

--- a/examples/react/src/generic-tests/edges/missing-handle.ts
+++ b/examples/react/src/generic-tests/edges/missing-handle.ts
@@ -1,0 +1,26 @@
+export default {
+  flowProps: {
+    nodes: [
+      {
+        id: 'source',
+        data: { label: 'Source' },
+        position: { x: 0, y: 0 },
+        type: 'input',
+      },
+      {
+        id: 'target',
+        data: { label: 'Target' },
+        position: { x: 200, y: 0 },
+      },
+    ],
+    edges: [
+      {
+        id: 'missing-handle',
+        source: 'source',
+        sourceHandle: 'missing',
+        target: 'target',
+      },
+    ],
+    onError: (code) => console.info(`react-flow-error:${code}`),
+  },
+} satisfies FlowConfig;

--- a/packages/react/src/components/EdgeWrapper/index.tsx
+++ b/packages/react/src/components/EdgeWrapper/index.tsx
@@ -85,7 +85,7 @@ function EdgeWrapper<EdgeType extends Edge = Edge>({
           sourceHandle: edge.sourceHandle || null,
           targetHandle: edge.targetHandle || null,
           connectionMode: store.connectionMode,
-          onError,
+          onError: store.onError,
         });
 
         const zIndex = getElevatedEdgeZIndex({

--- a/tests/playwright/e2e/edges.spec.ts
+++ b/tests/playwright/e2e/edges.spec.ts
@@ -175,4 +175,14 @@ test.describe('Edges', () => {
       await expect(svg).toHaveCSS('z-index', '1');
     });
   });
+
+  test('calls onError when an edge references a missing handle', async ({ page }) => {
+    const errorMessage = page.waitForEvent('console', {
+      predicate: (message) => message.text() === 'react-flow-error:008',
+    });
+
+    await page.goto('/tests/generic/edges/missing-handle');
+
+    await expect(errorMessage).resolves.toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Forward missing-handle errors to the current `onError` callback after nodes finish measuring.

## Problem

When `<ReactFlow />` creates its own provider, edges are available before `StoreUpdater` installs the caller's `onError` callback. `EdgeWrapper` can memoize its position selector during that first render and keep the default warning callback, so error `008` detected after handle measurement never reaches the caller.

## Changes

- Read `onError` from the current store state whenever the edge-position selector runs.
- Add a Playwright regression for a missing source handle without an external `<ReactFlowProvider />`.
- Add a patch changeset for `@xyflow/react`.

## Testing

- `@xyflow/react` typecheck
- React Chromium edge suite: 17 passed
- Focused ESLint check for `EdgeWrapper`
- Prettier check for all changed files

## Related

Fixes #5932