### PR TITLE
fix(react): keep minimap bounds at the viewport when all nodes are hidden

### DIFF
--- a/.changeset/minimap-all-hidden-nodes-bounds.md
+++ b/.changeset/minimap-all-hidden-nodes-bounds.md
@@ -1,0 +1,5 @@
+---
+"@xyflow/react": patch
+---
+
+Fix the `MiniMap` zooming out to include the origin when every node is hidden. The bounds are calculated from the visible nodes only, so the minimap now falls back to the viewport rect when no node is visible, like it already does for an empty flow.

--- a/.changeset/minimap-all-hidden-nodes-bounds.md
+++ b/.changeset/minimap-all-hidden-nodes-bounds.md
@@ -1,5 +1,6 @@
 ---
 "@xyflow/react": patch
+"@xyflow/svelte": patch
 ---
 
 Fix the `MiniMap` zooming out to include the origin when every node is hidden.

--- a/.changeset/minimap-all-hidden-nodes-bounds.md
+++ b/.changeset/minimap-all-hidden-nodes-bounds.md
@@ -2,4 +2,4 @@
 "@xyflow/react": patch
 ---
 
-Fix the `MiniMap` zooming out to include the origin when every node is hidden. The bounds are calculated from the visible nodes only, so the minimap now falls back to the viewport rect when no node is visible, like it already does for an empty flow.
+Fix the `MiniMap` zooming out to include the origin when every node is hidden.

--- a/packages/react/src/additional-components/MiniMap/MiniMap.tsx
+++ b/packages/react/src/additional-components/MiniMap/MiniMap.tsx
@@ -24,12 +24,25 @@ const selector = (s: ReactFlowState) => {
     height: s.height / s.transform[2],
   };
 
+  /*
+   * the bounds only cover the visible nodes, so we have to check for a visible node
+   * here as well. getInternalNodesBounds returns a rect at the origin when nothing
+   * passes the filter, which would stretch the bounds to include (0, 0).
+   */
+  let hasVisibleNode = false;
+
+  for (const node of s.nodeLookup.values()) {
+    if (!node.hidden) {
+      hasVisibleNode = true;
+      break;
+    }
+  }
+
   return {
     viewBB,
-    boundingRect:
-      s.nodeLookup.size > 0
-        ? getBoundsOfRects(getInternalNodesBounds(s.nodeLookup, { filter: filterHidden }), viewBB)
-        : viewBB,
+    boundingRect: hasVisibleNode
+      ? getBoundsOfRects(getInternalNodesBounds(s.nodeLookup, { filter: filterHidden }), viewBB)
+      : viewBB,
     rfId: s.rfId,
     panZoom: s.panZoom,
     translateExtent: s.translateExtent,

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -55,8 +55,6 @@
 
   let hasVisibleNodes = $derived(store.nodes.some((n) => !n.hidden));
 
-  $inspect('asd', hasVisibleNodes);
-
   let boundingRect = $derived(
     hasVisibleNodes
       ? getBoundsOfRects(

--- a/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
+++ b/packages/svelte/src/lib/plugins/Minimap/Minimap.svelte
@@ -53,8 +53,17 @@
     height: store.height / store.viewport.zoom
   });
 
+  let hasVisibleNodes = $derived(store.nodes.some((n) => !n.hidden));
+
+  $inspect('asd', hasVisibleNodes);
+
   let boundingRect = $derived(
-    getBoundsOfRects(getInternalNodesBounds(store.nodeLookup, { filter: (n) => !n.hidden }), viewBB)
+    hasVisibleNodes
+      ? getBoundsOfRects(
+          getInternalNodesBounds(store.nodeLookup, { filter: (n) => !n.hidden }),
+          viewBB
+        )
+      : viewBB
   );
 
   let scaledWidth = $derived(boundingRect.width / width);


### PR DESCRIPTION
## The bug

The minimap selector falls back to the viewport rect when the flow is empty, but the bounds it merges come from a traversal **filtered to the visible nodes**:

```ts
// packages/react/src/additional-components/MiniMap/MiniMap.tsx
boundingRect:
  s.nodeLookup.size > 0
    ? getBoundsOfRects(getInternalNodesBounds(s.nodeLookup, { filter: filterHidden }), viewBB)
    : viewBB,
```

`getInternalNodesBounds` returns `{ x: 0, y: 0, width: 0, height: 0 }` when nothing passes the filter, so a flow whose nodes are **all hidden** takes the first branch and merges a phantom rect at the origin into `viewBB`.

With the viewport panned away from the origin, the minimap then spans everything between `(0, 0)` and the viewport. Rendering the real `<MiniMap />` with the viewport at `(4000, 4000)`, 800 × 600:

| nodes | `viewBox` on `main` | with this change |
|---|---|---|
| one node, `hidden: true` | `-820 -153.33 6440 4906.67` | `3980 3980 840 640` |
| one visible node | `3980 3980 840 640` | `3980 3980 840 640` |
| no nodes at all | `3980 3980 840 640` | `3980 3980 840 640` |

So on `main` the minimap zooms out ~8× and the viewport mask shrinks to a speck as soon as the last visible node is hidden — e.g. a filter/search UI with no matches, or toggling all layers off.

## The fix

Check for a *visible* node instead of any node, so the selector takes the same fallback it already takes for an empty flow.

Only the all-hidden case changes; the output is identical as soon as one node is visible and for an empty flow (rows 2 and 3 above).

Since this selector runs on every store change, I measured the extra loop with 10 000 nodes (warmed up, median of 500 runs):

| | before | after |
|---|---|---|
| all nodes visible (the common case) | 0.174 ms | 0.172 ms — the loop exits on the first node |
| only the last node visible (worst case) | 0.061 ms | 0.079 ms |
| all nodes hidden | 0.067 ms | 0.019 ms — the bounds walk is skipped |

So the worst case costs ~19 µs at 10 000 nodes, against the 60–174 µs the bounds walk itself takes, and the all-hidden case gets cheaper.

`tsc --noEmit` and `eslint` pass. The numbers above come from rendering the real component from the built package, once on `main` and once with this change.

Same class as #5871, where `getNodesBounds` merged a phantom box at the origin for unresolvable ids — this is the filtered path that was left over.
