### PR TITLE
fix(react): defer ResizeObserver store updates

### DIFF
--- a/.changeset/defer-react-resize-observer-updates.md
+++ b/.changeset/defer-react-resize-observer-updates.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Prevent `ResizeObserver` loop warnings when node or pane dimensions change.

--- a/packages/react/src/container/NodeRenderer/useResizeObserver.ts
+++ b/packages/react/src/container/NodeRenderer/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ReactFlowState } from '../../types';
 import { useStore } from '../../hooks/useStore';
@@ -8,28 +8,39 @@ const selector = (s: ReactFlowState) => s.updateNodeInternals;
 
 export function useResizeObserver() {
   const updateNodeInternals = useStore(selector);
+  const updates = useRef(new Map<string, InternalNodeUpdate>());
+  const frameId = useRef<number | null>(null);
   const [resizeObserver] = useState(() => {
     if (typeof ResizeObserver === 'undefined') {
       return null;
     }
 
     return new ResizeObserver((entries: ResizeObserverEntry[]) => {
-      const updates = new Map<string, InternalNodeUpdate>();
       entries.forEach((entry: ResizeObserverEntry) => {
         const id = entry.target.getAttribute('data-id') as string;
-        updates.set(id, {
+        updates.current.set(id, {
           id,
           nodeElement: entry.target as HTMLDivElement,
           force: true,
         });
       });
 
-      updateNodeInternals(updates);
+      if (frameId.current === null) {
+        frameId.current = requestAnimationFrame(() => {
+          frameId.current = null;
+          updateNodeInternals(updates.current);
+          updates.current.clear();
+        });
+      }
     });
   });
 
   useEffect(() => {
     return () => {
+      if (frameId.current !== null) {
+        cancelAnimationFrame(frameId.current);
+      }
+      updates.current.clear();
       resizeObserver?.disconnect();
     };
   }, [resizeObserver]);

--- a/packages/react/src/hooks/useResizeHandler.ts
+++ b/packages/react/src/hooks/useResizeHandler.ts
@@ -22,18 +22,38 @@ export function useResizeHandler(domNode: MutableRefObject<HTMLDivElement | null
         store.getState().onError?.('004', errorMessages['error004']());
       }
 
-      store.setState({ width: size.width || 500, height: size.height || 500 });
+      const nextWidth = size.width || 500;
+      const nextHeight = size.height || 500;
+      const { width, height } = store.getState();
+
+      if (nextWidth === width && nextHeight === height) {
+        return;
+      }
+
+      store.setState({ width: nextWidth, height: nextHeight });
     };
 
     if (domNode.current) {
+      let frameId: number | null = null;
       updateDimensions();
       window.addEventListener('resize', updateDimensions);
 
-      const resizeObserver = new ResizeObserver(() => updateDimensions());
+      const resizeObserver = new ResizeObserver(() => {
+        if (frameId === null) {
+          frameId = requestAnimationFrame(() => {
+            frameId = null;
+            updateDimensions();
+          });
+        }
+      });
       resizeObserver.observe(domNode.current);
 
       return () => {
         window.removeEventListener('resize', updateDimensions);
+
+        if (frameId !== null) {
+          cancelAnimationFrame(frameId);
+        }
 
         if (resizeObserver && domNode.current) {
           resizeObserver.unobserve(domNode.current);


### PR DESCRIPTION
## Problem

The React node and pane `ResizeObserver` callbacks update the store synchronously. Those updates can cause React to commit layout changes before the current observer delivery cycle finishes, which makes browsers report:

`ResizeObserver loop completed with undelivered notifications.`

The warning has also been reported in #4792 and #3076.

## Fix

- Collect node measurements across observer callbacks and flush one `updateNodeInternals` call in the next animation frame.
- Schedule at most one pane measurement per animation frame.
- Skip pane store writes when the measured dimensions have not changed.
- Cancel pending animation frames during cleanup.

The initial pane measurement and the window resize listener remain synchronous. Public APIs do not change. The animation-frame scheduling follows the existing pattern in `useUpdateNodeInternals`.

## Validation

- `pnpm build`
- `pnpm --filter @xyflow/react typecheck`
- ESLint and Prettier checks on the changed source files
- React Playwright suite in Chromium and Firefox: 97 passed and 2 skipped. The remaining Firefox `autoPanOnNodeDrag` assertion also fails on an unchanged `main` checkout.
- Headed Chromium and Firefox checks with the `NodeResizer` example: resized a selected node, resized the viewport, and used zoom controls with zero console errors.

### AI disclosure

- [x] AI-assisted - Drafted with help of OpenAI Codex (GPT-5) 
