### PR TITLE
feat(react and svelte): add `deselectOnSelection` prop

### DIFF
--- a/.changeset/deselectOnSelection-prop.md
+++ b/.changeset/deselectOnSelection-prop.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/react": minor
+"@xyflow/svelte": minor
+---
+
+Add `deselectOnSelection` prop to `<ReactFlow />` and `<SvelteFlow />`. When set to `false`, starting a box selection no longer clears previously selected elements - previously selected nodes and edges stay selected while the box adds new ones.

--- a/examples/react/src/generic-tests/pane/deselect-on-selection.ts
+++ b/examples/react/src/generic-tests/pane/deselect-on-selection.ts
@@ -1,0 +1,40 @@
+export default {
+  flowProps: {
+    minZoom: 0.25,
+    maxZoom: 4,
+    fitView: true,
+    panOnDrag: false,
+    selectionOnDrag: true,
+    deselectOnSelection: false,
+    nodes: [
+      {
+        id: '1',
+        data: { label: '1' },
+        position: { x: 0, y: 0 },
+        type: 'input',
+      },
+      {
+        id: '2',
+        data: { label: '2' },
+        position: { x: -100, y: 100 },
+      },
+      {
+        id: '3',
+        data: { label: '3' },
+        position: { x: 100, y: 100 },
+      },
+    ],
+    edges: [
+      {
+        id: 'first-edge',
+        source: '1',
+        target: '2',
+      },
+      {
+        id: 'second-edge',
+        source: '1',
+        target: '3',
+      },
+    ],
+  },
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/pane/deselect-on-select.ts
+++ b/examples/svelte/src/generic-tests/pane/deselect-on-select.ts
@@ -1,0 +1,40 @@
+export default {
+	flowProps: {
+		minZoom: 0.25,
+		maxZoom: 4,
+		fitView: true,
+		panOnDrag: false,
+		selectionOnDrag: true,
+		deselectOnSelection: false,
+		nodes: [
+			{
+				id: '1',
+				data: { label: '1' },
+				position: { x: 0, y: 0 },
+				type: 'input'
+			},
+			{
+				id: '2',
+				data: { label: '2' },
+				position: { x: -100, y: 100 }
+			},
+			{
+				id: '3',
+				data: { label: '3' },
+				position: { x: 100, y: 100 }
+			}
+		],
+		edges: [
+			{
+				id: 'first-edge',
+				source: '1',
+				target: '2'
+			},
+			{
+				id: 'second-edge',
+				source: '1',
+				target: '3'
+			}
+		]
+	}
+} satisfies FlowConfig;

--- a/packages/react/src/container/FlowRenderer/index.tsx
+++ b/packages/react/src/container/FlowRenderer/index.tsx
@@ -47,6 +47,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
   deleteKeyCode,
   selectionKeyCode,
   selectionOnDrag,
+  deselectOnSelection,
   selectionMode,
   onSelectionStart,
   onSelectionEnd,
@@ -126,6 +127,7 @@ function FlowRendererComponent<NodeType extends Node = Node>({
         selectionKeyPressed={selectionKeyPressed}
         paneClickDistance={paneClickDistance}
         selectionOnDrag={_selectionOnDrag}
+        deselectOnSelection={deselectOnSelection}
       >
         {children}
         {nodesSelectionActive && (

--- a/packages/react/src/container/GraphView/index.tsx
+++ b/packages/react/src/container/GraphView/index.tsx
@@ -60,6 +60,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
   connectionLineContainerStyle,
   selectionKeyCode,
   selectionOnDrag,
+  deselectOnSelection,
   selectionMode,
   multiSelectionKeyCode,
   panActivationKeyCode,
@@ -126,6 +127,7 @@ function GraphViewComponent<NodeType extends Node = Node, EdgeType extends Edge 
       deleteKeyCode={deleteKeyCode}
       selectionKeyCode={selectionKeyCode}
       selectionOnDrag={selectionOnDrag}
+      deselectOnSelection={deselectOnSelection}
       selectionMode={selectionMode}
       onSelectionStart={onSelectionStart}
       onSelectionEnd={onSelectionEnd}

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -47,6 +47,7 @@ type PaneProps = {
     | 'onPaneMouseMove'
     | 'onPaneMouseLeave'
     | 'selectionOnDrag'
+    | 'deselectOnSelection'
   >
 >;
 
@@ -78,6 +79,7 @@ export function Pane({
   autoPanOnSelection,
   paneClickDistance,
   selectionOnDrag,
+  deselectOnSelection = true,
   onSelectionStart,
   onSelectionEnd,
   onPaneClick,
@@ -101,6 +103,8 @@ export function Pane({
 
   // Used to prevent click events when the user lets go of the selectionKey during a selection
   const selectionInProgress = useRef<boolean>(false);
+  const selectedNodeIdsBeforeSelectionStart = useRef<Set<string>>(new Set());
+  const selectedEdgeIdsBeforeSelectionStart = useRef<Set<string>>(new Set());
 
   // Used for auto pan when approaching the edges of the container during selection
   const position = useRef<XYPosition>({ x: 0, y: 0 });
@@ -218,13 +222,14 @@ export function Pane({
     const prevSelectedNodeIds = selectedNodeIds.current;
     const prevSelectedEdgeIds = selectedEdgeIds.current;
 
-    selectedNodeIds.current = new Set(
-      getNodesInside(nodeLookup, nextUserSelectRect, transform, selectionMode === SelectionMode.Partial, true).map(
+    selectedNodeIds.current = new Set([
+      ...selectedNodeIdsBeforeSelectionStart.current,
+      ...getNodesInside(nodeLookup, nextUserSelectRect, transform, selectionMode === SelectionMode.Partial, true).map(
         (node) => node.id
-      )
-    );
+      ),
+    ]);
 
-    selectedEdgeIds.current = new Set();
+    selectedEdgeIds.current = new Set(selectedEdgeIdsBeforeSelectionStart.current);
     const edgesSelectable = defaultEdgeOptions?.selectable ?? true;
 
     // We look for all edges connected to the selected nodes
@@ -284,7 +289,7 @@ export function Pane({
   }, []);
 
   const onPointerMove = (event: ReactPointerEvent): void => {
-    const { userSelectionRect, transform, resetSelectedElements } = store.getState();
+    const { userSelectionRect, transform } = store.getState();
 
     if (!containerBounds.current || !userSelectionRect) {
       return;
@@ -301,8 +306,7 @@ export function Pane({
       if (distance <= requiredDistance) {
         return;
       }
-      resetSelectedElements();
-      onSelectionStart?.(event);
+      beginSelection(event);
     }
 
     selectionInProgress.current = true;
@@ -313,6 +317,24 @@ export function Pane({
     }
 
     commitUserSelectionRect(mouseX, mouseY);
+  };
+
+  const beginSelection = (event: ReactPointerEvent): void => {
+    const { resetSelectedElements, nodeLookup, edgeLookup } = store.getState();
+
+    if (deselectOnSelection) {
+      selectedNodeIdsBeforeSelectionStart.current = new Set();
+      selectedEdgeIdsBeforeSelectionStart.current = new Set();
+      resetSelectedElements();
+    } else {
+      selectedNodeIdsBeforeSelectionStart.current = new Set(
+        [...nodeLookup.values()].filter((node) => node.selected).map((node) => node.id)
+      );
+      selectedEdgeIdsBeforeSelectionStart.current = new Set(
+        [...edgeLookup.values()].filter((edge) => edge.selected).map((edge) => edge.id)
+      );
+    }
+    onSelectionStart?.(event);
   };
 
   const onPointerUp = (event: ReactPointerEvent) => {

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -68,6 +68,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     deleteKeyCode = 'Backspace',
     selectionKeyCode = 'Shift',
     selectionOnDrag = false,
+    deselectOnSelection = true,
     selectionMode = SelectionMode.Full,
     panActivationKeyCode = 'Space',
     multiSelectionKeyCode = isMacOs() ? 'Meta' : 'Control',
@@ -268,6 +269,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
           connectionLineContainerStyle={connectionLineContainerStyle}
           selectionKeyCode={selectionKeyCode}
           selectionOnDrag={selectionOnDrag}
+          deselectOnSelection={deselectOnSelection}
           selectionMode={selectionMode}
           deleteKeyCode={deleteKeyCode}
           multiSelectionKeyCode={multiSelectionKeyCode}

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -342,6 +342,13 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    */
   selectionOnDrag?: boolean;
   /**
+   * When starting a new selection box, this controls whether the previously selected elements
+   * are deselected. Set to `false` to keep the existing selection and add the newly boxed
+   * elements to it.
+   * @default true
+   */
+  deselectOnSelection?: boolean;
+  /**
    * When set to `"partial"`, when the user creates a selection box by click and dragging nodes that
    * are only partially in the box are still selected.
    * @default 'full'

--- a/packages/svelte/src/lib/container/Pane/Pane.svelte
+++ b/packages/svelte/src/lib/container/Pane/Pane.svelte
@@ -58,6 +58,7 @@
     panOnDrag = true,
     paneClickDistance = 1,
     selectionOnDrag,
+    deselectOnSelection = true,
     autoPanOnSelection = true,
     onpaneclick,
     onpanecontextmenu,
@@ -88,6 +89,8 @@
 
   // Used to prevent click events when the user lets go of the selectionKey during a selection
   let selectionInProgress = false;
+  let selectedNodeIdsBeforeSelectionStart: Set<string> = new Set();
+  let selectedEdgeIdsBeforeSelectionStart: Set<string> = new Set();
 
   // Used for auto pan when approaching the edges of the container during selection
   let autoPanId: number = 0;
@@ -176,18 +179,19 @@
     const prevSelectedNodeIds = selectedNodeIds;
     const prevSelectedEdgeIds = selectedEdgeIds;
 
-    selectedNodeIds = new Set(
-      getNodesInside(
+    selectedNodeIds = new Set([
+      ...selectedNodeIdsBeforeSelectionStart,
+      ...getNodesInside(
         store.nodeLookup,
         nextUserSelectRect,
         [store.viewport.x, store.viewport.y, store.viewport.zoom],
         store.selectionMode === SelectionMode.Partial,
         true
       ).map((n) => n.id)
-    );
+    ]);
 
     const edgesSelectable = store.defaultEdgeOptions.selectable ?? true;
-    selectedEdgeIds = new Set();
+    selectedEdgeIds = new Set(selectedEdgeIdsBeforeSelectionStart);
 
     // We look for all edges connected to the selected nodes
     for (const nodeId of selectedNodeIds) {
@@ -263,8 +267,7 @@
       if (distance <= requiredDistance) {
         return;
       }
-      store.unselectNodesAndEdges();
-      onselectionstart?.(event);
+      beginSelection(event);
     }
 
     selectionInProgress = true;
@@ -275,6 +278,22 @@
     }
 
     commitUserSelectionRect(mousePos.x, mousePos.y);
+  }
+
+  function beginSelection(event: PointerEvent) {
+    if (deselectOnSelection) {
+      selectedNodeIdsBeforeSelectionStart = new Set();
+      selectedEdgeIdsBeforeSelectionStart = new Set();
+      store.unselectNodesAndEdges();
+    } else {
+      selectedNodeIdsBeforeSelectionStart = new Set(
+        store.nodes.filter((node) => node.selected).map((node) => node.id)
+      );
+      selectedEdgeIdsBeforeSelectionStart = new Set(
+        store.edges.filter((edge) => edge.selected).map((edge) => edge.id)
+      );
+    }
+    onselectionstart?.(event);
   }
 
   function onPointerUp(event: PointerEvent) {

--- a/packages/svelte/src/lib/container/Pane/types.ts
+++ b/packages/svelte/src/lib/container/Pane/types.ts
@@ -7,6 +7,7 @@ export type PaneProps<NodeType extends Node = Node, EdgeType extends Edge = Edge
   panOnDrag?: boolean | number[];
   paneClickDistance: number;
   selectionOnDrag?: boolean;
+  deselectOnSelection?: boolean;
   autoPanOnSelection?: boolean;
   onselectionstart?: (event: PointerEvent) => void;
   onselectionend?: (event: PointerEvent) => void;

--- a/packages/svelte/src/lib/container/SvelteFlow/SvelteFlow.svelte
+++ b/packages/svelte/src/lib/container/SvelteFlow/SvelteFlow.svelte
@@ -62,6 +62,7 @@
     panOnScrollSpeed = 0.5,
     panOnDrag = true,
     selectionOnDrag = false,
+    deselectOnSelection = true,
     autoPanOnSelection = true,
     connectionLineComponent,
     connectionLineStyle,
@@ -172,6 +173,7 @@
       {panOnDrag}
       {paneClickDistance}
       {selectionOnDrag}
+      {deselectOnSelection}
       {autoPanOnSelection}
     >
       <ViewportComponent bind:store>

--- a/packages/svelte/src/lib/container/SvelteFlow/types.ts
+++ b/packages/svelte/src/lib/container/SvelteFlow/types.ts
@@ -339,6 +339,13 @@ export type SvelteFlowProps<
      */
     selectionOnDrag?: boolean;
     /**
+     * When starting a new selection box, this controls whether the previously selected elements
+     * are deselected. Set to `false` to keep the existing selection and add the newly boxed
+     * elements to it.
+     * @default true
+     */
+    deselectOnSelection?: boolean;
+    /**
      * You can enable this optimisation to instruct Svelte Flow to only render nodes and edges that would be visible in the viewport.
      * This might improve performance when you have a large number of nodes and edges but also adds an overhead.
      * @default false

--- a/packages/svelte/src/lib/store/types.ts
+++ b/packages/svelte/src/lib/store/types.ts
@@ -86,6 +86,7 @@ export type SvelteFlowRestProps<NodeType extends Node = Node, EdgeType extends E
   | 'panOnScroll'
   | 'panOnDrag'
   | 'selectionOnDrag'
+  | 'deselectOnSelection'
   | 'connectionLineComponent'
   | 'connectionLineStyle'
   | 'connectionLineContainerStyle'

--- a/tests/playwright/e2e/pane.spec.ts
+++ b/tests/playwright/e2e/pane.spec.ts
@@ -313,3 +313,28 @@ test.describe('Pane activation keys', () => {
     expect(movementPx - Math.floor(transformsAfter.translateY - transformsBefore.translateY)).toBeLessThan(1);
   });
 });
+
+test.describe('Pane deselectOnSelection', () => {
+  test('keeps the existing selection when a new selection box starts', async ({ page }) => {
+    await page.goto('/tests/generic/pane/deselect-on-selection');
+    await page.waitForSelector('[data-id="first-edge"]', { timeout: 5000 });
+
+    const node1 = page.locator(`.${FRAMEWORK}-flow__node[data-id="1"]`);
+    const node2 = page.locator(`.${FRAMEWORK}-flow__node[data-id="2"]`);
+    const node3 = page.locator(`.${FRAMEWORK}-flow__node[data-id="3"]`);
+
+    await node1.click();
+    await expect(node1).toHaveClass(/selected/);
+
+    // Draw a selection box (a plain drag, since selectionOnDrag is enabled) around node 3 only.
+    const box = await node3.boundingBox();
+    await page.mouse.move(box!.x - 20, box!.y - 20);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width + 20, box!.y + box!.height + 20);
+    await page.mouse.up();
+
+    await expect(node1).toHaveClass(/selected/);
+    await expect(node3).toHaveClass(/selected/);
+    await expect(node2).not.toHaveClass(/selected/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a `deselectOnSelection` prop to React and Svelte. If set to `false`, then initiating a box drag keeps already selected elements (e.g. nodes and edges) still selected.

## Changes Made
- Adds a `deselectOnSelection` prop to React and Svelte. If `true` same behaviour as before, so `true` is default. Else, we union the already selected nodes and edges with the ones selected by the box drag.
- Adds E2E tests

## Testing
- ✅ All existing tests pass
- ✅ New `deselect-on-selection.ts` test fixture and `Pane deselectOnSelection` test added
- ✅ Backward compatibility verified

## Example Usage
1. Set `deselectOnSelection=false` on any existing example with multiple nodes
2. Run `pnpm dev`
3. Select a node
4. Box drag around a different node
5. See that the originally selected node is still highlighted

Closes #2782 