### PR TITLE
fix: stale node dimensions after `updateNodeInternals` call

### DIFF
--- a/.changeset/update-node-internals-async.md
+++ b/.changeset/update-node-internals-async.md
@@ -1,0 +1,10 @@
+---
+"@xyflow/system": patch
+"@xyflow/react": patch
+"@xyflow/svelte": patch
+"@xyflow/vue": patch
+---
+
+Make `useUpdateNodeInternals` return a `Promise<void>` (N.B. we use `tick()` for Svelte) that resolves after node dimensions have been re-measured and the store updated. Callers can now `await updateNodeInternals(id)` before performing layout or other dimension-dependent operations. The `UpdateNodeInternals` type is updated from `void` to `Promise<void>` (backward-compatible - existing callers ignoring the return value are unaffected).
+
+For Svelte specifically, fix non-deterministic delay before `updateNodeInternals` (and automatic remeasurement on `sourcePosition`/`targetPosition`/`type` changes) reflected updated node dimensions. Both paths deferred the measurement via `requestAnimationFrame`, which `await tick()` couldn't wait for. The automatic remeasurement no longer needs any deferral.

--- a/examples/react/src/generic-tests/nodes/components/UpdateNodeInternalsNode.tsx
+++ b/examples/react/src/generic-tests/nodes/components/UpdateNodeInternalsNode.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { useUpdateNodeInternals, useReactFlow, type NodeProps } from '@xyflow/react';
+
+export default function UpdateNodeInternalsNode({ id }: NodeProps) {
+  const updateNodeInternals = useUpdateNodeInternals();
+  const { getInternalNode } = useReactFlow();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const w = window as any;
+    w.__updateNodeInternals = updateNodeInternals;
+    w.__getInternalNode = getInternalNode;
+    w.__nodeId = id;
+    w.__expandContainer = () => {
+      const container = containerRef.current;
+      if (container && !container.querySelector('.extra-content')) {
+        const extra = document.createElement('div');
+        extra.className = 'extra-content';
+        extra.style.height = '150px';
+        extra.style.background = '#a8dadc';
+        container.appendChild(extra);
+      }
+    };
+  }, [id, updateNodeInternals, getInternalNode]);
+
+  return (
+    <div className="update-internals-node" style={{ padding: 10, border: '1px solid #ccc', background: '#fff' }}>
+      <div>Update Internals</div>
+      <div ref={containerRef} className="toggle-container" />
+    </div>
+  );
+}

--- a/examples/react/src/generic-tests/nodes/general.ts
+++ b/examples/react/src/generic-tests/nodes/general.ts
@@ -1,4 +1,5 @@
 import DragHandleNode from './components/DragHandleNode';
+import UpdateNodeInternalsNode from './components/UpdateNodeInternalsNode';
 
 export default {
   flowProps: {
@@ -7,6 +8,7 @@ export default {
     multiSelectionKeyCode: 's',
     nodeTypes: {
       DragHandleNode,
+      UpdateNodeInternalsNode,
     },
     nodeDragThreshold: 0,
     nodes: [
@@ -72,6 +74,12 @@ export default {
         data: { label: 'hidden' },
         position: { x: 0, y: 700 },
         hidden: true,
+      },
+      {
+        id: 'update-internals',
+        data: { label: 'Update Internals' },
+        position: { x: 300, y: 0 },
+        type: 'UpdateNodeInternalsNode',
       },
     ],
     edges: [

--- a/examples/svelte/src/generic-tests/nodes/components/UpdateNodeInternalsNode.svelte
+++ b/examples/svelte/src/generic-tests/nodes/components/UpdateNodeInternalsNode.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { useUpdateNodeInternals, useSvelteFlow, type NodeProps } from '@xyflow/svelte';
+
+	let { id }: NodeProps = $props();
+
+	const updateNodeInternals = useUpdateNodeInternals();
+	const { getInternalNode } = useSvelteFlow();
+	let containerEl: HTMLDivElement;
+
+	$effect(() => {
+		const w = window as any;
+		w.__updateNodeInternals = updateNodeInternals;
+		w.__getInternalNode = getInternalNode;
+		w.__nodeId = id;
+		w.__expandContainer = () => {
+			if (containerEl && !containerEl.querySelector('.extra-content')) {
+				const extra = document.createElement('div');
+				extra.className = 'extra-content';
+				extra.style.height = '150px';
+				extra.style.background = '#a8dadc';
+				containerEl.appendChild(extra);
+			}
+		};
+	});
+</script>
+
+<div class="update-internals-node">
+	<div bind:this={containerEl} class="toggle-container"></div>
+</div>
+
+<style>
+	.update-internals-node {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 10px;
+		border: 1px solid #ccc;
+		background: #fff;
+	}
+</style>

--- a/examples/svelte/src/generic-tests/nodes/general.ts
+++ b/examples/svelte/src/generic-tests/nodes/general.ts
@@ -1,4 +1,5 @@
 import DragHandleNode from './components/DragHandleNode.svelte';
+import UpdateNodeInternalsNode from './components/UpdateNodeInternalsNode.svelte';
 
 export default {
 	flowProps: {
@@ -8,7 +9,8 @@ export default {
 		autoPanOnNodeDrag: false,
 		deleteKey: 'd',
 		nodeTypes: {
-			DragHandleNode
+			DragHandleNode,
+			UpdateNodeInternalsNode
 		},
 		nodes: [
 			{
@@ -73,6 +75,12 @@ export default {
 				data: { label: 'hidden' },
 				position: { x: 0, y: 700 },
 				hidden: true
+			},
+			{
+				id: 'update-internals',
+				data: { label: 'Update Internals' },
+				position: { x: 300, y: 0 },
+				type: 'UpdateNodeInternalsNode'
 			}
 		],
 		edges: [

--- a/packages/react/src/hooks/useUpdateNodeInternals.ts
+++ b/packages/react/src/hooks/useUpdateNodeInternals.ts
@@ -10,8 +10,10 @@ import { useReactFlowStoreApi } from './useReactFlowStore';
  * on the canvas if necessary.
  *
  * @public
- * @returns Use this function to tell React Flow to update the internal state of one or more nodes
- * that you have changed programmatically.
+ * @returns A function that tells React Flow to update the internal state of one or more
+ * nodes that you have changed programmatically. Returns a `Promise<void>` that resolves
+ * after the next animation frame, once node dimensions have been re-measured and the store
+ * updated. `await` it before reading dimension-dependent state.
  *
  * @example
  * ```jsx
@@ -64,6 +66,15 @@ export function useUpdateNodeInternals(): UpdateNodeInternals {
       }
     });
 
-    requestAnimationFrame(() => updateNodeInternals(updates, { triggerFitView: false }));
+    return new Promise<void>((resolve, reject) => {
+      requestAnimationFrame(() => {
+        try {
+          updateNodeInternals(updates, { triggerFitView: false });
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
   }, []);
 }

--- a/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
+++ b/packages/svelte/src/lib/components/NodeWrapper/NodeWrapper.svelte
@@ -132,22 +132,20 @@
       targetPosition !== prevTargetPosition;
 
     if (doUpdate && nodeRef !== null) {
-      requestAnimationFrame(() => {
-        if (nodeRef !== null) {
-          store.updateNodeInternals(
-            new Map([
-              [
-                id,
-                {
-                  id,
-                  nodeElement: nodeRef,
-                  force: true
-                }
-              ]
-            ])
-          );
-        }
-      });
+      // This effect already runs after Svelte has applied the DOM updates
+      // so we can update immediately instead of deferring to a rAF
+      store.updateNodeInternals(
+        new Map([
+          [
+            id,
+            {
+              id,
+              nodeElement: nodeRef,
+              force: true
+            }
+          ]
+        ])
+      );
     }
 
     prevType = type;

--- a/packages/svelte/src/lib/hooks/useUpdateNodeInternals.svelte.ts
+++ b/packages/svelte/src/lib/hooks/useUpdateNodeInternals.svelte.ts
@@ -1,6 +1,7 @@
 /* eslint-disable svelte/prefer-svelte-reactivity */
 import { useSvelteFlowStore } from '$lib/store/index.js';
 import { getNodeIdContext } from '$lib/store/context.js';
+import { tick } from 'svelte';
 
 /**
  * When you programmatically add or remove handles to a node or update a node's
@@ -9,15 +10,17 @@ import { getNodeIdContext } from '$lib/store/context.js';
  * on the canvas if necessary.
  *
  * @public
- * @returns A function for telling Svelte Flow to update the internal state of one or more nodes
- * that you have changed programmatically.
+ * @returns A function that tells React Flow to update the internal state of one or more
+ * nodes that you have changed programmatically. Returns a `Promise<void>` that resolves
+ * after the next animation frame, once node dimensions have been re-measured and the store
+ * updated. `await` it before reading dimension-dependent state.
  */
-export function useUpdateNodeInternals(): (nodeId?: string | string[]) => void {
+export function useUpdateNodeInternals(): (nodeId?: string | string[]) => Promise<void> {
   const { domNode, updateNodeInternals } = $derived(useSvelteFlowStore());
   const nodeId = getNodeIdContext();
 
   // @todo: do we want to add this to system?
-  const updateInternals = (id?: string | string[]) => {
+  const updateInternals = (id?: string | string[]): Promise<void> => {
     if (!id && !nodeId) {
       throw new Error('When using outside of a node, you must provide an id.');
     }
@@ -34,7 +37,13 @@ export function useUpdateNodeInternals(): (nodeId?: string | string[]) => void {
       }
     });
 
-    requestAnimationFrame(() => updateNodeInternals(updates));
+    return tick().then(() => {
+      try {
+        updateNodeInternals(updates);
+      } catch (error) {
+        throw error;
+      }
+    })
   };
 
   return updateInternals;

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -260,7 +260,7 @@ export type D3SelectionInstance = D3Selection<Element, unknown, null, undefined>
 
 export type D3ZoomHandler = (this: Element, event: D3ZoomInputEvent, d: unknown) => void;
 
-export type UpdateNodeInternals = (nodeId: string | string[]) => void;
+export type UpdateNodeInternals = (nodeId: string | string[]) => Promise<void>;
 
 /**
  * This type is mostly used to help position things on top of the flow viewport. For

--- a/packages/vue/src/store/actions.ts
+++ b/packages/vue/src/store/actions.ts
@@ -58,7 +58,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   // can reuse `commitNodes` too.
   const { systemNodeLookup, systemParentLookup, commitNodes, commitEdges } = commit;
 
-  const updateNodeInternals: Actions<NodeType>['updateNodeInternals'] = (nodeId) => {
+  const updateNodeInternals: Actions<NodeType>['updateNodeInternals'] = async (nodeId) => {
     state.hooks.updateNodeInternals.trigger(Array.isArray(nodeId) ? nodeId : [nodeId]);
   };
 

--- a/tests/playwright/e2e/nodes.spec.ts
+++ b/tests/playwright/e2e/nodes.spec.ts
@@ -324,4 +324,59 @@ test.describe('Nodes', () => {
 
     await expect(node).toHaveCSS('background-color', 'rgb(255, 0, 0)');
   });
+
+  test.describe('updateNodeInternals', () => {
+    test('awaiting updateNodeInternals returns a resolved value and updates measured dimensions', async ({ page }) => {
+      const node = page
+        .locator(`.${FRAMEWORK}-flow__node`)
+        .and(page.locator('[data-id="update-internals"]'));
+      await expect(node).toHaveCSS('visibility', 'visible');
+
+      await page.waitForFunction(() => !!(window as any).__updateNodeInternals);
+
+      const initialMeasured = await page.evaluate(
+        () => (window as any).__getInternalNode((window as any).__nodeId)?.measured
+      );
+
+      const result = await page.evaluate(async () => {
+        const w = window as any;
+        w.__expandContainer();
+        const ret = await w.__updateNodeInternals(w.__nodeId);
+        const measured = w.__getInternalNode(w.__nodeId)?.measured;
+        return { isPromise: ret instanceof Promise, height: measured?.height ?? 0 };
+      });
+
+      // After awaiting, the return value is not a Promise (it resolved to undefined).
+      expect(result.isPromise).toBe(false);
+      // The store's measured dimensions now reflect the expanded DOM (150px taller).
+      expect(result.height).toBe(initialMeasured.height + 150);
+    });
+
+    test('not awaiting updateNodeInternals leaves measured dimensions stale', async ({ page }) => {
+      const node = page
+        .locator(`.${FRAMEWORK}-flow__node`)
+        .and(page.locator('[data-id="update-internals"]'));
+      await expect(node).toHaveCSS('visibility', 'visible');
+
+      await page.waitForFunction(() => !!(window as any).__updateNodeInternals);
+
+      const initialMeasured = await page.evaluate(
+        () => (window as any).__getInternalNode((window as any).__nodeId)?.measured
+      );
+
+      const result = await page.evaluate(() => {
+        const w = window as any;
+        w.__expandContainer();
+        // Call updateNodeInternals but do NOT await it.
+        const ret = w.__updateNodeInternals(w.__nodeId);
+        const measured = w.__getInternalNode(w.__nodeId)?.measured;
+        return { isPromise: ret instanceof Promise, height: measured?.height ?? 0 };
+      });
+
+      // The return value is a Promise (it was not awaited).
+      expect(result.isPromise).toBe(true);
+      // The store's measured dimensions are stale — unchanged from the collapsed size.
+      expect(result.height).toBe(initialMeasured.height);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Measuring the height and width of a node right after a change in height or width resulted in a stale measurement since there's a non-deterministic delay in `rAF`. We makes `useUpdateNodeInternals` async to ensure a fixed delay. In React we wrap the `rAF` in a `Promise` and in Svelte we use `tick().then(...)`

## Changes Made
- For React `useUpdateNodeInternals` wrap the `rAF` in a `Promise` 
- For Svelte we use `tick().then(...)`
- For both we add a `try...catch`
- Adds E2E tests

## Testing
- ✅ All existing tests pass
- ✅ New `UpdateNodeInternalsNode` test fixture component and `updateNodeInternals` test added

N.B. I'm unsure about the Vue change since I've been working on my fork on `main` - happy for you to do any changes in this regard

Closes #3910 