### PR TITLE
refactor(types): rename Handle to HandleBounds

### DIFF
--- a/.changeset/rename-handle-bounds.md
+++ b/.changeset/rename-handle-bounds.md
@@ -1,0 +1,9 @@
+---
+"@xyflow/system": major
+"@xyflow/react": major
+"@xyflow/svelte": major
+---
+
+Rename the measured handle geometry type from `Handle` to `HandleBounds` so it no longer collides with the `<Handle />` component.
+
+

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -80,6 +80,7 @@ export {
   type CoordinateExtent,
   type ColorMode,
   type HandleType,
+  type HandleBounds,
   type ShouldResize,
   type OnResizeStart,
   type OnResize,
@@ -116,10 +117,6 @@ export {
   NodeChangeset,
   EdgeChangeset,
 } from '@xyflow/system';
-
-// we need this workaround to prevent a duplicate identifier error
-import { type Handle as HandleBound } from '@xyflow/system';
-export type Handle = HandleBound;
 
 // system utils
 export {

--- a/packages/react/src/types/edges.ts
+++ b/packages/react/src/types/edges.ts
@@ -16,7 +16,7 @@ import type {
   DefaultEdgeOptionsBase,
   HandleType,
   ConnectionLineType,
-  Handle,
+  HandleBounds,
   EdgePosition,
   StepPathOptions,
   OnError,
@@ -266,7 +266,7 @@ export type ConnectionLineComponentProps<NodeType extends Node = Node> = {
   /** The node the connection line originates from. */
   fromNode: InternalNode<NodeType>;
   /** The handle on the `fromNode` that the connection line originates from. */
-  fromHandle: Handle;
+  fromHandle: HandleBounds;
   fromX: number;
   fromY: number;
   toX: number;
@@ -279,7 +279,7 @@ export type ConnectionLineComponentProps<NodeType extends Node = Node> = {
    */
   connectionStatus: 'valid' | 'invalid' | null;
   toNode: InternalNode<NodeType> | null;
-  toHandle: Handle | null;
+  toHandle: HandleBounds | null;
   pointer: XYPosition;
 };
 

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -11,7 +11,7 @@ import {
   type OnViewportChange,
   type SelectionRect,
   type SnapGrid,
-  type Handle,
+  type HandleBounds,
   type Transform,
   type PanZoomInstance,
   type PanBy,
@@ -85,7 +85,7 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
 
   connection: ConnectionState<InternalNode<NodeType>>;
   connectionMode: ConnectionMode;
-  connectionClickStartHandle: (Pick<Handle, 'nodeId' | 'id'> & Required<Pick<Handle, 'type'>>) | null;
+  connectionClickStartHandle: (Pick<HandleBounds, 'nodeId' | 'id'> & Required<Pick<HandleBounds, 'type'>>) | null;
 
   snapToGrid: boolean;
   snapGrid: SnapGrid;

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -121,6 +121,7 @@ export {
   type SetViewport,
   type FitBounds,
   type HandleConnection,
+  type HandleBounds,
   type ZIndexMode,
   type NodeHandle,
   type UseNodeConnectionsParams,

--- a/packages/svelte/src/lib/store/initial-store.svelte.ts
+++ b/packages/svelte/src/lib/store/initial-store.svelte.ts
@@ -34,7 +34,7 @@ import {
   pointToRendererPoint,
   type Transform,
   fitViewport,
-  type Handle,
+  type HandleBounds,
   type OnReconnect,
   type OnReconnectStart,
   type OnReconnectEnd,
@@ -470,7 +470,7 @@ export function getInitialStore<NodeType extends Node = Node, EdgeType extends E
     clickConnect?: boolean = $derived(signals.props.clickConnect ?? true);
     onclickconnectstart?: OnConnectStart = $derived(signals.props.onclickconnectstart);
     onclickconnectend?: OnConnectEnd = $derived(signals.props.onclickconnectend);
-    clickConnectStartHandle: Pick<Handle, 'id' | 'nodeId' | 'type'> | null = $state.raw(null);
+    clickConnectStartHandle: Pick<HandleBounds, 'id' | 'nodeId' | 'type'> | null = $state.raw(null);
 
     onselectiondrag?: OnSelectionDrag<NodeType> = $derived(signals.props.onselectiondrag);
     onselectiondragstart?: OnSelectionDrag<NodeType> = $derived(signals.props.onselectiondragstart);

--- a/packages/svelte/src/lib/types/general.ts
+++ b/packages/svelte/src/lib/types/general.ts
@@ -2,7 +2,7 @@ import type { ShortcutModifierDefinition } from '@svelte-put/shortcut';
 import type {
   FitViewOptionsBase,
   XYPosition,
-  Handle,
+  HandleBounds,
   Connection,
   OnBeforeDeleteBase,
   EdgeChangeset,
@@ -18,8 +18,8 @@ export type KeyDefinition = string | KeyDefinitionObject;
 
 export type ConnectionData = {
   connectionPosition: XYPosition | null;
-  connectionStartHandle: Handle | null;
-  connectionEndHandle: Handle | null;
+  connectionStartHandle: HandleBounds | null;
+  connectionEndHandle: HandleBounds | null;
   connectionStatus: string | null;
 };
 

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -6,7 +6,7 @@ import type { Transition } from 'd3-transition';
 
 import type { XYPosition, Rect, Position } from './utils';
 import type { InternalNodeBase, NodeBase, NodeDragItem } from './nodes';
-import type { Handle, HandleType } from './handles';
+import type { HandleBounds, HandleType } from './handles';
 import { type PanZoomInstance } from './panzoom';
 import { type EdgeBase } from '..';
 import type { D3ZoomInputEvent } from '../utils/events';
@@ -340,7 +340,7 @@ export type ConnectionInProgress<NodeType extends InternalNodeBase = InternalNod
   /** Returns the xy start position or `null` if no connection is in progress. */
   from: XYPosition;
   /** Returns the start handle or `null` if no connection is in progress. */
-  fromHandle: Handle;
+  fromHandle: HandleBounds;
   /** Returns the side (called position) of the start handle or `null` if no connection is in progress. */
   fromPosition: Position;
   /** Returns the start node or `null` if no connection is in progress. */
@@ -348,7 +348,7 @@ export type ConnectionInProgress<NodeType extends InternalNodeBase = InternalNod
   /** Returns the xy end position or `null` if no connection is in progress. */
   to: XYPosition;
   /** Returns the end handle or `null` if no connection is in progress. */
-  toHandle: Handle | null;
+  toHandle: HandleBounds | null;
   /** Returns the side (called position) of the end handle or `null` if no connection is in progress. */
   toPosition: Position;
   /** Returns the end node or `null` if no connection is in progress. */

--- a/packages/system/src/types/handles.ts
+++ b/packages/system/src/types/handles.ts
@@ -6,8 +6,7 @@ import type { Position, IsValidConnection } from '.';
 export type HandleType = 'source' | 'target';
 
 /**
- * Measured geometry of a connection handle on a node: identity, side, and box relative to the node.
- * Distinct from the `<Handle />` component and from {@link NodeHandle} (user-declared layout on `node.handles`).
+ * Measured position and size of a handle relative to the node
  *
  * @public
  */

--- a/packages/system/src/types/handles.ts
+++ b/packages/system/src/types/handles.ts
@@ -5,7 +5,13 @@ import type { Position, IsValidConnection } from '.';
  */
 export type HandleType = 'source' | 'target';
 
-export type Handle = {
+/**
+ * Measured geometry of a connection handle on a node: identity, side, and box relative to the node.
+ * Distinct from the `<Handle />` component and from {@link NodeHandle} (user-declared layout on `node.handles`).
+ *
+ * @public
+ */
+export type HandleBounds = {
   id?: string | null;
   nodeId: string;
   x: number;

--- a/packages/system/src/types/nodes.ts
+++ b/packages/system/src/types/nodes.ts
@@ -1,5 +1,4 @@
-import type { XYPosition, Position, CoordinateExtent, Handle } from '.';
-import { type Optional } from '../utils/types';
+import type { XYPosition, Position, CoordinateExtent, HandleBounds } from '.';
 
 /**
  * Framework independent node data structure.
@@ -125,9 +124,15 @@ export type NodeProps<NodeType extends NodeBase> = Pick<
     positionAbsoluteY: number;
   };
 
+/**
+ * Measured {@link HandleBounds} for a node, grouped by handle type.
+ * Stored on `internals.handleBounds`.
+ *
+ * @public
+ */
 export type NodeHandleBounds = {
-  source: Handle[] | null;
-  target: Handle[] | null;
+  source: HandleBounds[] | null;
+  target: HandleBounds[] | null;
 };
 
 export type InternalNodeUpdate = {
@@ -170,11 +175,15 @@ export type OnSelectionDrag<NodeType extends NodeBase = NodeBase> = (
 ) => void;
 
 /**
- * Type for the handles of a node
+ * User-declared handle layout on {@link NodeBase.handles}.
+ * Same fields as {@link HandleBounds} except `nodeId` (implied by the node) and optional `width`/`height`.
  *
  * @public
  */
-export type NodeHandle = Omit<Optional<Handle, 'width' | 'height'>, 'nodeId'>;
+export type NodeHandle = Omit<HandleBounds, 'nodeId' | 'width' | 'height'> & {
+  width?: number;
+  height?: number;
+};
 
 export type Align = 'center' | 'start' | 'end';
 

--- a/packages/system/src/utils/dom.ts
+++ b/packages/system/src/utils/dom.ts
@@ -1,4 +1,4 @@
-import type { Transform, XYPosition, SnapGrid, Dimensions, Position, Handle } from '../types';
+import type { Transform, XYPosition, SnapGrid, Dimensions, Position, HandleBounds } from '../types';
 import { isMouseEvent } from './events';
 import { snapPosition, pointToRendererPoint } from './general';
 
@@ -70,14 +70,14 @@ export const getHandleBounds = (
   nodeBounds: DOMRect,
   zoom: number,
   nodeId: string
-): Handle[] | null => {
+): HandleBounds[] | null => {
   const handles = nodeElement.querySelectorAll(`.${type}`);
 
   if (!handles || !handles.length) {
     return null;
   }
 
-  return Array.from(handles).map((handle): Handle => {
+  return Array.from(handles).map((handle): HandleBounds => {
     const handleBounds = handle.getBoundingClientRect();
 
     return {

--- a/packages/system/src/utils/edges/positions.ts
+++ b/packages/system/src/utils/edges/positions.ts
@@ -1,9 +1,8 @@
 import { type EdgePosition } from '../../types/edges';
 import { ConnectionMode, type OnError } from '../../types/general';
-import { type InternalNodeBase, type NodeHandle } from '../../types/nodes';
+import { type HandleBounds, type InternalNodeBase } from '../../types';
 import { Position, type XYPosition } from '../../types/utils';
 import { errorMessages } from '../constants';
-import { type Handle } from '../../types';
 import { getNodeDimensions } from '../general';
 
 export type GetEdgePositionParams = {
@@ -31,8 +30,8 @@ export function getEdgePosition(params: GetEdgePositionParams): EdgePosition | n
     return null;
   }
 
-  const sourceHandleBounds = sourceNode.internals.handleBounds || toHandleBounds(sourceNode.handles);
-  const targetHandleBounds = targetNode.internals.handleBounds || toHandleBounds(targetNode.handles);
+  const sourceHandleBounds = sourceNode.internals.handleBounds;
+  const targetHandleBounds = targetNode.internals.handleBounds;
 
   const sourceHandle = getHandle(sourceHandleBounds?.source ?? [], params.sourceHandle);
   const targetHandle = getHandle(
@@ -71,34 +70,9 @@ export function getEdgePosition(params: GetEdgePositionParams): EdgePosition | n
   };
 }
 
-function toHandleBounds(handles?: NodeHandle[]) {
-  if (!handles) {
-    return null;
-  }
-
-  const source: Handle[] = [];
-  const target: Handle[] = [];
-
-  for (const handle of handles) {
-    handle.width = handle.width ?? 1;
-    handle.height = handle.height ?? 1;
-
-    if (handle.type === 'source') {
-      source.push(handle as Handle);
-    } else if (handle.type === 'target') {
-      target.push(handle as Handle);
-    }
-  }
-
-  return {
-    source,
-    target,
-  };
-}
-
 export function getHandlePosition(
   node: InternalNodeBase,
-  handle: Handle | null,
+  handle: HandleBounds | null,
   fallbackPosition: Position = Position.Left,
   center = false
 ): XYPosition {
@@ -124,7 +98,7 @@ export function getHandlePosition(
   }
 }
 
-function getHandle(bounds: Handle[], handleId?: string | null): Handle | null {
+function getHandle(bounds: HandleBounds[], handleId?: string | null): HandleBounds | null {
   if (!bounds) {
     return null;
   }

--- a/packages/system/src/utils/store.ts
+++ b/packages/system/src/utils/store.ts
@@ -1,7 +1,7 @@
 import {
   dimensionChange,
   DimensionChange,
-  type Handle,
+  type HandleBounds,
   type HandleConnection,
   infiniteExtent,
   type NodeHandleBounds,
@@ -67,8 +67,8 @@ function parseHandles(userNode: NodeBase, internalNode?: InternalNodeBase): Node
     return !userNode.measured || userNode.hidden ? undefined : internalNode?.internals.handleBounds;
   }
 
-  const source: Handle[] = [];
-  const target: Handle[] = [];
+  const source: HandleBounds[] = [];
+  const target: HandleBounds[] = [];
 
   for (const handle of userNode.handles) {
     const handleBounds = {

--- a/packages/system/src/xyhandle/XYHandle.ts
+++ b/packages/system/src/xyhandle/XYHandle.ts
@@ -11,7 +11,7 @@ import {
   Position,
   oppositePosition,
   type ConnectionInProgress,
-  type Handle,
+  type HandleBounds,
   type Connection,
   type NodeBase,
   type EdgeBase,
@@ -55,7 +55,7 @@ function onPointerDown<NodeType extends NodeBase = NodeBase, EdgeType extends Ed
   // when xyflow is used inside a shadow root we can't use document
   const doc = getHostForElement(event.target);
   let autoPanId = 0;
-  let closestHandle: Handle | null;
+  let closestHandle: HandleBounds | null;
 
   const { x, y } = getEventPosition(event);
   const handleType = getHandleType(edgeUpdaterType, handleDomNode);
@@ -89,7 +89,7 @@ function onPointerDown<NodeType extends NodeBase = NodeBase, EdgeType extends Ed
   }
 
   // Stays the same for all consecutive pointermove events
-  const fromHandle: Handle = {
+  const fromHandle: HandleBounds = {
     ...fromHandleInternal,
     nodeId,
     type: handleType,

--- a/packages/system/src/xyhandle/types.ts
+++ b/packages/system/src/xyhandle/types.ts
@@ -6,7 +6,7 @@ import {
   type HandleType,
   type PanBy,
   type Transform,
-  type Handle,
+  type HandleBounds,
   type OnConnectEnd,
   type UpdateConnection,
   type IsValidConnection,
@@ -41,14 +41,14 @@ export type OnPointerDownParams<NodeType extends NodeBase = NodeBase, EdgeType e
     connectionState: FinalConnectionState<InternalNodeBase<NodeType>>
   ) => void;
   getTransform: () => Transform;
-  getFromHandle: () => Handle | null;
+  getFromHandle: () => HandleBounds | null;
   autoPanSpeed?: number;
   dragThreshold?: number;
   handleDomNode: Element;
 };
 
 export type IsValidParams<NodeType extends NodeBase = NodeBase, EdgeType extends EdgeBase = EdgeBase> = {
-  handle: Pick<Handle, 'nodeId' | 'id' | 'type'> | null;
+  handle: Pick<HandleBounds, 'nodeId' | 'id' | 'type'> | null;
   connectionMode: ConnectionMode;
   fromNodeId: string;
   fromHandleId: string | null;
@@ -69,5 +69,5 @@ export type Result = {
   handleDomNode: Element | null;
   isValid: boolean;
   connection: Connection | null;
-  toHandle: Handle | null;
+  toHandle: HandleBounds | null;
 };

--- a/packages/system/src/xyhandle/utils.ts
+++ b/packages/system/src/xyhandle/utils.ts
@@ -3,7 +3,7 @@ import {
   ConnectionMode,
   type HandleType,
   type XYPosition,
-  type Handle,
+  type HandleBounds,
   type InternalNodeBase,
   type NodeLookup,
 } from '../types';
@@ -37,8 +37,8 @@ export function getClosestHandle(
   connectionRadius: number,
   nodeLookup: NodeLookup,
   fromHandle: { nodeId: string; type: HandleType; id?: string | null }
-): Handle | null {
-  let closestHandles: Handle[] = [];
+): HandleBounds | null {
+  let closestHandles: HandleBounds[] = [];
   let minDistance = Infinity;
 
   const closeNodes = getNodesWithinDistance(position, nodeLookup, connectionRadius + ADDITIONAL_DISTANCE);
@@ -89,7 +89,7 @@ export function getHandle(
   nodeLookup: NodeLookup,
   connectionMode: ConnectionMode,
   withAbsolutePosition = false
-): Handle | null {
+): HandleBounds | null {
   const node = nodeLookup.get(nodeId);
   if (!node) {
     return null;

--- a/packages/vue/src/components/ConnectionLine/index.ts
+++ b/packages/vue/src/components/ConnectionLine/index.ts
@@ -1,4 +1,4 @@
-import type { Handle } from '@xyflow/system';
+import type { HandleBounds } from '@xyflow/system';
 import { ConnectionLineType, ConnectionMode, getBezierPath, getConnectionStatus, getHandlePosition, getMarkerId, getSmoothStepPath, oppositePosition, pointToRendererPoint, Position } from '@xyflow/system';
 import { computed, defineComponent, h, inject } from 'vue';
 import { storeToRefs, useVueFlow, useVueFlowStore } from '../../composables';
@@ -61,7 +61,7 @@ const ConnectionLine = defineComponent({
       const fromPosition = fromHandle?.position ?? Position.Top;
       const { x: fromX, y: fromY } = getHandlePosition(fromNode.value, fromHandle, fromPosition, true);
 
-      let toHandle: Handle | null = null;
+      let toHandle: HandleBounds | null = null;
       if (toNode.value) {
         // if connection mode is strict, we only look for handles of the opposite type
         if (connectionMode.value === ConnectionMode.Strict) {

--- a/packages/vue/src/composables/useHandle.ts
+++ b/packages/vue/src/composables/useHandle.ts
@@ -120,6 +120,8 @@ export function useHandle({
         type: toValue(type),
         id: toValue(handleId),
         position: Position.Top,
+        width: 0,
+        height: 0,
         ...getEventPosition(event),
       };
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -3,11 +3,6 @@
  * @module vue-flow
  */
 
-// `Handle` names both the component (exported below) and the system type for a handle's measured bounds.
-// Re-exporting the type through an alias declaration (not a re-export specifier) lets them share the name
-// without a duplicate-identifier error.
-import type { Handle as HandleBounds } from '@xyflow/system';
-
 export * from './components/Background';
 
 export * from './components/Controls';
@@ -26,7 +21,6 @@ export { default as StraightEdge } from './components/Edges/StraightEdge';
 export * from './components/EdgeToolbar';
 
 export { default as Handle } from './components/Handle/Handle.vue';
-export type Handle = HandleBounds;
 export * from './components/MiniMap';
 export * from './components/NodeResizer';
 export * from './components/NodeToolbar';
@@ -116,6 +110,7 @@ export {
   type FitViewOptionsBase as FitViewOptions,
   type GetViewport,
   type HandleConnection,
+  type HandleBounds,
   type HandleType,
   type IsValidConnection,
   type MarkerProps,

--- a/packages/vue/src/types/connection.ts
+++ b/packages/vue/src/types/connection.ts
@@ -1,4 +1,4 @@
-import type { ConnectionLineType, EdgeMarkerType, Handle, Position, XYPosition } from '@xyflow/system';
+import type { ConnectionLineType, EdgeMarkerType, HandleBounds, Position, XYPosition } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { ClassValue } from './flow';
 import type { InternalNode, Node } from './node';
@@ -38,11 +38,11 @@ export interface ConnectionLineProps<NodeType extends Node = Node> {
   /** the node the connection started from */
   fromNode: InternalNode<NodeType>;
   /** the handle the connection started from (not the DOM element) */
-  fromHandle: Handle | null;
+  fromHandle: HandleBounds | null;
   /** the node the connection currently ends on, or `null` */
   toNode: InternalNode<NodeType> | null;
   /** the handle the connection currently ends on (not the DOM element), or `null` */
-  toHandle: Handle | null;
+  toHandle: HandleBounds | null;
   /** marker url */
   markerStart?: string;
   /** marker url */

--- a/packages/vue/src/types/handle.ts
+++ b/packages/vue/src/types/handle.ts
@@ -1,8 +1,6 @@
-import type { Handle, HandleType, IsValidConnection, Position } from '@xyflow/system';
+import type { HandleType, IsValidConnection, Position } from '@xyflow/system';
 import type { Edge } from './edge';
 import type { InternalNode } from './node';
-
-export type ConnectingHandle = Omit<Handle, 'width' | 'height'>;
 
 export type HandleConnectableFunc = (node: InternalNode, connectedEdges: Edge[]) => boolean;
 

--- a/packages/vue/src/types/store.ts
+++ b/packages/vue/src/types/store.ts
@@ -11,6 +11,7 @@ import type {
   EdgeLookup,
   FitViewOptionsBase,
   HandleType,
+  HandleBounds,
   IsValidConnection,
   NodeChangeset,
   NodeConnection,
@@ -34,7 +35,6 @@ import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent }
 import type { ConnectionLineOptions } from './connection';
 import type { DefaultEdgeOptions, Edge, EdgeReconnectable } from './edge';
 import type { FlowExportObject, OnBeforeDelete, VueFlowProps } from './flow';
-import type { ConnectingHandle } from './handle';
 import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks';
 import type { BuiltInNode, InternalNode, Node, NodeOrigin } from './node';
 
@@ -114,7 +114,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   /** the ongoing drag-connection as a single {@link ConnectionState} (`inProgress: false` when idle) */
   connection: ConnectionState<InternalNode<NodeType>>;
   /** the handle a click-to-connect interaction started from (separate from the drag `connection`) */
-  connectionClickStartHandle: ConnectingHandle | null;
+  connectionClickStartHandle: HandleBounds | null;
   connectionRadius: number;
   connectionDragThreshold: number;
   isValidConnection: IsValidConnection | null;

--- a/packages/vue/src/utils/edge.ts
+++ b/packages/vue/src/utils/edge.ts
@@ -1,8 +1,8 @@
-import type { Handle, ZIndexMode } from '@xyflow/system';
+import type { HandleBounds, ZIndexMode } from '@xyflow/system';
 import type { Actions, Edge } from '../types';
 import { getElevatedEdgeZIndex } from '@xyflow/system';
 
-export function getEdgeHandle(bounds: Handle[] | null, handleId?: string | null): Handle | null {
+export function getEdgeHandle(bounds: HandleBounds[] | null, handleId?: string | null): HandleBounds | null {
   if (!bounds) {
     return null;
   }


### PR DESCRIPTION
This PR renames the Handle type to HandleBounds. We could also drop `toHandleBounds`, because this is already done in `adoptUserNodes`. 