### PR TITLE
fix(react): change default for `elevateEdgesOnSelect`

### DIFF
--- a/.changeset/elevate-edges-on-select-default.md
+++ b/.changeset/elevate-edges-on-select-default.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': minor
+---
+
+Elevate selected edges by default (`elevateEdgesOnSelect` now defaults to `true`), enabling reconnection of overlapping edges by selecting them first

--- a/examples/react/src/generic-tests/Flow.tsx
+++ b/examples/react/src/generic-tests/Flow.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import {
   ReactFlow,
   addEdge,
+  reconnectEdge,
   OnNodesChange,
   OnEdgesChange,
   OnConnect,
@@ -11,6 +12,7 @@ import {
   Background,
   Node,
   Edge,
+  OnReconnect,
 } from '@xyflow/react';
 
 type FlowProps = {
@@ -25,10 +27,14 @@ export default ({ flowConfig }: FlowProps) => {
   const onNodesChange: OnNodesChange = useCallback((changes) => setNodes((nds) => changes.applyTo(nds as Node[])), []);
   const onEdgesChange: OnEdgesChange = useCallback((changes) => setEdges((eds) => changes.applyTo(eds as Edge[])), []);
   const onConnect: OnConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds as Edge[])), []);
+  const onReconnect: OnReconnect = useCallback(
+    (oldEdge, connection) => setEdges((eds) => reconnectEdge(oldEdge, connection, eds)),
+    []
+  );
 
   return (
     <div style={{ height: '100%' }}>
-      <ReactFlow {...props} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect}>
+      <ReactFlow {...props} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onReconnect={onReconnect}>
         {flowConfig.controlsProps && <Controls {...flowConfig.controlsProps} />}
         {flowConfig.panelProps && <Panel {...flowConfig.panelProps} />}
         {flowConfig.minimapProps && <MiniMap {...flowConfig.minimapProps} />}

--- a/examples/react/src/generic-tests/edges/reconnect.ts
+++ b/examples/react/src/generic-tests/edges/reconnect.ts
@@ -1,0 +1,52 @@
+export default {
+  flowProps: {
+    fitView: true,
+    multiSelectionKeyCode: 's',
+    deleteKeyCode: 'd',
+    nodes: [
+      {
+        id: 'rc-1',
+        data: { label: '1' },
+        position: { x: 0, y: 0 },
+        type: 'input',
+      },
+      {
+        id: 'rc-2',
+        data: { label: '2' },
+        position: { x: 0, y: 200 },
+        type: 'input',
+      },
+      {
+        id: 'rc-3',
+        data: { label: '3' },
+        position: { x: 250, y: 100 },
+      },
+      {
+        id: 'rc-4',
+        data: { label: '4' },
+        position: { x: 250, y: 400 },
+      },
+    ],
+    edges: [
+      {
+        id: 'reconnect-1',
+        source: 'rc-1',
+        target: 'rc-3',
+        reconnectable: true,
+      },
+      {
+        id: 'reconnect-2',
+        source: 'rc-2',
+        target: 'rc-3',
+        reconnectable: true,
+      },
+      {
+        id: 'reconnect-3',
+        source: 'rc-1',
+        target: 'rc-4',
+        reconnectable: true,
+        zIndex: 5,
+      },
+    ],
+  },
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/edges/reconnect.ts
+++ b/examples/svelte/src/generic-tests/edges/reconnect.ts
@@ -1,0 +1,49 @@
+export default {
+	flowProps: {
+		fitView: true,
+		multiSelectionKey: ['Meta', 's'],
+		deleteKey: 'd',
+		nodes: [
+			{
+				id: 'rc-1',
+				data: { label: '1' },
+				position: { x: 0, y: 0 },
+				type: 'input'
+			},
+			{
+				id: 'rc-2',
+				data: { label: '2' },
+				position: { x: 0, y: 200 },
+				type: 'input'
+			},
+			{
+				id: 'rc-3',
+				data: { label: '3' },
+				position: { x: 250, y: 100 }
+			},
+			{
+				id: 'rc-4',
+				data: { label: '4' },
+				position: { x: 250, y: 400 }
+			}
+		],
+		edges: [
+			{
+				id: 'reconnect-1',
+				source: 'rc-1',
+				target: 'rc-3'
+			},
+			{
+				id: 'reconnect-2',
+				source: 'rc-2',
+				target: 'rc-3'
+			},
+			{
+				id: 'reconnect-3',
+				source: 'rc-1',
+				target: 'rc-4',
+				zIndex: 5
+			}
+		]
+	}
+} satisfies FlowConfig;

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -127,7 +127,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     proOptions,
     defaultEdgeOptions,
     elevateNodesOnSelect = true,
-    elevateEdgesOnSelect = false,
+    elevateEdgesOnSelect = true,
     disableKeyboardA11y = false,
     autoPanOnConnect,
     autoPanOnNodeDrag,

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -617,7 +617,9 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   elevateNodesOnSelect?: boolean;
   /**
    * Enabling this option will raise the z-index of edges when they are selected.
-   * @default false
+   * This also ensures that, when multiple reconnectable edges share a handle,
+   * the selected edge's repoint anchor is the one that receives the drag.
+   * @default true
    */
   elevateEdgesOnSelect?: boolean;
   /**

--- a/tests/playwright/e2e/edges.spec.ts
+++ b/tests/playwright/e2e/edges.spec.ts
@@ -176,3 +176,25 @@ test.describe('Edges', () => {
     });
   });
 });
+
+test.describe('elevate edges on select for overlapping reconnect anchors', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/generic/edges/reconnect');
+  });
+
+  test('selected edge gets elevated z-index above non-selected overlapping edge', async ({ page }) => {
+    const edge1 = page.locator('[data-id="reconnect-1"]');
+
+    await edge1.click();
+    await expect(edge1).toHaveClass(/selected/);
+
+    const svg1 = page.locator('svg', { has: page.locator('[data-id="reconnect-1"]') });
+    const svg2 = page.locator('svg', { has: page.locator('[data-id="reconnect-2"]') });
+
+    await expect(svg1).toHaveCSS('z-index', '1000');
+    await expect(svg2).toHaveCSS('z-index', '0');
+    const z1 = await svg1.evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10));
+    const z2 = await svg2.evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10));
+    expect(z1).toBeGreaterThan(z2);
+  });
+});


### PR DESCRIPTION
## Summary

Changes the default for the `elevateEdgesOnSelect` prop default for React to be true. This now lines up with the Svelte behaviour and allows users to select which reconnect edge to drag. Without this, on React we have LIFO behaviour.

PR made against the `renovate` branch as discussed here: #5975

## Changes Made

- Changes the default for the `elevateEdgesOnSelect` prop default for React to be true. 
- Adds E2E tests

## Testing

- ✅ All existing tests pass
- ✅ New `reconnect.ts` test fixture and `elevate edges on select for overlapping reconnect anchors` test added

## Example Usage

1. Connect multiple reconnect edges into one handle 
2. Select the edge you want to drag
3. Drag the edge, then this edge should be dragged 

Closes #3840