### PR TITLE
fix(react): use the current nodeExtent in setNodes

### DIFF
--- a/.changeset/setnodes-stale-node-extent.md
+++ b/.changeset/setnodes-stale-node-extent.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Fix `setNodes` re-clamping node positions with the initial `nodeExtent` instead of the current one, so nodes could escape a `nodeExtent` that was changed at runtime.
+Use correct `nodeExtent` for internal `setNodes`.

--- a/.changeset/setnodes-stale-node-extent.md
+++ b/.changeset/setnodes-stale-node-extent.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix `setNodes` re-clamping node positions with the initial `nodeExtent` instead of the current one, so nodes could escape a `nodeExtent` that was changed at runtime.

--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -101,6 +101,7 @@ const createStore = ({
           nodeLookup,
           parentLookup,
           nodeOrigin,
+          nodeExtent,
           elevateNodesOnSelect,
           fitViewQueued,
           zIndexMode,


### PR DESCRIPTION
## The bug

Changing `nodeExtent` at runtime works — until the next `nodes` update. Then every node is re-clamped with the extent the store was **created** with, so nodes can end up outside the extent that is currently configured.

`setNodes` destructures everything it forwards to `adoptUserNodes` from `get()`, except `nodeExtent`. That identifier therefore resolves to the `createStore({ ..., nodeExtent, ... })` parameter rather than state — and state is what `setNodeExtent` updates (which is where the `nodeExtent` prop lands, via `StoreUpdater`).

Its two siblings in the same store already read it from state:

| action | `nodeExtent` from |
|---|---|
| `updateNodeInternals` | `get()` ✅ |
| `setNodeExtent` | `get()` ✅ |
| `setNodes` | `createStore` closure ❌ |

## Reproduction

Driving the real store (`createStore` → `setNodeExtent` → `setNodes`) with one node at `{ x: 500, y: 500 }`, `measured: 10 × 10`:

```ts
const store = createStore({ nodes, edges: [], nodeExtent: [[0, 0], [100, 100]] });
store.getState().setNodeExtent([[0, 0], [50, 50]]);   // shrink the extent at runtime
store.getState().setNodes(nodes);                     // any nodes update
// -> read nodeLookup.get('n').internals.positionAbsolute
```

| scenario | before | after |
|---|---|---|
| extent changed at runtime (`[[0,0],[100,100]]` → `[[0,0],[50,50]]`), then a `nodes` update | **`(90, 90)`** — clamped with the old extent, outside the current one | **`(40, 40)`** — correct (`50 − 10`) |
| no `nodeExtent` ever configured | `(500, 500)` | `(500, 500)` — unchanged |
| `nodeExtent` configured, never changed | `(90, 90)` | `(90, 90)` — unchanged |

## The fix

Add `nodeExtent` to the `get()` destructure in `setNodes`. One line.

Only the first scenario changes. `adoptUserNodes` merges options with `mergeObjects`, which skips `undefined`, so for a flow with no `nodeExtent` the previous `undefined` and the new `infiniteExtent` (state's default, `nodeExtent ?? infiniteExtent`) resolve identically — confirmed by the second row above.

`tsc --noEmit` and `eslint` pass. I couldn't run the cypress component suite locally, so there's no test in this PR — happy to add one (the existing `uses nodeExtent` case in `view-props.cy.tsx` plus a prop change would cover it) if you'd like.

Found while auditing the store actions after #5871 / #5929.
