### PR TITLE
fix(svelte): hide edge if connected node is hidden

### DIFF
--- a/.changeset/good-stamps-melt.md
+++ b/.changeset/good-stamps-melt.md
@@ -1,0 +1,6 @@
+---
+"@xyflow/svelte": patch
+---
+
+Hide edge if connected node is hidden
+  

--- a/packages/svelte/src/lib/store/visibleElements.ts
+++ b/packages/svelte/src/lib/store/visibleElements.ts
@@ -89,7 +89,7 @@ export function getLayoutedEdges<NodeType extends Node = Node, EdgeType extends 
     const sourceNode = nodeLookup.get(edge.source);
     const targetNode = nodeLookup.get(edge.target);
 
-    if (!sourceNode || !targetNode) {
+    if (!sourceNode || !targetNode || sourceNode.hidden || targetNode.hidden) {
       continue;
     }
 


### PR DESCRIPTION
It seems that edges are still rendered even if a connected node is hidden.