### PR TITLE
fix(react): change default for `elevateEdgesOnSelect`

### DIFF
--- a/.changeset/cozy-wings-slide.md
+++ b/.changeset/cozy-wings-slide.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/react": patch
+---
+
+Minimap still works after ReactFlow remounts
+  

--- a/.changeset/elevate-edges-on-select-default.md
+++ b/.changeset/elevate-edges-on-select-default.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': minor
+---
+
+Elevate selected edges by default (`elevateEdgesOnSelect` now defaults to `true`), enabling reconnection of overlapping edges by selecting them first

--- a/.changeset/eleven-news-battle.md
+++ b/.changeset/eleven-news-battle.md
@@ -3,5 +3,5 @@
 "@xyflow/react": patch
 ---
 
-Show log if user hides attribution
+Show log if user hides attribution in development
   

--- a/.changeset/eleven-news-battle.md
+++ b/.changeset/eleven-news-battle.md
@@ -1,0 +1,7 @@
+---
+"@xyflow/svelte": patch
+"@xyflow/react": patch
+---
+
+Show log if user hides attribution in development
+  

--- a/.changeset/eleven-news-battle.md
+++ b/.changeset/eleven-news-battle.md
@@ -1,0 +1,7 @@
+---
+"@xyflow/svelte": patch
+"@xyflow/react": patch
+---
+
+Show log if user hides attribution
+  

--- a/.changeset/minimap-onnodeclick-conditional-hook.md
+++ b/.changeset/minimap-onnodeclick-conditional-hook.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix `MiniMap` calling `useCallback` conditionally for `onNodeClick`.

--- a/.changeset/minimap-onnodeclick-conditional-hook.md
+++ b/.changeset/minimap-onnodeclick-conditional-hook.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix `MiniMap` calling `useCallback` conditionally for `onNodeClick`, which crashed with "Rendered more hooks than during the previous render" when the prop was toggled on or off, and pinned the handler to its first-render value.

--- a/.changeset/minimap-onnodeclick-conditional-hook.md
+++ b/.changeset/minimap-onnodeclick-conditional-hook.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Fix `MiniMap` calling `useCallback` conditionally for `onNodeClick`, which crashed with "Rendered more hooks than during the previous render" when the prop was toggled on or off, and pinned the handler to its first-render value.
+Fix `MiniMap` calling `useCallback` conditionally for `onNodeClick`.

--- a/.changeset/slick-kings-yell.md
+++ b/.changeset/slick-kings-yell.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/svelte": patch
+---
+
+Fix unnecessary edge rerenders
+  

--- a/examples/react/src/App/routes.ts
+++ b/examples/react/src/App/routes.ts
@@ -63,6 +63,7 @@ import DetachedHandle from '../examples/DetachedHandle';
 import ZIndexMode from '../examples/ZIndexMode';
 import Middlewares from '../examples/Middlewares';
 import NodeSelectionBug from '../examples/NodeSelectionBug';
+import Remount from '../examples/Remount';
 
 export interface IRoute {
   name: string;
@@ -290,6 +291,11 @@ const routes: IRoute[] = [
     name: 'Provider',
     path: 'provider',
     component: Provider,
+  },
+  {
+    name: 'Remount',
+    path: 'remount',
+    component: Remount,
   },
   {
     name: 'Save/Restore',

--- a/examples/react/src/examples/Remount/index.tsx
+++ b/examples/react/src/examples/Remount/index.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { ReactFlow, ReactFlowProvider, MiniMap, Background, Controls } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+const defaultNodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: 'Root' } },
+  { id: '2', position: { x: 0, y: 120 }, data: { label: 'Child A' } },
+  { id: '3', position: { x: 180, y: 120 }, data: { label: 'Child B' } },
+  { id: '4', position: { x: 360, y: 120 }, data: { label: 'Child C' } },
+];
+
+const defaultEdges = [
+  { id: 'e1-2', source: '1', target: '2' },
+  { id: 'e1-3', source: '1', target: '3' },
+  { id: 'e1-4', source: '1', target: '4' },
+];
+
+function Flow({ remountKey }: { remountKey: number }) {
+  return (
+    <ReactFlow key={remountKey} defaultNodes={defaultNodes} defaultEdges={defaultEdges} fitView>
+      <Background />
+      <Controls />
+      <MiniMap pannable zoomable />
+    </ReactFlow>
+  );
+}
+
+export default function App() {
+  const [remountKey, setRemountKey] = useState(0);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <button onClick={() => setRemountKey((k) => k + 1)} style={{ padding: 8 }}>
+        Remount ReactFlow
+      </button>
+      <div style={{ flex: 1 }}>
+        <ReactFlowProvider>
+          <Flow remountKey={remountKey} />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}

--- a/examples/react/src/examples/Validation/validation.module.css
+++ b/examples/react/src/examples/Validation/validation.module.css
@@ -50,3 +50,7 @@
   left: 50%;
   transform: translateX(-50%);
 }
+
+.validationflow :global .react-flow__attribution {
+  opacity: 0;
+}

--- a/examples/react/src/generic-tests/Flow.tsx
+++ b/examples/react/src/generic-tests/Flow.tsx
@@ -4,6 +4,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
   addEdge,
+  reconnectEdge,
   OnNodesChange,
   OnEdgesChange,
   OnConnect,
@@ -11,6 +12,7 @@ import {
   Panel,
   MiniMap,
   Background,
+  OnReconnect,
 } from '@xyflow/react';
 
 type FlowProps = {
@@ -25,10 +27,14 @@ export default ({ flowConfig }: FlowProps) => {
   const onNodesChange: OnNodesChange = useCallback((changes) => setNodes((nds) => applyNodeChanges(changes, nds)), []);
   const onEdgesChange: OnEdgesChange = useCallback((changes) => setEdges((eds) => applyEdgeChanges(changes, eds)), []);
   const onConnect: OnConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), []);
+  const onReconnect: OnReconnect = useCallback(
+    (oldEdge, connection) => setEdges((eds) => reconnectEdge(oldEdge, connection, eds)),
+    []
+  );
 
   return (
     <div style={{ height: '100%' }}>
-      <ReactFlow {...props} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect}>
+      <ReactFlow {...props} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onReconnect={onReconnect}>
         {flowConfig.controlsProps && <Controls {...flowConfig.controlsProps} />}
         {flowConfig.panelProps && <Panel {...flowConfig.panelProps} />}
         {flowConfig.minimapProps && <MiniMap {...flowConfig.minimapProps} />}

--- a/examples/react/src/generic-tests/edges/reconnect.ts
+++ b/examples/react/src/generic-tests/edges/reconnect.ts
@@ -1,0 +1,52 @@
+export default {
+  flowProps: {
+    fitView: true,
+    multiSelectionKeyCode: 's',
+    deleteKeyCode: 'd',
+    nodes: [
+      {
+        id: 'rc-1',
+        data: { label: '1' },
+        position: { x: 0, y: 0 },
+        type: 'input',
+      },
+      {
+        id: 'rc-2',
+        data: { label: '2' },
+        position: { x: 0, y: 200 },
+        type: 'input',
+      },
+      {
+        id: 'rc-3',
+        data: { label: '3' },
+        position: { x: 250, y: 100 },
+      },
+      {
+        id: 'rc-4',
+        data: { label: '4' },
+        position: { x: 250, y: 400 },
+      },
+    ],
+    edges: [
+      {
+        id: 'reconnect-1',
+        source: 'rc-1',
+        target: 'rc-3',
+        reconnectable: true,
+      },
+      {
+        id: 'reconnect-2',
+        source: 'rc-2',
+        target: 'rc-3',
+        reconnectable: true,
+      },
+      {
+        id: 'reconnect-3',
+        source: 'rc-1',
+        target: 'rc-4',
+        reconnectable: true,
+        zIndex: 5,
+      },
+    ],
+  },
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/edges/reconnect.ts
+++ b/examples/svelte/src/generic-tests/edges/reconnect.ts
@@ -1,0 +1,49 @@
+export default {
+	flowProps: {
+		fitView: true,
+		multiSelectionKey: ['Meta', 's'],
+		deleteKey: 'd',
+		nodes: [
+			{
+				id: 'rc-1',
+				data: { label: '1' },
+				position: { x: 0, y: 0 },
+				type: 'input'
+			},
+			{
+				id: 'rc-2',
+				data: { label: '2' },
+				position: { x: 0, y: 200 },
+				type: 'input'
+			},
+			{
+				id: 'rc-3',
+				data: { label: '3' },
+				position: { x: 250, y: 100 }
+			},
+			{
+				id: 'rc-4',
+				data: { label: '4' },
+				position: { x: 250, y: 400 }
+			}
+		],
+		edges: [
+			{
+				id: 'reconnect-1',
+				source: 'rc-1',
+				target: 'rc-3'
+			},
+			{
+				id: 'reconnect-2',
+				source: 'rc-2',
+				target: 'rc-3'
+			},
+			{
+				id: 'reconnect-3',
+				source: 'rc-1',
+				target: 'rc-4',
+				zIndex: 5
+			}
+		]
+	}
+} satisfies FlowConfig;

--- a/examples/svelte/src/routes/examples/validation/style.css
+++ b/examples/svelte/src/routes/examples/validation/style.css
@@ -9,3 +9,7 @@
 .svelte-flow__handle.valid {
 	background: #55dd99;
 }
+
+.svelte-flow__attribution {
+	display: none;
+}

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -85,7 +85,7 @@ function MiniMapComponent<NodeType extends Node = Node>({
 }: MiniMapProps<NodeType>) {
   const store = useStoreApi<NodeType>();
   const svg = useRef<SVGSVGElement>(null);
-  const { boundingRect, viewBB, rfId, panZoom, translateExtent, flowWidth, flowHeight, ariaLabelConfig } = useStore(
+  const { boundingRect, panZoom, viewBB, rfId, translateExtent, flowWidth, flowHeight, ariaLabelConfig } = useStore(
     selector,
     areEqual
   );
@@ -108,10 +108,11 @@ function MiniMapComponent<NodeType extends Node = Node>({
   viewScaleRef.current = viewScale;
 
   useEffect(() => {
-    if (svg.current && panZoom) {
+    const currentPanZoom = store.getState().panZoom;
+    if (svg.current && currentPanZoom) {
       minimapInstance.current = XYMinimap({
         domNode: svg.current,
-        panZoom,
+        panZoom: currentPanZoom,
         getTransform: () => store.getState().transform,
         getViewScale: () => viewScaleRef.current,
       });
@@ -141,10 +142,13 @@ function MiniMapComponent<NodeType extends Node = Node>({
       }
     : undefined;
 
-  const nodeClickHandler = useCallback((event: MouseEvent, nodeId: string) => {
-    const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
-    onNodeClick?.(event, node);
-  }, [onNodeClick]);
+  const nodeClickHandler = useCallback(
+    (event: MouseEvent, nodeId: string) => {
+      const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
+      onNodeClick?.(event, node);
+    },
+    [onNodeClick]
+  );
 
   const onSvgNodeClick = onNodeClick ? nodeClickHandler : undefined;
 

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -141,12 +141,12 @@ function MiniMapComponent<NodeType extends Node = Node>({
       }
     : undefined;
 
-  const onSvgNodeClick = onNodeClick
-    ? useCallback((event: MouseEvent, nodeId: string) => {
-        const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
-        onNodeClick(event, node);
-      }, [])
-    : undefined;
+  const nodeClickHandler = useCallback((event: MouseEvent, nodeId: string) => {
+    const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
+    onNodeClick?.(event, node);
+  }, [onNodeClick]);
+
+  const onSvgNodeClick = onNodeClick ? nodeClickHandler : undefined;
 
   const _ariaLabel = ariaLabel ?? ariaLabelConfig['minimap.ariaLabel'];
 

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -141,12 +141,19 @@ function MiniMapComponent<NodeType extends Node = Node>({
       }
     : undefined;
 
-  const onSvgNodeClick = onNodeClick
-    ? useCallback((event: MouseEvent, nodeId: string) => {
-        const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
-        onNodeClick(event, node);
-      }, [])
-    : undefined;
+  /*
+   * the handler is kept in a ref so that the callback identity stays stable for
+   * the memoized minimap nodes while still calling the current onNodeClick
+   */
+  const onNodeClickRef = useRef(onNodeClick);
+  onNodeClickRef.current = onNodeClick;
+
+  const nodeClickHandler = useCallback((event: MouseEvent, nodeId: string) => {
+    const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
+    onNodeClickRef.current?.(event, node);
+  }, []);
+
+  const onSvgNodeClick = onNodeClick ? nodeClickHandler : undefined;
 
   const _ariaLabel = ariaLabel ?? ariaLabelConfig['minimap.ariaLabel'];
 

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -141,17 +141,10 @@ function MiniMapComponent<NodeType extends Node = Node>({
       }
     : undefined;
 
-  /*
-   * the handler is kept in a ref so that the callback identity stays stable for
-   * the memoized minimap nodes while still calling the current onNodeClick
-   */
-  const onNodeClickRef = useRef(onNodeClick);
-  onNodeClickRef.current = onNodeClick;
-
   const nodeClickHandler = useCallback((event: MouseEvent, nodeId: string) => {
     const node: NodeType = store.getState().nodeLookup.get(nodeId)!.internals.userNode;
-    onNodeClickRef.current?.(event, node);
-  }, []);
+    onNodeClick?.(event, node);
+  }, [onNodeClick]);
 
   const onSvgNodeClick = onNodeClick ? nodeClickHandler : undefined;
 

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { type PanelPosition, domNodeIsVisible } from '@xyflow/system';
+import { type PanelPosition, isDomNodeVisible } from '@xyflow/system';
 
 import { Panel } from '../Panel';
 import { type ProOptions } from '../../types/general';
@@ -25,7 +25,7 @@ export function Attribution({ proOptions, position = 'bottom-right' }: Attributi
   useEffect(() => {
     if (process.env.NODE_ENV === 'development' && !warned.current) {
       setTimeout(() => {
-        if (!domNodeIsVisible('.react-flow__attribution')) {
+        if (!isDomNodeVisible('.react-flow__attribution')) {
           console.warn(
             `React Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to React Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
             'font-style: italic;'

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,6 +1,7 @@
-import type { PanelPosition, ProOptions } from '@xyflow/system';
+import type { PanelPosition } from '@xyflow/system';
 
 import { Panel } from '../Panel';
+import { type ProOptions } from '../../types/general';
 
 type AttributionProps = {
   proOptions?: ProOptions;

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,6 +1,7 @@
 import type { PanelPosition, ProOptions } from '@xyflow/system';
 
 import { Panel } from '../Panel';
+import { useEffect, useRef } from 'react';
 
 type AttributionProps = {
   proOptions?: ProOptions;
@@ -11,7 +12,41 @@ const link = `https://reactflow.dev${
   process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
 }`;
 
+const consoleLink = 'https://reactflow.dev/attribution';
+
+function isVisible(el: Element | null) {
+  if (!el || !el.isConnected) return false;
+
+  const style = getComputedStyle(el);
+
+  if (style.display === 'none') return false;
+  if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+  if (style.opacity === '0') return false;
+
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return false;
+
+  return true;
+}
+
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
+  const warned = useRef(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development' && !warned.current) {
+      setTimeout(() => {
+        if (!isVisible(document.querySelector('.react-flow__attribution'))) {
+          console.warn(
+            `React Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to React Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
+            'font-style: italic;'
+          );
+        }
+      }, 1000);
+
+      warned.current = true;
+    }
+  }, []);
+
   if (proOptions?.hideAttribution) {
     return null;
   }

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { type PanelPosition, isDomNodeVisible } from '@xyflow/system';
+import { useEffect } from 'react';
+import { type PanelPosition, handleAttributionWarning } from '@xyflow/system';
 
 import { Panel } from '../Panel';
 import { type ProOptions } from '../../types/general';
@@ -13,28 +13,17 @@ const link = `https://reactflow.dev${
   process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
 }`;
 
-const consoleLink = 'https://reactflow.dev/remove-attribution?utm_source=console';
-
 /**
  * React Flow is independent and entirely funded by its users.
  * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
  */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
-  const warned = useRef(false);
-
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development' && !warned.current) {
-      setTimeout(() => {
-        if (!isDomNodeVisible('.react-flow__attribution')) {
-          console.warn(
-            `React Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to React Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
-            'font-style: italic;'
-          );
-        }
-      }, 1000);
-
-      warned.current = true;
+    if (process.env.NODE_ENV !== 'development') {
+      return;
     }
+
+    handleAttributionWarning('react');
   }, []);
 
   if (proOptions?.hideAttribution) {

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,6 +1,7 @@
-import type { PanelPosition, ProOptions } from '@xyflow/system';
+import type { PanelPosition } from '@xyflow/system';
 
 import { Panel } from '../Panel';
+import { type ProOptions } from '../../types/general';
 
 type AttributionProps = {
   proOptions?: ProOptions;
@@ -11,6 +12,10 @@ const link = `https://reactflow.dev${
   process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
 }`;
 
+/**
+ * React Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
+ */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
   if (proOptions?.hideAttribution) {
     return null;

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -13,7 +13,7 @@ const link = `https://reactflow.dev${
 
 /**
  * React Flow is independent and entirely funded by its users.
- * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/attribution
+ * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
  */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
   if (proOptions?.hideAttribution) {

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -11,6 +11,9 @@ const link = `https://reactflow.dev${
   process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
 }`;
 
+/**
+ * Please only hide the React Flow attribution when you are subscribed to React Flow Pro
+ */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
   if (proOptions?.hideAttribution) {
     return null;

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,7 +1,8 @@
-import type { PanelPosition, ProOptions } from '@xyflow/system';
+import { useEffect, useRef } from 'react';
+import { type PanelPosition, domNodeIsVisible } from '@xyflow/system';
 
 import { Panel } from '../Panel';
-import { useEffect, useRef } from 'react';
+import { type ProOptions } from '../../types/general';
 
 type AttributionProps = {
   proOptions?: ProOptions;
@@ -12,30 +13,19 @@ const link = `https://reactflow.dev${
   process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
 }`;
 
-const consoleLink = 'https://reactflow.dev/attribution';
+const consoleLink = 'https://reactflow.dev/remove-attribution?utm_source=console';
 
-function isVisible(el: Element | null) {
-  if (!el || !el.isConnected) return false;
-
-  const style = getComputedStyle(el);
-
-  if (style.display === 'none') return false;
-  if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
-  if (style.opacity === '0') return false;
-
-  const rect = el.getBoundingClientRect();
-  if (rect.width === 0 && rect.height === 0) return false;
-
-  return true;
-}
-
+/**
+ * React Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
+ */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
   const warned = useRef(false);
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'development' && !warned.current) {
       setTimeout(() => {
-        if (!isVisible(document.querySelector('.react-flow__attribution'))) {
+        if (!domNodeIsVisible('.react-flow__attribution')) {
           console.warn(
             `React Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to React Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
             'font-style: italic;'

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -1,4 +1,5 @@
-import type { PanelPosition } from '@xyflow/system';
+import { useEffect } from 'react';
+import { type PanelPosition, handleAttributionWarning } from '@xyflow/system';
 
 import { Panel } from '../Panel';
 import { type ProOptions } from '../../types/general';
@@ -17,6 +18,14 @@ const link = `https://reactflow.dev${
  * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
  */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      return;
+    }
+
+    handleAttributionWarning('react');
+  }, []);
+
   if (proOptions?.hideAttribution) {
     return null;
   }

--- a/packages/react/src/components/Attribution/index.tsx
+++ b/packages/react/src/components/Attribution/index.tsx
@@ -12,7 +12,8 @@ const link = `https://reactflow.dev${
 }`;
 
 /**
- * Please only hide the React Flow attribution when you are subscribed to React Flow Pro
+ * React Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/attribution
  */
 export function Attribution({ proOptions, position = 'bottom-right' }: AttributionProps) {
   if (proOptions?.hideAttribution) {

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -128,7 +128,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     proOptions,
     defaultEdgeOptions,
     elevateNodesOnSelect = true,
-    elevateEdgesOnSelect = false,
+    elevateEdgesOnSelect = true,
     disableKeyboardA11y = false,
     autoPanOnConnect,
     autoPanOnNodeDrag,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -65,7 +65,6 @@ export {
   type SetCenterOptions,
   type FitBoundsOptions,
   type PanelPosition,
-  type ProOptions,
   SelectionMode,
   type SelectionRect,
   type OnError,

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -615,7 +615,9 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   elevateNodesOnSelect?: boolean;
   /**
    * Enabling this option will raise the z-index of edges when they are selected.
-   * @default false
+   * This also ensures that, when multiple reconnectable edges share a handle,
+   * the selected edge's repoint anchor is the one that receives the drag.
+   * @default true
    */
   elevateEdgesOnSelect?: boolean;
   /**

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -8,7 +8,6 @@ import type {
   CoordinateExtent,
   KeyCode,
   PanOnScrollMode,
-  ProOptions,
   PanelPosition,
   OnMove,
   OnMoveStart,
@@ -47,14 +46,17 @@ import type {
   OnNodeDrag,
   OnBeforeDelete,
   IsValidConnection,
+  ProOptions,
 } from '.';
 
 /**
  * ReactFlow component props.
  * @public
  */
-export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends Edge = Edge>
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onError'> {
+export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends Edge = Edge> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onError'
+> {
   /**
    * An array of nodes to render in a controlled flow.
    * @default []
@@ -602,9 +604,8 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   /**
    * By default, we render a small attribution in the corner of your flows that links back to the project.
    *
-   * Anyone is free to remove this attribution whether they're a Pro subscriber or not
-   * but we ask that you take a quick look at our {@link https://reactflow.dev/learn/troubleshooting/remove-attribution | removing attribution guide}
-   * before doing so.
+   * Please only remove the attribution if you have a React Flow subscription.
+   * More information in the {@link https://reactflow.dev/remove-attribution | removing attribution guide}.
    */
   proOptions?: ProOptions;
   /**

--- a/packages/react/src/types/general.ts
+++ b/packages/react/src/types/general.ts
@@ -230,3 +230,13 @@ export type OnBeforeDelete<NodeType extends Node = Node, EdgeType extends Edge =
  *  If the function returns `true`, the connection is valid and can be created.
  */
 export type IsValidConnection<EdgeType extends Edge = Edge> = (edge: EdgeType | Connection) => boolean;
+
+/**
+ * React Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
+ * */
+export type ProOptions = {
+  account?: string;
+  /** If you hide the attribution, please support our work with a subscription. */
+  hideAttribution: boolean;
+};

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -13,7 +13,7 @@
   <!--
 @component
 Svelte Flow is independent and entirely funded by its users.
- * If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
+If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
 -->
   <Panel
     {position}

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { isDomNodeVisible } from '@xyflow/system';
+  import { handleAttributionWarning } from '@xyflow/system';
 
   import { Panel } from '$lib/container/Panel/index.js';
   import type { AttributionProps } from './types.js';
@@ -10,21 +10,8 @@
     process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
   }`;
 
-  const consoleLink = 'https://svelteflow.dev/remove-attribution?utm_source=console';
-
-  let warned = false;
-
-  if (process.env.NODE_ENV === 'development' && !warned) {
-    setTimeout(() => {
-      if (!isDomNodeVisible('.svelte-flow__attribution')) {
-        console.warn(
-          `Svelte Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to Svelte Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
-          'font-style: italic;'
-        );
-      }
-    }, 1000);
-
-    warned = true;
+  if (process.env.NODE_ENV === 'development') {
+    handleAttributionWarning('svelte');
   }
 </script>
 

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -12,7 +12,8 @@
 {#if !proOptions?.hideAttribution}
   <!--
 @component
-Please only hide the Svelte Flow attribution when you are subscribed to Svelte Flow Pro
+Svelte Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/attribution
 -->
   <Panel
     {position}

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -10,6 +10,10 @@
 </script>
 
 {#if !proOptions?.hideAttribution}
+  <!--
+@component
+Please only hide the Svelte Flow attribution when you are subscribed to Svelte Flow Pro
+-->
   <Panel
     {position}
     class="svelte-flow__attribution"

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { domNodeIsVisible } from '@xyflow/system';
+  import { isDomNodeVisible } from '@xyflow/system';
 
   import { Panel } from '$lib/container/Panel/index.js';
   import type { AttributionProps } from './types.js';
@@ -16,7 +16,7 @@
 
   if (process.env.NODE_ENV === 'development' && !warned) {
     setTimeout(() => {
-      if (!domNodeIsVisible('.svelte-flow__attribution')) {
+      if (!isDomNodeVisible('.svelte-flow__attribution')) {
         console.warn(
           `Svelte Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to Svelte Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
           'font-style: italic;'

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -13,7 +13,7 @@
   <!--
 @component
 Svelte Flow is independent and entirely funded by its users.
- * If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/attribution
+ * If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
 -->
   <Panel
     {position}

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { domNodeIsVisible } from '@xyflow/system';
+
   import { Panel } from '$lib/container/Panel/index.js';
   import type { AttributionProps } from './types.js';
 
@@ -7,9 +9,31 @@
   const link = `https://svelteflow.dev${
     process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
   }`;
+
+  const consoleLink = 'https://svelteflow.dev/remove-attribution?utm_source=console';
+
+  let warned = false;
+
+  if (process.env.NODE_ENV === 'development' && !warned) {
+    setTimeout(() => {
+      if (!domNodeIsVisible('.svelte-flow__attribution')) {
+        console.warn(
+          `Svelte Flow: It seems like you are hiding the attribution. Please only do this when you are subscribed to Svelte Flow Pro: ${consoleLink}\n%cYou can ignore this warning if you are subscribed.`,
+          'font-style: italic;'
+        );
+      }
+    }, 1000);
+
+    warned = true;
+  }
 </script>
 
 {#if !proOptions?.hideAttribution}
+  <!--
+@component
+Svelte Flow is independent and entirely funded by its users.
+If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
+-->
   <Panel
     {position}
     class="svelte-flow__attribution"

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { handleAttributionWarning } from '@xyflow/system';
+
   import { Panel } from '$lib/container/Panel/index.js';
   import type { AttributionProps } from './types.js';
 
@@ -7,6 +9,14 @@
   const link = `https://svelteflow.dev${
     process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
   }`;
+
+  $effect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      return;
+    }
+
+    handleAttributionWarning('svelte');
+  });
 </script>
 
 {#if !proOptions?.hideAttribution}

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -10,9 +10,13 @@
     process.env.NODE_ENV === 'production' ? '?utm_source=attribution' : '/attribution'
   }`;
 
-  if (process.env.NODE_ENV === 'development') {
+  $effect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      return;
+    }
+
     handleAttributionWarning('svelte');
-  }
+  });
 </script>
 
 {#if !proOptions?.hideAttribution}

--- a/packages/svelte/src/lib/components/Attribution/Attribution.svelte
+++ b/packages/svelte/src/lib/components/Attribution/Attribution.svelte
@@ -10,6 +10,11 @@
 </script>
 
 {#if !proOptions?.hideAttribution}
+  <!--
+@component
+Svelte Flow is independent and entirely funded by its users.
+If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
+-->
   <Panel
     {position}
     class="svelte-flow__attribution"

--- a/packages/svelte/src/lib/components/Attribution/types.ts
+++ b/packages/svelte/src/lib/components/Attribution/types.ts
@@ -1,4 +1,6 @@
-import type { PanelPosition, ProOptions } from '@xyflow/system';
+import type { PanelPosition } from '@xyflow/system';
+
+import type { ProOptions } from '$lib/types/general.js';
 
 export type AttributionProps = {
   proOptions?: ProOptions;

--- a/packages/svelte/src/lib/container/SvelteFlow/types.ts
+++ b/packages/svelte/src/lib/container/SvelteFlow/types.ts
@@ -13,7 +13,6 @@ import type {
   OnError,
   ConnectionMode,
   PanelPosition,
-  ProOptions,
   ColorMode,
   OnConnect,
   OnConnectStart,
@@ -38,7 +37,8 @@ import type {
   OnBeforeDelete,
   IsValidConnection,
   OnBeforeReconnect,
-  OnSelectionChange
+  OnSelectionChange,
+  ProOptions
 } from '$lib/types/index.js';
 
 import type { Component } from 'svelte';
@@ -441,9 +441,8 @@ export type SvelteFlowProps<
     attributionPosition?: PanelPosition;
     /**
      * By default, we render a small attribution in the corner of your flows that links back to the project.
-     * You are free to remove this attribution but we ask that you take a quick look at our
-     * {@link https://svelteflow.dev/learn/troubleshooting/remove-attribution | removing attribution guide}
-     * before doing so.
+     * Please only remove the attribution if you have a Svelte Flow subscription.
+     * More information in the {@link https://svelteflow.dev/remove-attribution | removing attribution guide}.
      */
     proOptions?: ProOptions;
     isValidConnection?: IsValidConnection<EdgeType>;

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -87,7 +87,6 @@ export {
   type SetCenterOptions,
   type FitBoundsOptions,
   type PanelPosition,
-  type ProOptions,
   SelectionMode,
   type SelectionRect,
   type OnError,

--- a/packages/svelte/src/lib/store/initial-store.svelte.ts
+++ b/packages/svelte/src/lib/store/initial-store.svelte.ts
@@ -273,6 +273,8 @@ export function getInitialStore<NodeType extends Node = Node, EdgeType extends E
         visibleEdges = getLayoutedEdges(options as EdgeLayoutAllOptions<NodeType, EdgeType>);
       }
 
+      this._prevVisibleEdges = visibleEdges;
+
       return {
         nodes: visibleNodes,
         edges: visibleEdges

--- a/packages/svelte/src/lib/types/general.ts
+++ b/packages/svelte/src/lib/types/general.ts
@@ -60,3 +60,13 @@ export type OnSelectionChange<
   NodeType extends Node = Node,
   EdgeType extends Edge = Edge
 > = (params: { nodes: NodeType[]; edges: EdgeType[] }) => void;
+
+/**
+ * Svelte Flow is independent and entirely funded by its users.
+ * If you hide the attribution, please support our work by subscribing to Svelte Flow Pro: https://svelteflow.dev/remove-attribution
+ * */
+export type ProOptions = {
+  account?: string;
+  /** If you hide the attribution, please support our work with a subscription. */
+  hideAttribution: boolean;
+};

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -279,11 +279,6 @@ export type PanelPosition =
   | 'center-left'
   | 'center-right';
 
-export type ProOptions = {
-  account?: string;
-  hideAttribution: boolean;
-};
-
 export type UseDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;
 
 export enum SelectionMode {

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -284,7 +284,7 @@ export type PanelPosition =
  * */
 export type ProOptions = {
   account?: string;
-  /** This should only be used by users with a subscription. */
+  /** If you hide the attribution, please support our work with a subscription. */
   hideAttribution: boolean;
 };
 

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -279,15 +279,6 @@ export type PanelPosition =
   | 'center-left'
   | 'center-right';
 
-/**
- * The pro options are meant to be used only for users with a subscription.
- * */
-export type ProOptions = {
-  account?: string;
-  /** If you hide the attribution, please support our work with a subscription. */
-  hideAttribution: boolean;
-};
-
 export type UseDragEvent = D3DragEvent<HTMLDivElement, null, SubjectPosition>;
 
 export enum SelectionMode {

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -279,8 +279,12 @@ export type PanelPosition =
   | 'center-left'
   | 'center-right';
 
+/**
+ * The pro options are meant to be used only for users with a subscription.
+ * */
 export type ProOptions = {
   account?: string;
+  /** This should only be used by users with a subscription. */
   hideAttribution: boolean;
 };
 

--- a/packages/system/src/utils/attribution.ts
+++ b/packages/system/src/utils/attribution.ts
@@ -12,7 +12,7 @@ export function handleAttributionWarning(library: 'react' | 'svelte' | 'vue') {
   setTimeout(() => {
     if (!isDomNodeVisible(`.${library}-flow__attribution`)) {
       console.warn(
-        `${framework}: It seems like you are hiding the attribution. Please only do this when you are subscribed to ${framework} Pro: https://${library}flow.dev/remove-attribution?utm_source=console\n%cYou can ignore this warning if you are subscribed.`,
+        `${framework}: It seems like you are hiding the attribution. Please only do this when you are subscribed to ${framework} Pro: https://${library}flow.dev/remove-attr\n%cYou can ignore this warning if you are subscribed.`,
         'font-style: italic;'
       );
     }

--- a/packages/system/src/utils/attribution.ts
+++ b/packages/system/src/utils/attribution.ts
@@ -1,0 +1,20 @@
+import { isDomNodeVisible } from './general';
+
+let warned = false;
+
+export function handleAttributionWarning(library: 'react' | 'svelte' | 'vue') {
+  if (warned || process.env.NODE_ENV !== 'development') {
+    return;
+  }
+  warned = true;
+  const framework = `${library.charAt(0).toUpperCase() + library.slice(1)} Flow`;
+
+  setTimeout(() => {
+    if (!isDomNodeVisible(`.${library}-flow__attribution`)) {
+      console.warn(
+        `${framework}: It seems like you are hiding the attribution. Please only do this when you are subscribed to ${framework} Pro: https://${library}flow.dev/remove-attr\n%cYou can ignore this warning if you are subscribed.`,
+        'font-style: italic;'
+      );
+    }
+  }, 1000);
+}

--- a/packages/system/src/utils/attribution.ts
+++ b/packages/system/src/utils/attribution.ts
@@ -1,0 +1,20 @@
+import { isDomNodeVisible } from './general';
+
+let warned = false;
+
+export function handleAttributionWarning(library: 'react' | 'svelte' | 'vue') {
+  if (warned || process.env.NODE_ENV !== 'development') {
+    return;
+  }
+  warned = true;
+  const framework = `${library.charAt(0).toUpperCase() + library.slice(1)} Flow`;
+
+  setTimeout(() => {
+    if (!isDomNodeVisible(`.${library}-flow__attribution`)) {
+      console.warn(
+        `${framework}: It seems like you are hiding the attribution. Please only do this when you are subscribed to ${framework} Pro: https://${library}flow.dev/remove-attribution?utm_source=console\n%cYou can ignore this warning if you are subscribed.`,
+        'font-style: italic;'
+      );
+    }
+  }, 1000);
+}

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -433,3 +433,19 @@ export function withResolvers<T>(): {
 export function mergeAriaLabelConfig(partial?: Partial<AriaLabelConfig>): AriaLabelConfig {
   return { ...defaultAriaLabelConfig, ...(partial || {}) };
 }
+
+export function domNodeIsVisible(selector: string) {
+  const el = typeof document !== 'undefined' ? document.querySelector(selector) : null;
+  if (!el || !el.isConnected) return false;
+
+  const style = getComputedStyle(el);
+
+  if (style.display === 'none') return false;
+  if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+  if (style.opacity === '0') return false;
+
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return false;
+
+  return true;
+}

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -433,3 +433,19 @@ export function withResolvers<T>(): {
 export function mergeAriaLabelConfig(partial?: Partial<AriaLabelConfig>): AriaLabelConfig {
   return { ...defaultAriaLabelConfig, ...(partial || {}) };
 }
+
+export function isDomNodeVisible(selector: string) {
+  const el = typeof document !== 'undefined' ? document.querySelector(selector) : null;
+  if (!el || !el.isConnected) return false;
+
+  const style = getComputedStyle(el);
+
+  if (style.display === 'none') return false;
+  if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+  if (style.opacity === '0') return false;
+
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return false;
+
+  return true;
+}

--- a/packages/system/src/utils/general.ts
+++ b/packages/system/src/utils/general.ts
@@ -434,7 +434,7 @@ export function mergeAriaLabelConfig(partial?: Partial<AriaLabelConfig>): AriaLa
   return { ...defaultAriaLabelConfig, ...(partial || {}) };
 }
 
-export function domNodeIsVisible(selector: string) {
+export function isDomNodeVisible(selector: string) {
   const el = typeof document !== 'undefined' ? document.querySelector(selector) : null;
   if (!el || !el.isConnected) return false;
 

--- a/packages/system/src/utils/index.ts
+++ b/packages/system/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './attribution';
 export * from './connections';
 export * from './dom';
 export * from './edges';

--- a/tests/playwright/e2e/edges.spec.ts
+++ b/tests/playwright/e2e/edges.spec.ts
@@ -176,3 +176,25 @@ test.describe('Edges', () => {
     });
   });
 });
+
+test.describe('elevate edges on select for overlapping reconnect anchors', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/generic/edges/reconnect');
+  });
+
+  test('selected edge gets elevated z-index above non-selected overlapping edge', async ({ page }) => {
+    const edge1 = page.locator('[data-id="reconnect-1"]');
+
+    await edge1.click();
+    await expect(edge1).toHaveClass(/selected/);
+
+    const svg1 = page.locator('svg', { has: page.locator('[data-id="reconnect-1"]') });
+    const svg2 = page.locator('svg', { has: page.locator('[data-id="reconnect-2"]') });
+
+    await expect(svg1).toHaveCSS('z-index', '1000');
+    await expect(svg2).toHaveCSS('z-index', '0');
+    const z1 = await svg1.evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10));
+    const z2 = await svg2.evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10));
+    expect(z1).toBeGreaterThan(z2);
+  });
+});


### PR DESCRIPTION
## Summary

Changes the default for the `elevateEdgesOnSelect` prop default for React to be true. This now lines up with the Svelte behaviour and allows users to select which reconnect edge to drag. Without this, on React we have LIFO behaviour.

## Changes Made

- Changes the default for the `elevateEdgesOnSelect` prop default for React to be true. 
- Adds E2E tests

## Testing

- ✅ All existing tests pass
- ✅ New `reconnect.ts` test fixture and `elevate edges on select for overlapping reconnect anchors` test added

## Example Usage

1. Connect multiple reconnect edges into one handle 
2. Select the edge you want to drag
3. Drag the edge, then this edge should be dragged 

Closes #3840