### PR TITLE
fix(react): correct offset math in Background pattern

### DIFF
--- a/.changeset/yellow-bushes-make.md
+++ b/.changeset/yellow-bushes-make.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix `<Background />` pattern offset being miscalculated due to an errant `|| 1` fallback in the offset math, causing dots/lines to be misaligned by more than expected (off by 1px with the default `offset={0}`, and by up to half the gap size for non-zero `offset` values).

--- a/.changeset/yellow-bushes-make.md
+++ b/.changeset/yellow-bushes-make.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Fix `<Background />` pattern offset being miscalculated due to an errant `|| 1` fallback in the offset math, causing dots/lines to be misaligned by more than expected (off by 1px with the default `offset={0}`, and by up to half the gap size for non-zero `offset` values).
+Fix `<Background />` pattern offset miscalculation.

--- a/packages/react/src/additional-components/Background/Background.tsx
+++ b/packages/react/src/additional-components/Background/Background.tsx
@@ -43,8 +43,8 @@ function BackgroundComponent({
 
   const patternDimensions: [number, number] = isCross ? [scaledSize, scaledSize] : scaledGap;
   const scaledOffset: [number, number] = [
-    offsetXY[0] * transform[2] || 1 + patternDimensions[0] / 2,
-    offsetXY[1] * transform[2] || 1 + patternDimensions[1] / 2,
+    offsetXY[0] * transform[2] + patternDimensions[0] / 2,
+    offsetXY[1] * transform[2] + patternDimensions[1] / 2,
   ];
 
   const _patternId = `${patternId}${id ? id : ''}`;

--- a/tests/playwright/e2e/background.spec.ts
+++ b/tests/playwright/e2e/background.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Background', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/examples/backgrounds');
+  });
+
+  test('centers the dot pattern with default gap and no offset (zoom 1, pan 0,0)', async ({ page }) => {
+    // flow-a renders <Background variant={BackgroundVariant.Dots} /> with defaults:
+    // gap=20, offset=0. At zoom 1 the pattern should be centered by exactly half
+    // the gap, i.e. translate(-10,-10), not translate(-11,-11).
+    const pattern = page.locator('#pattern-flow-a0');
+
+    await expect(pattern).toHaveAttribute('patternTransform', 'translate(-10,-10)');
+  });
+
+  test('applies both the offset and the half-cell centering for a non-zero offset', async ({ page }) => {
+    // flow-d's second background renders <Background variant={BackgroundVariant.Lines} gap={100} offset={2} />
+    // at zoom 1, so the expected translation is offset + half the gap: 2 + 50 = 52.
+    const pattern = page.locator('#pattern-flow-d1');
+
+    await expect(pattern).toHaveAttribute('patternTransform', 'translate(-52,-52)');
+  });
+});


### PR DESCRIPTION
The scaledOffset calculation used an errant "|| 1" fallback (likely copy-pasted from the scaledGap line above, where it makes sense to floor a zero gap). Applied to offset this caused two bugs:

- With the default offset={0}, offset*zoom is 0/falsy, so the fallback kicked in and added an extra +1px on top of the intended half-cell centering (translate(-11,-11) instead of (-10,-10) for gap={20}, zoom=1).
- With any non-zero offset, offset*zoom is truthy, so the "||" short- circuits and the entire "+ patternDimensions/2" centering term is dropped, not just miscalculated (e.g. gap={100}, offset={2} produced translate(-2,-2) instead of the correct (-52,-52)).

Removing the fallback and just adding the two terms fixes both cases.