### PR TITLE
Remove updateAbsolutePositions

### DIFF
--- a/packages/react/src/store/index.ts
+++ b/packages/react/src/store/index.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import {
   adoptUserNodes,
-  updateAbsolutePositions,
   panBy as panBySystem,
   updateNodeInternals as updateNodeInternalsSystem,
   updateConnectionLookup,
@@ -191,8 +190,6 @@ const createStore = ({
         if (!updatedInternals) {
           return;
         }
-
-        updateAbsolutePositions(nodeLookup, parentLookup, { nodeOrigin, nodeExtent, zIndexMode });
 
         if (fitViewQueued) {
           void resolveFitView();

--- a/packages/svelte/src/lib/store/index.ts
+++ b/packages/svelte/src/lib/store/index.ts
@@ -11,7 +11,6 @@ import {
   type CoordinateExtent,
   type UpdateConnection,
   type ConnectionState,
-  updateAbsolutePositions,
   snapPosition,
   calculateNodePosition,
   type SetCenterOptions,
@@ -109,12 +108,6 @@ export function createStore<NodeType extends Node = Node, EdgeType extends Edge 
     if (!updatedInternals) {
       return;
     }
-
-    updateAbsolutePositions(store.nodeLookup, store.parentLookup, {
-      nodeOrigin: store.nodeOrigin,
-      nodeExtent: store.nodeExtent,
-      zIndexMode: store.zIndexMode
-    });
 
     if (store.fitViewQueued) {
       store.resolveFitView();

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -47,10 +47,6 @@ const defaultOptions = {
   elevateNodesOnSelect: true,
   zIndexMode: 'basic' as ZIndexMode,
   defaults: {},
-};
-
-const adoptUserNodesDefaultOptions = {
-  ...defaultOptions,
   checkEquality: true,
 };
 
@@ -66,27 +62,9 @@ function mergeObjects<T extends Record<string, unknown>>(base: T, incoming?: Par
   return result;
 }
 
-export function updateAbsolutePositions<NodeType extends NodeBase>(
-  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
-  parentLookup: ParentLookup<InternalNodeBase<NodeType>>,
-  options?: UpdateNodesOptions<NodeType>
-) {
-  const _options = mergeObjects(defaultOptions, options);
-  for (const node of nodeLookup.values()) {
-    if (node.parentId) {
-      updateChildNode(node, nodeLookup, parentLookup, _options);
-    } else {
-      const positionWithOrigin = getNodePositionWithOrigin(node, _options.nodeOrigin);
-      const extent = isCoordinateExtent(node.extent) ? node.extent : _options.nodeExtent;
-      const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(node));
-      node.internals.positionAbsolute = clampedPosition;
-    }
-  }
-}
-
 function parseHandles(userNode: NodeBase, internalNode?: InternalNodeBase): NodeHandleBounds | undefined {
   if (!userNode.handles) {
-    return !userNode.measured ? undefined : internalNode?.internals.handleBounds;
+    return !userNode.measured || userNode.hidden ? undefined : internalNode?.internals.handleBounds;
   }
 
   const source: Handle[] = [];
@@ -125,19 +103,14 @@ type UpdateNodesOptions<NodeType extends NodeBase> = {
   checkEquality?: boolean;
 };
 
-export function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
+function isManualZIndexMode(zIndexMode?: ZIndexMode): boolean {
   return zIndexMode === 'manual';
 }
-
-type AdoptUserNodesReturn = {
-  nodesInitialized: boolean;
-  hasSelectedNodes: boolean;
-};
 
 type SubflowContext<NodeType extends NodeBase> = {
   nodeLookup: NodeLookup<InternalNodeBase<NodeType>>;
   parentLookup: ParentLookup<InternalNodeBase<NodeType>>;
-  options: UpdateNodesOptions<NodeType>;
+  options: Required<UpdateNodesOptions<NodeType>>;
   rootParentIndex: { i: number };
   processedNodes: Set<string>;
   deferredChildNodes: Map<string, InternalNodeBase<NodeType>[]>;
@@ -147,13 +120,13 @@ export function adoptUserNodes<NodeType extends NodeBase>(
   nodes: NodeType[],
   nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
   parentLookup: ParentLookup<InternalNodeBase<NodeType>>,
-  options: UpdateNodesOptions<NodeType> = {}
-): AdoptUserNodesReturn {
-  const _options = mergeObjects(adoptUserNodesDefaultOptions, options);
+  _options: UpdateNodesOptions<NodeType> = {}
+) {
+  const options = mergeObjects(defaultOptions, _options);
   const rootParentIndex = { i: 0 };
   const tmpLookup = new Map(nodeLookup);
   const selectedNodeZ: number =
-    _options?.elevateNodesOnSelect && !isManualZIndexMode(_options.zIndexMode) ? SELECTED_NODE_Z : 0;
+    options.elevateNodesOnSelect && !isManualZIndexMode(options.zIndexMode) ? SELECTED_NODE_Z : 0;
   // We track the nodes that already have been processed (relevant for subflows)
   const processedNodes = new Set<string>();
   // Deferred child nodes are grouped by the parent id they are waiting for
@@ -164,7 +137,7 @@ export function adoptUserNodes<NodeType extends NodeBase>(
   nodeLookup.clear();
   parentLookup.clear();
 
-  const subflowContext = {
+  const subflowContext: SubflowContext<NodeType> = {
     nodeLookup,
     parentLookup,
     options,
@@ -176,15 +149,15 @@ export function adoptUserNodes<NodeType extends NodeBase>(
   for (const userNode of nodes) {
     let internalNode = tmpLookup.get(userNode.id);
 
-    if (_options.checkEquality && userNode === internalNode?.internals.userNode) {
+    if (options.checkEquality && userNode === internalNode?.internals.userNode) {
       nodeLookup.set(userNode.id, internalNode);
     } else {
-      const positionWithOrigin = getNodePositionWithOrigin(userNode, _options.nodeOrigin);
-      const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : _options.nodeExtent;
+      const positionWithOrigin = getNodePositionWithOrigin(userNode, options.nodeOrigin);
+      const extent = isCoordinateExtent(userNode.extent) ? userNode.extent : options.nodeExtent;
       const clampedPosition = clampPosition(positionWithOrigin, extent, getNodeDimensions(userNode));
 
       internalNode = {
-        ..._options.defaults,
+        ...options.defaults,
         ...userNode,
         measured: {
           width: userNode.measured?.width,
@@ -194,7 +167,7 @@ export function adoptUserNodes<NodeType extends NodeBase>(
           positionAbsolute: clampedPosition,
           // if user re-initializes the node or removes `measured` for whatever reason, we reset the handleBounds so that the node gets re-measured
           handleBounds: parseHandles(userNode, internalNode),
-          z: calculateZ(userNode, selectedNodeZ, _options.zIndexMode),
+          z: calculateZ(userNode, selectedNodeZ, options.zIndexMode),
           userNode,
         },
       };
@@ -232,7 +205,7 @@ function resolveSubflowsForNode<NodeType extends NodeBase>(
   node: InternalNodeBase<NodeType>,
   context: SubflowContext<NodeType>
 ) {
-  const { nodeLookup, parentLookup, options, rootParentIndex, processedNodes, deferredChildNodes } = context;
+  const { processedNodes, deferredChildNodes } = context;
 
   // The parent may appear later in the nodes array or may itself still be deferred.
   if (node.parentId && !processedNodes.has(node.parentId)) {
@@ -243,7 +216,7 @@ function resolveSubflowsForNode<NodeType extends NodeBase>(
   }
 
   if (node.parentId) {
-    updateChildNode(node, nodeLookup, parentLookup, options, rootParentIndex);
+    updateChildNode(node, context);
   }
 
   processedNodes.add(node.id);
@@ -278,12 +251,9 @@ function updateParentLookup<NodeType extends NodeBase>(
  */
 function updateChildNode<NodeType extends NodeBase>(
   node: InternalNodeBase<NodeType>,
-  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
-  parentLookup: ParentLookup<InternalNodeBase<NodeType>>,
-  options: UpdateNodesOptions<NodeType>,
-  rootParentIndex?: { i: number }
+  context: SubflowContext<NodeType>
 ) {
-  const { elevateNodesOnSelect, nodeOrigin, nodeExtent, zIndexMode } = mergeObjects(defaultOptions, options);
+  const { nodeLookup, parentLookup, rootParentIndex } = context;
   const parentId = node.parentId!;
   const parentNode = nodeLookup.get(parentId);
 
@@ -299,7 +269,7 @@ function updateChildNode<NodeType extends NodeBase>(
     rootParentIndex &&
     !parentNode.parentId &&
     parentNode.internals.rootParentIndex === undefined &&
-    zIndexMode === 'auto'
+    context.options.zIndexMode === 'auto'
   ) {
     parentNode.internals.rootParentIndex = ++rootParentIndex.i;
     parentNode.internals.z = parentNode.internals.z + rootParentIndex.i * ROOT_PARENT_Z_INCREMENT;
@@ -310,6 +280,22 @@ function updateChildNode<NodeType extends NodeBase>(
     rootParentIndex.i = parentNode.internals.rootParentIndex;
   }
 
+  updateChildXYZ(node, parentNode, context);
+}
+
+/**
+ * Updates positionAbsolute and zIndex of a child node and the parentLookup.
+ */
+function updateChildXYZ<NodeType extends NodeBase>(
+  node: InternalNodeBase<NodeType>,
+  parentNode: InternalNodeBase<NodeType>,
+  context: {
+    nodeLookup: NodeLookup<InternalNodeBase<NodeType>>;
+    options: Required<UpdateNodesOptions<NodeType>>;
+  }
+) {
+  const { elevateNodesOnSelect, nodeOrigin, nodeExtent, zIndexMode } = context.options;
+
   const selectedNodeZ = elevateNodesOnSelect && !isManualZIndexMode(zIndexMode) ? SELECTED_NODE_Z : 0;
   const { x, y, z } = calculateChildXYZ(node, parentNode, nodeOrigin, nodeExtent, selectedNodeZ, zIndexMode);
   const { positionAbsolute } = node.internals;
@@ -317,7 +303,7 @@ function updateChildNode<NodeType extends NodeBase>(
 
   if (positionChanged || z !== node.internals.z) {
     // we create a new object to mark the node as updated
-    nodeLookup.set(node.id, {
+    context.nodeLookup.set(node.id, {
       ...node,
       internals: {
         ...node.internals,
@@ -457,20 +443,30 @@ export function handleExpandParent(
   return changes;
 }
 
-export function updateNodeInternals<NodeType extends InternalNodeBase>(
+type UpdateInternalsContext<NodeType extends NodeBase> = {
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>;
+  parentLookup: ParentLookup<InternalNodeBase<NodeType>>;
+  updates: Map<string, InternalNodeUpdate>;
+  zoom: number;
+  options: Required<UpdateNodesOptions<NodeType>>;
+  changes: (DimensionChange | PositionChange)[];
+  parentExpandChildren: ParentExpandChild[];
+  updatedInternals: boolean;
+};
+
+export function updateNodeInternals<NodeType extends NodeBase>(
   updates: Map<string, InternalNodeUpdate>,
-  nodeLookup: NodeLookup<NodeType>,
-  parentLookup: ParentLookup<NodeType>,
+  nodeLookup: NodeLookup<InternalNodeBase<NodeType>>,
+  parentLookup: ParentLookup<InternalNodeBase<NodeType>>,
   domNode: HTMLElement | null,
   nodeOrigin?: NodeOrigin,
   nodeExtent?: CoordinateExtent,
   zIndexMode?: ZIndexMode
 ): { changes: (DimensionChange | PositionChange)[]; updatedInternals: boolean } {
   const viewportNode = domNode?.querySelector('.xyflow__viewport');
-  let updatedInternals = false;
 
   if (!viewportNode) {
-    return { changes: [], updatedInternals };
+    return { changes: [], updatedInternals: false };
   }
 
   const changes: (DimensionChange | PositionChange)[] = [];
@@ -479,79 +475,30 @@ export function updateNodeInternals<NodeType extends InternalNodeBase>(
   // in this array we collect nodes, that might trigger changes (like expanding parent)
   const parentExpandChildren: ParentExpandChild[] = [];
 
+  const context: UpdateInternalsContext<NodeType> = {
+    nodeLookup,
+    parentLookup,
+    zoom,
+    changes,
+    updates,
+    parentExpandChildren,
+    options: mergeObjects(defaultOptions, { nodeOrigin, nodeExtent, zIndexMode }),
+    updatedInternals: false,
+  };
+
   for (const update of updates.values()) {
     const node = nodeLookup.get(update.id);
     if (!node) {
       continue;
     }
 
-    if (node.hidden) {
-      nodeLookup.set(node.id, {
-        ...node,
-        internals: {
-          ...node.internals,
-          handleBounds: undefined,
-        },
-      });
-      updatedInternals = true;
+    if (node.parentId) {
       continue;
     }
 
-    const dimensions = getDimensions(update.nodeElement);
-    const dimensionChanged = node.measured.width !== dimensions.width || node.measured.height !== dimensions.height;
-    const doUpdate = !!(
-      dimensions.width &&
-      dimensions.height &&
-      (dimensionChanged || !node.internals.handleBounds || update.force)
-    );
+    updateInternals(node, update, context);
 
-    if (doUpdate) {
-      const nodeBounds = update.nodeElement.getBoundingClientRect();
-      const extent = isCoordinateExtent(node.extent) ? node.extent : nodeExtent;
-      let { positionAbsolute } = node.internals;
-
-      if (node.parentId && node.extent === 'parent') {
-        const parentNode = nodeLookup.get(node.parentId);
-        if (parentNode) {
-          positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, parentNode);
-        }
-      } else if (extent) {
-        positionAbsolute = clampPosition(positionAbsolute, extent, dimensions);
-      }
-
-      const newNode = {
-        ...node,
-        measured: dimensions,
-        internals: {
-          ...node.internals,
-          positionAbsolute,
-          handleBounds: {
-            source: getHandleBounds('source', update.nodeElement, nodeBounds, zoom, node.id),
-            target: getHandleBounds('target', update.nodeElement, nodeBounds, zoom, node.id),
-          },
-        },
-      };
-
-      nodeLookup.set(node.id, newNode);
-
-      if (node.parentId) {
-        updateChildNode(newNode, nodeLookup, parentLookup, { nodeOrigin, zIndexMode });
-      }
-
-      updatedInternals = true;
-
-      if (dimensionChanged) {
-        changes.push(dimensionChange(node.id, dimensions));
-
-        if (node.expandParent && node.parentId) {
-          parentExpandChildren.push({
-            id: node.id,
-            parentId: node.parentId,
-            rect: nodeToRect(newNode, nodeOrigin),
-          });
-        }
-      }
-    }
+    walkChildren(node, context);
   }
 
   if (parentExpandChildren.length > 0) {
@@ -559,7 +506,105 @@ export function updateNodeInternals<NodeType extends InternalNodeBase>(
     changes.push(...parentExpandChanges);
   }
 
-  return { changes, updatedInternals };
+  return { changes, updatedInternals: context.updatedInternals };
+}
+
+function updateInternals<NodeType extends NodeBase>(
+  node: InternalNodeBase<NodeType>,
+  update: InternalNodeUpdate,
+  context: UpdateInternalsContext<NodeType>
+) {
+  const { nodeLookup, updates, changes, parentExpandChildren, zoom } = context;
+  const { nodeOrigin, nodeExtent } = context.options;
+  if (node.hidden) {
+    nodeLookup.set(node.id, {
+      ...node,
+      internals: {
+        ...node.internals,
+        handleBounds: undefined,
+      },
+    });
+    updates.delete(node.id);
+    context.updatedInternals = true;
+    return;
+  }
+
+  const dimensions = getDimensions(update.nodeElement);
+  const dimensionChanged = node.measured.width !== dimensions.width || node.measured.height !== dimensions.height;
+  const doUpdate = !!(
+    dimensions.width &&
+    dimensions.height &&
+    (dimensionChanged || !node.internals.handleBounds || update.force)
+  );
+
+  if (doUpdate) {
+    const nodeBounds = update.nodeElement.getBoundingClientRect();
+    const extent = isCoordinateExtent(node.extent) ? node.extent : nodeExtent;
+    let { positionAbsolute } = node.internals;
+
+    if (node.parentId && node.extent === 'parent') {
+      const parentNode = nodeLookup.get(node.parentId);
+      if (parentNode) {
+        positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, parentNode);
+      }
+    } else if (extent) {
+      positionAbsolute = clampPosition(positionAbsolute, extent, dimensions);
+    }
+
+    const newNode = {
+      ...node,
+      measured: dimensions,
+      internals: {
+        ...node.internals,
+        positionAbsolute,
+        handleBounds: {
+          source: getHandleBounds('source', update.nodeElement, nodeBounds, zoom, node.id),
+          target: getHandleBounds('target', update.nodeElement, nodeBounds, zoom, node.id),
+        },
+      },
+    };
+
+    context.nodeLookup.set(node.id, newNode);
+
+    context.updatedInternals = true;
+    updates.delete(node.id);
+
+    if (dimensionChanged) {
+      changes.push(dimensionChange(node.id, dimensions));
+
+      if (node.expandParent && node.parentId) {
+        parentExpandChildren.push({
+          id: node.id,
+          parentId: node.parentId,
+          rect: nodeToRect(newNode, nodeOrigin),
+        });
+      }
+    }
+
+    walkChildren(node, context);
+  }
+}
+
+function walkChildren<NodeType extends NodeBase>(
+  node: InternalNodeBase<NodeType>,
+  context: UpdateInternalsContext<NodeType>
+) {
+  const { parentLookup, nodeLookup, updates } = context;
+  const children = parentLookup.get(node.id);
+  if (children) {
+    for (const child of children.values()) {
+      const childUpdate = updates.get(child.id);
+      if (!childUpdate) {
+        return;
+      }
+      const childNode = nodeLookup.get(child.id);
+      if (!childNode) {
+        return;
+      }
+      updateInternals(childNode, childUpdate, context);
+      updateChildXYZ(childNode, node, context);
+    }
+  }
 }
 
 export async function panBy({

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -516,14 +516,8 @@ function updateInternals<NodeType extends NodeBase>(
 ) {
   const { nodeLookup, updates, changes, parentExpandChildren, zoom } = context;
   const { nodeOrigin, nodeExtent } = context.options;
+
   if (node.hidden) {
-    nodeLookup.set(node.id, {
-      ...node,
-      internals: {
-        ...node.internals,
-        handleBounds: undefined,
-      },
-    });
     updates.delete(node.id);
     context.updatedInternals = true;
     return;

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -262,8 +262,6 @@ function updateChildNode<NodeType extends NodeBase>(
     return;
   }
 
-  updateParentLookup(node, parentLookup);
-
   // We just want to set the rootParentIndex for the first child
   if (
     rootParentIndex &&
@@ -280,7 +278,8 @@ function updateChildNode<NodeType extends NodeBase>(
     rootParentIndex.i = parentNode.internals.rootParentIndex;
   }
 
-  updateChildXYZ(node, parentNode, context);
+  const updatedNode = updateChildXYZ(node, parentNode, context);
+  updateParentLookup(updatedNode, parentLookup);
 }
 
 /**
@@ -303,15 +302,18 @@ function updateChildXYZ<NodeType extends NodeBase>(
 
   if (positionChanged || z !== node.internals.z) {
     // we create a new object to mark the node as updated
-    context.nodeLookup.set(node.id, {
+    const newNode = {
       ...node,
       internals: {
         ...node.internals,
         positionAbsolute: positionChanged ? { x, y } : positionAbsolute,
         z,
       },
-    });
+    };
+    context.nodeLookup.set(node.id, newNode);
+    return newNode;
   }
+  return node;
 }
 
 function calculateZ(node: NodeBase, selectedNodeZ: number, zIndexMode: ZIndexMode): number {
@@ -492,6 +494,7 @@ export function updateNodeInternals<NodeType extends NodeBase>(
       continue;
     }
 
+    // if the node has a parent it will be updated via walkChildren later
     if (node.parentId) {
       continue;
     }
@@ -561,6 +564,7 @@ function updateInternals<NodeType extends NodeBase>(
     context.nodeLookup.set(node.id, newNode);
 
     context.updatedInternals = true;
+    // by deleting the update we prevent the node from being updated again
     updates.delete(node.id);
 
     if (dimensionChanged) {
@@ -583,7 +587,7 @@ function walkChildren<NodeType extends NodeBase>(
   node: InternalNodeBase<NodeType>,
   context: UpdateInternalsContext<NodeType>
 ) {
-  const { parentLookup, nodeLookup, updates } = context;
+  const { parentLookup, updates } = context;
   const children = parentLookup.get(node.id);
   if (children) {
     for (const child of children.values()) {
@@ -591,12 +595,8 @@ function walkChildren<NodeType extends NodeBase>(
       if (!childUpdate) {
         return;
       }
-      const childNode = nodeLookup.get(child.id);
-      if (!childNode) {
-        return;
-      }
-      updateInternals(childNode, childUpdate, context);
-      updateChildXYZ(childNode, node, context);
+      updateInternals(child, childUpdate, context);
+      updateChildXYZ(child, node, context);
     }
   }
 }

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -499,9 +499,9 @@ export function updateNodeInternals<NodeType extends NodeBase>(
       continue;
     }
 
-    updateInternals(node, update, context);
+    const updatedNode = updateInternals(node, update, context);
 
-    walkChildren(node, context);
+    walkChildren(updatedNode, context);
   }
 
   if (parentExpandChildren.length > 0) {
@@ -516,14 +516,14 @@ function updateInternals<NodeType extends NodeBase>(
   node: InternalNodeBase<NodeType>,
   update: InternalNodeUpdate,
   context: UpdateInternalsContext<NodeType>
-) {
+): InternalNodeBase<NodeType> {
   const { nodeLookup, updates, changes, parentExpandChildren, zoom } = context;
   const { nodeOrigin, nodeExtent } = context.options;
 
   if (node.hidden) {
     updates.delete(node.id);
     context.updatedInternals = true;
-    return;
+    return node;
   }
 
   const dimensions = getDimensions(update.nodeElement);
@@ -533,6 +533,8 @@ function updateInternals<NodeType extends NodeBase>(
     dimensions.height &&
     (dimensionChanged || !node.internals.handleBounds || update.force)
   );
+
+  let updatedNode: InternalNodeBase<NodeType> = node;
 
   if (doUpdate) {
     const nodeBounds = update.nodeElement.getBoundingClientRect();
@@ -548,7 +550,7 @@ function updateInternals<NodeType extends NodeBase>(
       positionAbsolute = clampPosition(positionAbsolute, extent, dimensions);
     }
 
-    const newNode = {
+    updatedNode = {
       ...node,
       measured: dimensions,
       internals: {
@@ -561,7 +563,7 @@ function updateInternals<NodeType extends NodeBase>(
       },
     };
 
-    context.nodeLookup.set(node.id, newNode);
+    context.nodeLookup.set(node.id, updatedNode);
 
     context.updatedInternals = true;
     // by deleting the update we prevent the node from being updated again
@@ -574,13 +576,15 @@ function updateInternals<NodeType extends NodeBase>(
         parentExpandChildren.push({
           id: node.id,
           parentId: node.parentId,
-          rect: nodeToRect(newNode, nodeOrigin),
+          rect: nodeToRect(updatedNode, nodeOrigin),
         });
       }
     }
 
-    walkChildren(node, context);
+    walkChildren(updatedNode, context);
   }
+
+  return updatedNode;
 }
 
 function walkChildren<NodeType extends NodeBase>(
@@ -593,10 +597,10 @@ function walkChildren<NodeType extends NodeBase>(
     for (const child of children.values()) {
       const childUpdate = updates.get(child.id);
       if (!childUpdate) {
-        return;
+        continue;
       }
-      updateInternals(child, childUpdate, context);
-      updateChildXYZ(child, node, context);
+      const updatedChild = updateInternals(child, childUpdate, context);
+      updateChildXYZ(updatedChild, node, context);
     }
   }
 }

--- a/packages/vue/src/components/Nodes/NodeWrapper.ts
+++ b/packages/vue/src/components/Nodes/NodeWrapper.ts
@@ -94,7 +94,10 @@ const NodeWrapper = defineComponent({
 
     // a node "has dimensions" once measured OR given explicit width/height OR initialWidth/initialHeight (the
     // SSR fallback, no ResizeObserver) — the visibility gate so sized/SSR nodes render immediately
-    const isInit = computed(() => (internalNode.value ? nodeHasDimensions(internalNode.value) : false));
+    const hasDimensions = computed(() => (internalNode.value ? nodeHasDimensions(internalNode.value) : false));
+
+    // a node counts as initialized only once it ALSO has handle bounds.
+    const isInitialized = computed(() => hasDimensions.value && !!internalNode.value?.internals.handleBounds);
 
     const isParent = computed(() => (parentLookup.get(props.id)?.size ?? 0) > 0);
 
@@ -171,8 +174,8 @@ const NodeWrapper = defineComponent({
 
     onMounted(() => {
       watch(
-        () => internalNode.value?.hidden,
-        (isHidden = false, _, onCleanup) => {
+        [() => internalNode.value?.hidden, isInitialized],
+        ([isHidden = false], _, onCleanup) => {
           if (!isHidden && nodeElement.value) {
             props.resizeObserver.observe(nodeElement.value);
 
@@ -241,7 +244,7 @@ const NodeWrapper = defineComponent({
             node.class,
           ],
           'style': {
-            visibility: isInit.value ? 'visible' : 'hidden',
+            visibility: hasDimensions.value ? 'visible' : 'hidden',
             zIndex: node.internals.z ?? zIndex.value,
             transform: `translate(${node.internals.positionAbsolute.x}px,${node.internals.positionAbsolute.y}px)`,
             pointerEvents: hasPointerEvents.value ? 'all' : 'none',

--- a/packages/vue/src/store/commit.ts
+++ b/packages/vue/src/store/commit.ts
@@ -95,9 +95,9 @@ export function createCommit<NodeType extends Node = Node, EdgeType extends Edge
 
     state.nodesSelectionActive = state.nodesSelectionActive && hasSelectedNodes;
 
-    if (systemParentLookup.size > 0) {
-      syncLookups();
-    }
+    // always mirror: `syncLookups` is the only writer that adds/prunes entries in the reactive
+    // `nodeLookup`, so skipping it on parentless graphs leaves added nodes unrendered
+    syncLookups();
 
     if (state.fitViewQueued && areNodesInitialized(nodeLookup)) {
       resolveFitView(state, nodeLookup);

--- a/packages/vue/src/store/commit.ts
+++ b/packages/vue/src/store/commit.ts
@@ -1,6 +1,5 @@
 import type { EdgeLookup, NodeLookup } from '@xyflow/system';
 import type { Edge, InternalNode, Node, State } from '../types';
-import { updateAbsolutePositions } from '@xyflow/system';
 import { markRaw, toRaw } from 'vue';
 import { adoptNodes, areNodesInitialized, ErrorCode, updateConnectionLookup, VueFlowError } from '../utils';
 import { resolveFitView } from './fitView';
@@ -80,24 +79,6 @@ export function createCommit<NodeType extends Node = Node, EdgeType extends Edge
     }
   }
 
-  /**
-   * Recompute parent-aware absolute positions/z on the system lookup, then mirror into the reactive lookups.
-   * Lookup-only, no write-back to `state.nodes`. The full `updateAbsolutePositions` pass only runs when there
-   * are child nodes (adoption already clamps position/z for changed nodes) or `forceFullPass`.
-   */
-  function recomputeAbsolutePositions(forceFullPass = false) {
-    if (forceFullPass || systemParentLookup.size > 0) {
-      updateAbsolutePositions(systemNodeLookup, systemParentLookup, {
-        nodeOrigin: state.nodeOrigin,
-        nodeExtent: state.nodeExtent,
-        elevateNodesOnSelect: state.elevateNodesOnSelect,
-        zIndexMode: state.zIndexMode,
-      });
-    }
-
-    syncLookups();
-  }
-
   function commitNodes(nodes: NodeType[], checkEquality = true) {
     const {
       nodes: adopted,
@@ -114,7 +95,9 @@ export function createCommit<NodeType extends Node = Node, EdgeType extends Edge
 
     state.nodesSelectionActive = state.nodesSelectionActive && hasSelectedNodes;
 
-    recomputeAbsolutePositions();
+    if (systemParentLookup.size > 0) {
+      syncLookups();
+    }
 
     if (state.fitViewQueued && areNodesInitialized(nodeLookup)) {
       resolveFitView(state, nodeLookup);

--- a/packages/vue/src/utils/store.ts
+++ b/packages/vue/src/utils/store.ts
@@ -5,7 +5,6 @@ import type {
   HandleType,
   IsValidConnection,
   NodeConnection,
-  NodeHandleBounds,
   NodeLookup as SystemNodeLookup,
   ParentLookup as SystemParentLookup,
   ZIndexMode,
@@ -182,16 +181,10 @@ export function adoptNodes<NodeType extends Node = Node>(
     validNodes.push(markRaw(toRaw(node)));
   }
 
-  const priorInternals = new Map<
-    string,
-    { measured?: { width?: number; height?: number }; handleBounds: NodeHandleBounds | undefined }
-  >();
+  const priorMeasured = new Map<string, { width: number; height: number } | undefined>();
   for (const [id, internal] of nodeLookup) {
     const { width, height } = internal.measured ?? {};
-    priorInternals.set(id, {
-      measured: width !== undefined && height !== undefined ? { width, height } : undefined,
-      handleBounds: internal.internals.handleBounds,
-    });
+    priorMeasured.set(id, width !== undefined && height !== undefined ? { width, height } : undefined);
   }
 
   const { hasSelectedNodes } = adoptUserNodes(validNodes, nodeLookup, parentLookup, { ...options, checkEquality: options?.checkEquality ?? true });
@@ -201,16 +194,11 @@ export function adoptNodes<NodeType extends Node = Node>(
       triggerError(new VueFlowError(ErrorCode.NODE_MISSING_PARENT, node.id, node.parentId));
     }
 
-    const prior = priorInternals.get(node.id);
+    const prior = priorMeasured.get(node.id);
     if (prior) {
       const internal = nodeLookup.get(node.id);
-      if (internal) {
-        if (prior.measured && (internal.measured?.width === undefined || internal.measured?.height === undefined)) {
-          internal.measured = prior.measured;
-        }
-        if (prior.handleBounds && !internal.internals.handleBounds) {
-          internal.internals.handleBounds = prior.handleBounds;
-        }
+      if (internal && (internal.measured?.width === undefined || internal.measured?.height === undefined)) {
+        internal.measured = prior;
       }
     }
   }


### PR DESCRIPTION
Instead of calling `updateAbsolutePositions` after updateNodeInternal do the work directly inside `updateNodeInternals`.

This lets us get rid of updateAbsolutePosition and we don't need to iterate on the nodeLookup afterwards. Even for singular updates we iterated over the nodeLookup once the internals have been updated. 

Now, if you call `updateNodeInternals` on a single node we just update that node and maybe walk its children.
The only reason we called `updateAbsolutePositions` anyway, was to have an updated `nodeLookup` so that `fitView` can take the correct child positions into account immediately.
 
I also extracted `updateChildXYZ` from `updateChildNode`, since we can skip updating the z-indexes and the `parentLookup` at this stage.

Also this uncovered a potential bug: We update the `parentLookup` before we have calculated the actual child positions. This way the node inside the parentLookup is not the same node as in the nodeLookup.

### Before
<img width="562" height="96" alt="image" src="https://github.com/user-attachments/assets/22c6bf26-164b-4f82-aa8f-7e37e1144d12" />

### After
<img width="541" height="89" alt="image" src="https://github.com/user-attachments/assets/ade50070-427d-42a6-bb7e-eee2046fa318" />


Caveat: It was pretty fast before already, and in reality this functions takes way longer because of `getBoundingClientRect()` which is just mocked in this benchmark 
