### PR TITLE
Add optional isNodeSelectable callback for box/lasso selection

### DIFF
--- a/.changeset/is-node-selectable-lasso.md
+++ b/.changeset/is-node-selectable-lasso.md
@@ -1,0 +1,7 @@
+---
+"@xyflow/system": minor
+"@xyflow/react": minor
+"@xyflow/svelte": minor
+---
+
+Add optional `isNodeSelectable` callback to filter nodes during box/lasso selection

--- a/examples/react/src/generic-tests/nodes/is-node-selectable-default.ts
+++ b/examples/react/src/generic-tests/nodes/is-node-selectable-default.ts
@@ -1,0 +1,25 @@
+const nodes = [
+  {
+    id: 'keep-a',
+    data: { label: 'keep-a' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: 'skip',
+    data: { label: 'skip' },
+    position: { x: 200, y: 0 },
+  },
+  {
+    id: 'keep-b',
+    data: { label: 'keep-b' },
+    position: { x: 400, y: 0 },
+  },
+];
+
+export default {
+  flowProps: {
+    fitView: true,
+    nodes,
+    edges: [],
+  },
+} satisfies FlowConfig;

--- a/examples/react/src/generic-tests/nodes/is-node-selectable-filter.ts
+++ b/examples/react/src/generic-tests/nodes/is-node-selectable-filter.ts
@@ -1,0 +1,26 @@
+const nodes = [
+  {
+    id: 'keep-a',
+    data: { label: 'keep-a' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: 'skip',
+    data: { label: 'skip' },
+    position: { x: 200, y: 0 },
+  },
+  {
+    id: 'keep-b',
+    data: { label: 'keep-b' },
+    position: { x: 400, y: 0 },
+  },
+];
+
+export default {
+  flowProps: {
+    fitView: true,
+    nodes,
+    edges: [],
+    isNodeSelectable: (node) => node.id !== 'skip',
+  },
+} satisfies FlowConfig;

--- a/examples/react/src/generic-tests/nodes/is-node-selectable-passthrough.ts
+++ b/examples/react/src/generic-tests/nodes/is-node-selectable-passthrough.ts
@@ -1,0 +1,26 @@
+const nodes = [
+  {
+    id: 'keep-a',
+    data: { label: 'keep-a' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: 'skip',
+    data: { label: 'skip' },
+    position: { x: 200, y: 0 },
+  },
+  {
+    id: 'keep-b',
+    data: { label: 'keep-b' },
+    position: { x: 400, y: 0 },
+  },
+];
+
+export default {
+  flowProps: {
+    fitView: true,
+    nodes,
+    edges: [],
+    isNodeSelectable: () => true,
+  },
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/nodes/is-node-selectable-default.ts
+++ b/examples/svelte/src/generic-tests/nodes/is-node-selectable-default.ts
@@ -1,0 +1,25 @@
+const nodes = [
+	{
+		id: 'keep-a',
+		data: { label: 'keep-a' },
+		position: { x: 0, y: 0 }
+	},
+	{
+		id: 'skip',
+		data: { label: 'skip' },
+		position: { x: 200, y: 0 }
+	},
+	{
+		id: 'keep-b',
+		data: { label: 'keep-b' },
+		position: { x: 400, y: 0 }
+	}
+];
+
+export default {
+	flowProps: {
+		fitView: true,
+		nodes,
+		edges: []
+	}
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/nodes/is-node-selectable-filter.ts
+++ b/examples/svelte/src/generic-tests/nodes/is-node-selectable-filter.ts
@@ -1,0 +1,26 @@
+const nodes = [
+	{
+		id: 'keep-a',
+		data: { label: 'keep-a' },
+		position: { x: 0, y: 0 }
+	},
+	{
+		id: 'skip',
+		data: { label: 'skip' },
+		position: { x: 200, y: 0 }
+	},
+	{
+		id: 'keep-b',
+		data: { label: 'keep-b' },
+		position: { x: 400, y: 0 }
+	}
+];
+
+export default {
+	flowProps: {
+		fitView: true,
+		nodes,
+		edges: [],
+		isNodeSelectable: (node) => node.id !== 'skip'
+	}
+} satisfies FlowConfig;

--- a/examples/svelte/src/generic-tests/nodes/is-node-selectable-passthrough.ts
+++ b/examples/svelte/src/generic-tests/nodes/is-node-selectable-passthrough.ts
@@ -1,0 +1,26 @@
+const nodes = [
+	{
+		id: 'keep-a',
+		data: { label: 'keep-a' },
+		position: { x: 0, y: 0 }
+	},
+	{
+		id: 'skip',
+		data: { label: 'skip' },
+		position: { x: 200, y: 0 }
+	},
+	{
+		id: 'keep-b',
+		data: { label: 'keep-b' },
+		position: { x: 400, y: 0 }
+	}
+];
+
+export default {
+	flowProps: {
+		fitView: true,
+		nodes,
+		edges: [],
+		isNodeSelectable: () => true
+	}
+} satisfies FlowConfig;

--- a/packages/react/src/components/StoreUpdater/index.tsx
+++ b/packages/react/src/components/StoreUpdater/index.tsx
@@ -63,6 +63,7 @@ const reactFlowFieldsToTrack = [
   'onError',
   'connectionRadius',
   'isValidConnection',
+  'isNodeSelectable',
   'selectNodesOnDrag',
   'nodeDragThreshold',
   'connectionDragThreshold',

--- a/packages/react/src/container/Pane/index.tsx
+++ b/packages/react/src/container/Pane/index.tsx
@@ -12,6 +12,7 @@ import { shallow } from 'zustand/shallow';
 import cc from 'classcat';
 import {
   getNodesInside,
+  filterSelectedNodes,
   getEventPosition,
   SelectionMode,
   areSetsEqual,
@@ -199,6 +200,7 @@ export function Pane({
       triggerNodeChanges,
       triggerEdgeChanges,
       defaultEdgeOptions,
+      isNodeSelectable,
     } = store.getState();
 
     const userStartPosition = { x: userSelectionRect.startX, y: userSelectionRect.startY };
@@ -219,9 +221,10 @@ export function Pane({
     const prevSelectedEdgeIds = selectedEdgeIds.current;
 
     selectedNodeIds.current = new Set(
-      getNodesInside(nodeLookup, nextUserSelectRect, transform, selectionMode === SelectionMode.Partial, true).map(
-        (node) => node.id
-      )
+      filterSelectedNodes(
+        getNodesInside(nodeLookup, nextUserSelectRect, transform, selectionMode === SelectionMode.Partial, true),
+        isNodeSelectable
+      ).map((node) => node.id)
     );
 
     selectedEdgeIds.current = new Set();

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -136,6 +136,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     autoPanSpeed,
     connectionRadius,
     isValidConnection,
+    isNodeSelectable,
     onError,
     style,
     id,
@@ -243,6 +244,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
           onError={onError}
           connectionRadius={connectionRadius}
           isValidConnection={isValidConnection}
+          isNodeSelectable={isNodeSelectable}
           selectNodesOnDrag={selectNodesOnDrag}
           nodeDragThreshold={nodeDragThreshold}
           connectionDragThreshold={connectionDragThreshold}

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -146,6 +146,7 @@ const getInitialState = ({
     connectionRadius: 20,
     onError: devWarn,
     isValidConnection: undefined,
+    isNodeSelectable: undefined,
     onSelectionChangeHandlers: [],
 
     lib: 'react',

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -46,6 +46,7 @@ import type {
   OnNodeDrag,
   OnBeforeDelete,
   IsValidConnection,
+  IsNodeSelectable,
   ProOptions,
 } from '.';
 
@@ -349,6 +350,16 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
    * @default 'full'
    */
   selectionMode?: SelectionMode;
+  /**
+   * Optional predicate used to exclude nodes from box/lasso selection after they are found inside
+   * the selection rect. Click selection is not affected.
+   *
+   * When omitted, every node inside the rect is selected (current behavior).
+   *
+   * @example
+   * isNodeSelectable={(node) => node.type !== 'group'}
+   */
+  isNodeSelectable?: IsNodeSelectable<NodeType>;
   /**
    * If a key is set, you can pan the viewport while that key is held down even if `panOnScroll`
    * is set to `false`.

--- a/packages/react/src/types/general.ts
+++ b/packages/react/src/types/general.ts
@@ -232,6 +232,12 @@ export type OnBeforeDelete<NodeType extends Node = Node, EdgeType extends Edge =
 export type IsValidConnection<EdgeType extends Edge = Edge> = (edge: EdgeType | Connection) => boolean;
 
 /**
+ * This type can be used to type the `isNodeSelectable` function.
+ * If the function returns `false`, the node is excluded from box/lasso selection.
+ */
+export type IsNodeSelectable<NodeType extends Node = Node> = (node: NodeType) => boolean;
+
+/**
  * React Flow is independent and entirely funded by its users.
  * If you hide the attribution, please support our work by subscribing to React Flow Pro: https://reactflow.dev/remove-attribution
  * */

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -48,6 +48,7 @@ import type {
   OnNodeDrag,
   OnBeforeDelete,
   IsValidConnection,
+  IsNodeSelectable,
   InternalNode,
 } from '.';
 
@@ -149,6 +150,7 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
   connectionRadius: number;
 
   isValidConnection: IsValidConnection<EdgeType> | undefined;
+  isNodeSelectable: IsNodeSelectable<NodeType> | undefined;
 
   lib: string;
   debug: boolean;

--- a/packages/svelte/src/lib/container/Pane/Pane.svelte
+++ b/packages/svelte/src/lib/container/Pane/Pane.svelte
@@ -44,6 +44,7 @@
     SelectionMode,
     getEventPosition,
     getNodesInside,
+    filterSelectedNodes,
     calcAutoPan,
     pointToRendererPoint,
     rendererPointToPoint,
@@ -177,12 +178,15 @@
     const prevSelectedEdgeIds = selectedEdgeIds;
 
     selectedNodeIds = new Set(
-      getNodesInside(
-        store.nodeLookup,
-        nextUserSelectRect,
-        [store.viewport.x, store.viewport.y, store.viewport.zoom],
-        store.selectionMode === SelectionMode.Partial,
-        true
+      filterSelectedNodes(
+        getNodesInside(
+          store.nodeLookup,
+          nextUserSelectRect,
+          [store.viewport.x, store.viewport.y, store.viewport.zoom],
+          store.selectionMode === SelectionMode.Partial,
+          true
+        ),
+        store.isNodeSelectable
       ).map((n) => n.id)
     );
 

--- a/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
+++ b/packages/svelte/src/lib/container/SvelteFlow/Wrapper.svelte
@@ -36,6 +36,7 @@
     edgeTypes,
     colorMode: _colorMode,
     isValidConnection,
+    isNodeSelectable,
     onmove,
     onmovestart,
     onmoveend,

--- a/packages/svelte/src/lib/container/SvelteFlow/types.ts
+++ b/packages/svelte/src/lib/container/SvelteFlow/types.ts
@@ -36,6 +36,7 @@ import type {
   OnBeforeConnect,
   OnBeforeDelete,
   IsValidConnection,
+  IsNodeSelectable,
   OnBeforeReconnect,
   OnSelectionChange,
   ProOptions
@@ -221,6 +222,16 @@ export type SvelteFlowProps<
      * @default 'full'
      */
     selectionMode?: SelectionMode;
+    /**
+     * Optional predicate used to exclude nodes from box/lasso selection after they are found inside
+     * the selection rect. Click selection is not affected.
+     *
+     * When omitted, every node inside the rect is selected (current behavior).
+     *
+     * @example
+     * isNodeSelectable={(node) => node.type !== 'group'}
+     */
+    isNodeSelectable?: IsNodeSelectable<NodeType>;
     /**
      * Controls if nodes should be automatically selected when being dragged
      */

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -116,6 +116,7 @@ export {
   type ResizeParamsWithDirection,
   type ResizeDragEvent,
   type IsValidConnection,
+  type IsNodeSelectable,
   type NodeConnection,
   type AriaLabelConfig,
   type SetCenter,

--- a/packages/svelte/src/lib/store/initial-store.svelte.ts
+++ b/packages/svelte/src/lib/store/initial-store.svelte.ts
@@ -62,6 +62,7 @@ import type {
   OnBeforeConnect,
   OnBeforeDelete,
   IsValidConnection,
+  IsNodeSelectable,
   Edge,
   Node,
   EdgeLayouted,
@@ -378,6 +379,9 @@ export function getInitialStore<NodeType extends Node = Node, EdgeType extends E
     connectionRadius: number = $derived(signals.props.connectionRadius ?? 20);
     isValidConnection: IsValidConnection<EdgeType> = $derived(
       signals.props.isValidConnection ?? (() => true)
+    );
+    isNodeSelectable: IsNodeSelectable<NodeType> | undefined = $derived(
+      signals.props.isNodeSelectable
     );
 
     selectNodesOnDrag: boolean = $derived(signals.props.selectNodesOnDrag ?? true);

--- a/packages/svelte/src/lib/types/general.ts
+++ b/packages/svelte/src/lib/types/general.ts
@@ -56,6 +56,12 @@ export type IsValidConnection<EdgeType extends Edge = Edge> = (
   edge: EdgeType | Connection
 ) => boolean;
 
+/**
+ * This type can be used to type the `isNodeSelectable` function.
+ * If the function returns `false`, the node is excluded from box/lasso selection.
+ */
+export type IsNodeSelectable<NodeType extends Node = Node> = (node: NodeType) => boolean;
+
 export type OnSelectionChange<
   NodeType extends Node = Node,
   EdgeType extends Edge = Edge

--- a/packages/system/src/types/general.ts
+++ b/packages/system/src/types/general.ts
@@ -156,6 +156,12 @@ export type OnReconnectEnd<NodeType extends NodeBase = NodeBase, EdgeType extend
 export type IsValidConnection<EdgeType extends EdgeBase = EdgeBase> = (edge: EdgeType | Connection) => boolean;
 
 /**
+ * Optional predicate used to exclude nodes from box/lasso selection after they are found inside the selection rect.
+ * When omitted, every node returned by `getNodesInside` remains selectable.
+ */
+export type IsNodeSelectable<NodeType extends NodeBase = NodeBase> = (node: NodeType) => boolean;
+
+/**
  * @inline
  */
 export type FitViewParamsBase<NodeType extends NodeBase> = {

--- a/packages/system/src/utils/graph.ts
+++ b/packages/system/src/utils/graph.ts
@@ -23,6 +23,7 @@ import {
   NodeLookup,
   InternalNodeBase,
   NodeDragItem,
+  IsNodeSelectable,
 } from '../types';
 import { errorMessages } from '../constants';
 
@@ -302,6 +303,18 @@ export const getNodesInside = <NodeType extends NodeBase = NodeBase>(
 
   return visibleNodes;
 };
+
+/**
+ * Filters nodes found inside a selection rect with an optional `isNodeSelectable` predicate.
+ * When the predicate is omitted, the original list is returned unchanged.
+ *
+ * @internal
+ */
+export const filterSelectedNodes = <NodeType extends NodeBase = NodeBase>(
+  nodes: InternalNodeBase<NodeType>[],
+  isNodeSelectable?: IsNodeSelectable<NodeType>
+): InternalNodeBase<NodeType>[] =>
+  isNodeSelectable ? nodes.filter((node) => isNodeSelectable(node.internals.userNode)) : nodes;
 
 /**
  * This utility filters an array of edges, keeping only those where either the source or target

--- a/tests/playwright/e2e/is-node-selectable.spec.ts
+++ b/tests/playwright/e2e/is-node-selectable.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { FRAMEWORK } from './constants';
+
+async function boxSelectAllNodes(page: Page) {
+  const keepA = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-a"]'));
+  const keepB = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-b"]'));
+
+  await expect(keepA).toHaveCSS('visibility', 'visible');
+  await expect(keepB).toHaveCSS('visibility', 'visible');
+
+  const a = await keepA.boundingBox();
+  const b = await keepB.boundingBox();
+
+  await page.keyboard.down('Shift');
+  await page.mouse.move(Math.min(a!.x, b!.x) - 20, Math.min(a!.y, b!.y) - 20);
+  await page.mouse.down();
+  await page.mouse.move(
+    Math.max(a!.x + a!.width, b!.x + b!.width) + 20,
+    Math.max(a!.y + a!.height, b!.y + b!.height) + 20
+  );
+  await page.mouse.up();
+  await page.keyboard.up('Shift');
+}
+
+test.describe('isNodeSelectable box/lasso filter', () => {
+  test('default (omitted) selects every node inside the rect', async ({ page }) => {
+    await page.goto('/tests/generic/nodes/is-node-selectable-default');
+
+    const keepA = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-a"]'));
+    const skip = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="skip"]'));
+    const keepB = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-b"]'));
+
+    await boxSelectAllNodes(page);
+
+    await expect(keepA).toHaveClass(/selected/);
+    await expect(skip).toHaveClass(/selected/);
+    await expect(keepB).toHaveClass(/selected/);
+  });
+
+  test('filter excludes nodes for which the predicate returns false', async ({ page }) => {
+    await page.goto('/tests/generic/nodes/is-node-selectable-filter');
+
+    const keepA = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-a"]'));
+    const skip = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="skip"]'));
+    const keepB = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-b"]'));
+
+    await boxSelectAllNodes(page);
+
+    await expect(keepA).toHaveClass(/selected/);
+    await expect(skip).not.toHaveClass(/selected/);
+    await expect(keepB).toHaveClass(/selected/);
+  });
+
+  test('passthrough predicate preserves default box selection', async ({ page }) => {
+    await page.goto('/tests/generic/nodes/is-node-selectable-passthrough');
+
+    const keepA = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-a"]'));
+    const skip = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="skip"]'));
+    const keepB = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="keep-b"]'));
+
+    await boxSelectAllNodes(page);
+
+    await expect(keepA).toHaveClass(/selected/);
+    await expect(skip).toHaveClass(/selected/);
+    await expect(keepB).toHaveClass(/selected/);
+  });
+
+  test('filter does not prevent click selection', async ({ page }) => {
+    await page.goto('/tests/generic/nodes/is-node-selectable-filter');
+
+    const skip = page.locator(`.${FRAMEWORK}-flow__node`).and(page.locator('[data-id="skip"]'));
+    await expect(skip).toHaveCSS('visibility', 'visible');
+
+    await skip.click();
+
+    await expect(skip).toHaveClass(/selected/);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/xyflow/xyflow/issues/5751

## Summary

Adds an optional `isNodeSelectable` predicate so box/lasso selection can exclude nodes after `getNodesInside()` returns candidates. When the prop is omitted, current behavior is preserved.

### Use cases

- Comment/group container nodes that should not be selected along with their children
- Background/decoration nodes that should never participate in bulk selection
- Locked or role-based view-only nodes in collaborative editors

### API

```tsx
<ReactFlow isNodeSelectable={(node) => node.type !== 'group'} />
```

```svelte
<SvelteFlow isNodeSelectable={(node) => node.type !== 'group'} />
```

The callback is invoked only on the result set of `getNodesInside()` (typically tens of nodes), not on every node in the flow. Click selection is unchanged.

### Implementation

Shared `filterSelectedNodes` helper in `@xyflow/system`, used by both React and Svelte `Pane` selection handlers. Types are wired through the public React Flow and Svelte Flow props. The change is optional and non-breaking.

### Relation to #4658

#4658 is about **edges** with `selectable: false` still being included in lasso selection. Node `selectable: false` is already respected during lasso via `getNodesInside(..., excludeNonSelectableNodes = true)`. This PR does not change that behavior and leaves #4658 as a separate issue. Custom node filtering beyond `selectable` can use `isNodeSelectable`.

## How to test

1. Run the new Playwright tests in `tests/playwright/e2e/is-node-selectable.spec.ts` for both frameworks (filter on / passthrough / default / click selection unaffected).
2. Open `/tests/generic/nodes/is-node-selectable-filter` in the examples app, shift-drag a box over all three nodes, and confirm `skip` is not selected.
3. Open `/tests/generic/nodes/is-node-selectable-default` and confirm all three nodes inside the rect are selected.

## Validation

- `pnpm build` and `pnpm typecheck` for `@xyflow/system`, `@xyflow/react`, and `@xyflow/svelte`: passed
- ESLint on changed files: passed
- Playwright Chromium, new `is-node-selectable` tests: **4/4 React**, **4/4 Svelte**
- Existing React multi-select regression (`selecting multiple nodes with shift drag`): passed

Public API docs live in the web repo. This change includes JSDoc on the public props and a changeset for the package changelog.
