### PR TITLE
fix(react): preserve node and edge order in setNodes and setEdges

### DIFF
--- a/.changeset/quiet-nodes-reorder.md
+++ b/.changeset/quiet-nodes-reorder.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': patch
+---
+
+Preserve node and edge order when updating controlled flows through `setNodes` and `setEdges` from `useReactFlow`.

--- a/examples/react/src/generic-tests/nodes/reorder.ts
+++ b/examples/react/src/generic-tests/nodes/reorder.ts
@@ -1,0 +1,40 @@
+import { createElement } from 'react';
+import { useReactFlow } from '@xyflow/react';
+
+function ReorderButton() {
+  const { setNodes, setEdges } = useReactFlow();
+  return createElement(
+    'button',
+    {
+      onClick: () => {
+        setNodes((nodes) =>
+          nodes[0].id === 'parent' ? [nodes[2], nodes[0], nodes[1]] : [nodes[1], nodes[2], nodes[0]]
+        );
+        setEdges((edges) => [...edges].reverse());
+      },
+    },
+    'Reorder'
+  );
+}
+
+export default {
+  flowProps: {
+    fitView: true,
+    nodes: [
+      {
+        id: 'parent',
+        position: { x: 0, y: 0 },
+        data: { label: 'Parent' },
+        style: { width: 250, height: 200 },
+        selected: true,
+      },
+      { id: 'child', parentId: 'parent', position: { x: 30, y: 80 }, data: { label: 'Child' } },
+      { id: 'other', position: { x: 400, y: 0 }, data: { label: 'Other' } },
+    ],
+    edges: [
+      { id: 'first', source: 'parent', target: 'other' },
+      { id: 'second', source: 'child', target: 'other' },
+    ],
+  },
+  panelProps: { position: 'bottom-right', children: createElement(ReorderButton) },
+} satisfies FlowConfig;

--- a/packages/react/src/utils/changes.ts
+++ b/packages/react/src/utils/changes.ts
@@ -291,10 +291,23 @@ export function getElementsDiffChanges({
 }): any[] {
   const changes: any[] = [];
   const itemsLookup = new Map<string, any>(items.map((item) => [item.id, item]));
+  const previousIndices = new Map(Array.from(lookup.keys(), (id, index) => [id, index]));
+  let lastRetainedIndex = -1;
 
   for (const [index, item] of items.entries()) {
     const lookupItem = lookup.get(item.id);
     const storeItem = lookupItem?.internals?.userNode ?? lookupItem;
+    const previousIndex = previousIndices.get(item.id);
+
+    // Retained elements must stay in their previous relative order. Reinsert
+    // moved elements at their requested index using the existing change types.
+    if (previousIndex !== undefined) {
+      if (previousIndex < lastRetainedIndex) {
+        changes.push({ id: item.id, type: 'remove' }, { item, type: 'add', index });
+        continue;
+      }
+      lastRetainedIndex = previousIndex;
+    }
 
     if (storeItem !== undefined && storeItem !== item) {
       changes.push({ id: item.id, item: item, type: 'replace' });

--- a/tests/playwright/e2e/elements-diff.spec.ts
+++ b/tests/playwright/e2e/elements-diff.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import type { Node, Edge } from '../../../packages/react/src/types';
+import type { NodeLookup } from '../../../packages/system/src/types';
+import { adoptUserNodes } from '../../../packages/system/src/utils/store';
+import { getElementsDiffChanges, applyNodeChanges, applyEdgeChanges } from '../../../packages/react/src/utils/changes';
+
+const nodes: Node[] = ['a', 'b', 'c'].map((id, index) => ({
+  id,
+  position: { x: index * 100, y: 0 },
+  data: { label: id },
+  selected: id === 'a',
+}));
+
+function diff(next: Node[], previous = nodes) {
+  const lookup: NodeLookup = new Map();
+  adoptUserNodes(previous, lookup, new Map());
+  return getElementsDiffChanges({ items: next, lookup });
+}
+
+test.describe('getElementsDiffChanges', () => {
+  for (const order of [
+    [1, 0, 2],
+    [2, 0, 1],
+    [1, 2, 0],
+    [2, 1, 0],
+  ]) {
+    test(`preserves the requested order ${order.join(',')} with unchanged objects`, () => {
+      const next = order.map((index) => nodes[index]);
+      expect(applyNodeChanges(diff(next), nodes)).toEqual(next);
+    });
+  }
+
+  test('combines reordering with additions, deletions and changed node data', () => {
+    const next = [
+      { ...nodes[0], id: 'new' },
+      nodes[2],
+      { ...nodes[0], data: { label: 'updated' }, position: { x: 50, y: 50 } },
+    ];
+    expect(applyNodeChanges(diff(next), nodes)).toEqual(next);
+    expect(nodes.map((node) => node.id)).toEqual(['a', 'b', 'c']);
+    expect(nodes[0].data.label).toBe('a');
+  });
+
+  test('does not produce changes for an unchanged array', () => {
+    expect(diff([...nodes])).toEqual([]);
+  });
+
+  test('does not move retained nodes when inserting or deleting other nodes', () => {
+    const added = { ...nodes[0], id: 'new' };
+    expect(diff([added, ...nodes])).toEqual([{ type: 'add', item: added, index: 0 }]);
+    expect(diff([nodes[0], nodes[2]])).toEqual([{ type: 'remove', id: 'b' }]);
+  });
+
+  test('keeps same-order updates as replacements', () => {
+    const updated = { ...nodes[1], selected: true };
+    expect(diff([nodes[0], updated, nodes[2]])).toEqual([{ type: 'replace', id: 'b', item: updated }]);
+  });
+
+  test('reorders edges without losing their data', () => {
+    const edges: Edge[] = [
+      { id: 'ab', source: 'a', target: 'b', selected: true },
+      { id: 'bc', source: 'b', target: 'c' },
+      { id: 'ca', source: 'c', target: 'a' },
+    ];
+    const next = [edges[2], { ...edges[0], label: 'updated' }];
+    const changes = getElementsDiffChanges({ items: next, lookup: new Map(edges.map((edge) => [edge.id, edge])) });
+    expect(applyEdgeChanges(changes, edges)).toEqual(next);
+  });
+});

--- a/tests/playwright/e2e/reorder.spec.ts
+++ b/tests/playwright/e2e/reorder.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { FRAMEWORK } from './constants';
+
+test('setNodes and setEdges preserve order, subflows and selection', async ({ page }) => {
+  test.skip(FRAMEWORK !== 'react', 'Regression for the useReactFlow helpers');
+  await page.goto('/tests/generic/nodes/reorder');
+  const nodes = page.locator('.react-flow__node');
+  const edges = page.locator('.react-flow__edge');
+  const child = page.locator('.react-flow__node[data-id="child"]');
+  await expect(child).toBeVisible();
+  const childTransform = await child.evaluate((element) => element.style.transform);
+  await page.getByRole('button', { name: 'Reorder', exact: true }).click();
+  await expect(nodes).toHaveCount(3);
+  await expect(nodes.nth(0)).toHaveAttribute('data-id', 'other');
+  await expect(nodes.nth(1)).toHaveAttribute('data-id', 'parent');
+  await expect(nodes.nth(2)).toHaveAttribute('data-id', 'child');
+  await expect(edges).toHaveCount(2);
+  await expect(edges.first()).toHaveAttribute('data-id', 'second');
+  await expect(page.locator('.react-flow__node[data-id="parent"]')).toHaveClass(/selected/);
+  expect(await child.evaluate((element) => element.style.transform)).toBe(childTransform);
+  await child.click();
+  await expect(child).toHaveClass(/selected/);
+  const before = await child.boundingBox();
+  await page.mouse.move(before!.x + 40, before!.y + 20);
+  await page.mouse.down();
+  await page.mouse.move(before!.x + 70, before!.y + 50, { steps: 5 });
+  await page.mouse.up();
+  await expect.poll(() => child.evaluate((element) => element.style.transform)).not.toBe(childTransform);
+  await expect(edges).toHaveCount(2);
+  await page.getByRole('button', { name: 'Reorder', exact: true }).click();
+  await expect(nodes.nth(0)).toHaveAttribute('data-id', 'parent');
+  await expect(nodes.nth(1)).toHaveAttribute('data-id', 'child');
+  await expect(nodes.nth(2)).toHaveAttribute('data-id', 'other');
+  await expect(edges.first()).toHaveAttribute('data-id', 'first');
+  await expect(child).toHaveClass(/selected/);
+});


### PR DESCRIPTION
## Summary

Fixes #4919.

`getElementsDiffChanges` detects additions, removals and object replacements, but currently drops updates that only reorder existing objects. Controlled flows consequently retain the old node/edge order when using `setNodes` or `setEdges` from `useReactFlow`.

Track the previous relative order and represent moved elements with the existing remove + indexed-add changes. Retained elements stay in their original relative order; `applyNodeChanges` / `applyEdgeChanges` apply removals first and insert moved/new elements at the requested indices. Same-order updates and pure additions/deletions keep their existing change semantics. No new dependency or public change type is introduced.

The standard helpers apply the entire batch atomically and preserve node IDs, data, selection, child positions and connected edges. Custom change handlers will observe remove/add pairs for moved elements; they should process the complete batch rather than treat each remove as a standalone business-level deletion.

## Tests

- Add source-level regression cases for same-reference swaps/rotations/reversal, mixed reorder + insertion/deletion/data updates, no-op updates, pure insert/delete, replacements, and edge ordering.
- Add a controlled-flow browser fixture verifying subflow order, preserved child position and selection, subsequent selection/drag, and repeated reordering.
- Add a patch changeset for `@xyflow/react`.

## Validation

Base: `0a1f9575b25679f2880175de8d3eae21aedde921`.

- Before the fix: six new source-level regression cases fail on incorrect node/edge order; three existing-behavior cases pass. The initial browser attempt could not run until Chromium was installed, so this before/after claim is limited to those source-level tests.
- After the fix: full React Playwright suite on Chromium **60/60 passed**, including all ten new tests.
- `pnpm --filter @xyflow/system build`: passed.
- `pnpm --filter @xyflow/react build`: passed.
- `pnpm --filter @xyflow/react typecheck`: passed.
- ESLint on `packages/react/src/utils/changes.ts`: passed.
- Prettier check on all changed TypeScript files: passed.

Reproduce on a POSIX shell after installing dependencies, building the packages and installing Chromium:

```sh
FRAMEWORK=react pnpm --filter playwright exec playwright test -c playwright.react.config.ts --project chromium --workers 2
```

Validation limitations: the full React lint command reports two errors in untouched files (`Handle/index.tsx:42`, unused `selector`; `useReactFlow.ts:133`, unnecessary assertion). Cypress component tests could not start because the repository's Cypress 13.6.6 Vite integration fails with Vite 8 (`Not implemented property: warnings`); the regressions use the existing Playwright infrastructure instead. Firefox/WebKit were not run. No unrelated source or dependency changes are included.
