### PR TITLE
feat(react): report keyboard node movement with onNodeMove

### DIFF
--- a/.changeset/quick-taxis-move.md
+++ b/.changeset/quick-taxis-move.md
@@ -1,0 +1,5 @@
+---
+'@xyflow/react': minor
+---
+
+Add an `onNodeMove` callback for keyboard-driven node movement.

--- a/examples/react/src/generic-tests/nodes/general.ts
+++ b/examples/react/src/generic-tests/nodes/general.ts
@@ -9,6 +9,13 @@ export default {
       DragHandleNode,
     },
     nodeDragThreshold: 0,
+    onNodeMove: (event, node, nodes) => {
+      document.body.dataset.nodeMoveEvent = JSON.stringify({
+        key: event.key,
+        node: { id: node.id, position: node.position },
+        nodes: nodes.map(({ id, position }) => ({ id, position })),
+      });
+    },
     nodes: [
       {
         id: 'Node-1',

--- a/packages/react/src/components/NodeWrapper/index.tsx
+++ b/packages/react/src/components/NodeWrapper/index.tsx
@@ -78,7 +78,7 @@ function NodeWrapper<NodeType extends Node>({
     isSelectable,
     nodeClickDistance,
   });
-  const moveSelectedNodes = useMoveSelectedNodes();
+  const moveSelectedNodes = useMoveSelectedNodes<NodeType>();
 
   if (node.hidden) {
     return null;
@@ -156,6 +156,8 @@ function NodeWrapper<NodeType extends Node>({
       moveSelectedNodes({
         direction: arrowKeyDiffs[event.key],
         factor: event.shiftKey ? 4 : 1,
+        event: event.nativeEvent,
+        nodeId: id,
       });
     }
   };

--- a/packages/react/src/components/NodesSelection/index.tsx
+++ b/packages/react/src/components/NodesSelection/index.tsx
@@ -39,7 +39,7 @@ export function NodesSelection<NodeType extends Node>({
 }: NodesSelectionProps<NodeType>) {
   const store = useStoreApi<NodeType>();
   const { width, height, transformString, userSelectionActive } = useStore(selector, shallow);
-  const moveSelectedNodes = useMoveSelectedNodes();
+  const moveSelectedNodes = useMoveSelectedNodes<NodeType>();
 
   const nodeRef = useRef<HTMLDivElement>(null);
 
@@ -76,6 +76,7 @@ export function NodesSelection<NodeType extends Node>({
       moveSelectedNodes({
         direction: arrowKeyDiffs[event.key],
         factor: event.shiftKey ? 4 : 1,
+        event: event.nativeEvent,
       });
     }
   };

--- a/packages/react/src/components/StoreUpdater/index.tsx
+++ b/packages/react/src/components/StoreUpdater/index.tsx
@@ -50,6 +50,7 @@ const reactFlowFieldsToTrack = [
   'onNodeDrag',
   'onNodeDragStart',
   'onNodeDragStop',
+  'onNodeMove',
   'onSelectionDrag',
   'onSelectionDragStart',
   'onSelectionDragStop',

--- a/packages/react/src/container/ReactFlow/index.tsx
+++ b/packages/react/src/container/ReactFlow/index.tsx
@@ -49,6 +49,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
     onNodeDragStart,
     onNodeDrag,
     onNodeDragStop,
+    onNodeMove,
     onNodesDelete,
     onEdgesDelete,
     onDelete,
@@ -228,6 +229,7 @@ function ReactFlow<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
           onNodeDragStart={onNodeDragStart}
           onNodeDrag={onNodeDrag}
           onNodeDragStop={onNodeDragStop}
+          onNodeMove={onNodeMove}
           onSelectionDrag={onSelectionDrag}
           onSelectionDragStart={onSelectionDragStart}
           onSelectionDragStop={onSelectionDragStop}

--- a/packages/react/src/hooks/useMoveSelectedNodes.ts
+++ b/packages/react/src/hooks/useMoveSelectedNodes.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { calculateNodePosition, snapPosition, type XYPosition } from '@xyflow/system';
 
-import { type Node } from '../types';
+import { type InternalNode, type Node } from '../types';
 import { useStoreApi } from './useStore';
 
 const selectedAndDraggable = (nodesDraggable: boolean) => (n: Node) =>
@@ -13,56 +13,84 @@ const selectedAndDraggable = (nodesDraggable: boolean) => (n: Node) =>
  * @internal
  * @returns function for updating node positions
  */
-export function useMoveSelectedNodes() {
-  const store = useStoreApi();
+export function useMoveSelectedNodes<NodeType extends Node = Node>() {
+  const store = useStoreApi<NodeType>();
 
-  const moveSelectedNodes = useCallback((params: { direction: XYPosition; factor: number }) => {
-    const { nodeExtent, snapToGrid, snapGrid, nodesDraggable, onError, updateNodePositions, nodeLookup, nodeOrigin } =
-      store.getState();
-    const nodeUpdates = new Map();
-    const isSelected = selectedAndDraggable(nodesDraggable);
-
-    /*
-     * by default a node moves 5px on each key press
-     * if snap grid is enabled, we use that for the velocity
-     */
-    const xVelo = snapToGrid ? snapGrid[0] : 5;
-    const yVelo = snapToGrid ? snapGrid[1] : 5;
-
-    const xDiff = params.direction.x * xVelo * params.factor;
-    const yDiff = params.direction.y * yVelo * params.factor;
-
-    for (const [, node] of nodeLookup) {
-      if (!isSelected(node)) {
-        continue;
-      }
-
-      let nextPosition = {
-        x: node.internals.positionAbsolute.x + xDiff,
-        y: node.internals.positionAbsolute.y + yDiff,
-      };
-
-      if (snapToGrid) {
-        nextPosition = snapPosition(nextPosition, snapGrid);
-      }
-
-      const { position, positionAbsolute } = calculateNodePosition({
-        nodeId: node.id,
-        nextPosition,
-        nodeLookup,
+  const moveSelectedNodes = useCallback(
+    (params: { direction: XYPosition; factor: number; event: KeyboardEvent; nodeId?: string }) => {
+      const {
         nodeExtent,
-        nodeOrigin,
+        snapToGrid,
+        snapGrid,
+        nodesDraggable,
         onError,
-      });
+        updateNodePositions,
+        nodeLookup,
+        nodeOrigin,
+        onNodeMove,
+      } = store.getState();
+      const nodeUpdates = new Map<string, InternalNode<NodeType>>();
+      const isSelected = selectedAndDraggable(nodesDraggable);
+      let hasChange = false;
 
-      node.position = position;
-      node.internals.positionAbsolute = positionAbsolute;
+      /*
+       * by default a node moves 5px on each key press
+       * if snap grid is enabled, we use that for the velocity
+       */
+      const xVelo = snapToGrid ? snapGrid[0] : 5;
+      const yVelo = snapToGrid ? snapGrid[1] : 5;
 
-      nodeUpdates.set(node.id, node);
-    }
+      const xDiff = params.direction.x * xVelo * params.factor;
+      const yDiff = params.direction.y * yVelo * params.factor;
 
-    updateNodePositions(nodeUpdates);
-  }, []);
+      for (const [, node] of nodeLookup) {
+        if (!isSelected(node)) {
+          continue;
+        }
+
+        let nextPosition = {
+          x: node.internals.positionAbsolute.x + xDiff,
+          y: node.internals.positionAbsolute.y + yDiff,
+        };
+
+        if (snapToGrid) {
+          nextPosition = snapPosition(nextPosition, snapGrid);
+        }
+
+        const { position, positionAbsolute } = calculateNodePosition({
+          nodeId: node.id,
+          nextPosition,
+          nodeLookup,
+          nodeExtent,
+          nodeOrigin,
+          onError,
+        });
+
+        hasChange = hasChange || node.position.x !== position.x || node.position.y !== position.y;
+        node.position = position;
+        node.internals.positionAbsolute = positionAbsolute;
+
+        nodeUpdates.set(node.id, node);
+      }
+
+      const movedNodes =
+        hasChange && onNodeMove
+          ? Array.from(nodeUpdates.values(), (node) => ({
+              ...node.internals.userNode,
+              position: { ...node.position },
+              dragging: false,
+            }))
+          : [];
+
+      updateNodePositions(nodeUpdates);
+
+      if (movedNodes.length && onNodeMove) {
+        const currentNode = movedNodes.find((node) => node.id === params.nodeId) ?? movedNodes[0];
+        onNodeMove(params.event, currentNode, movedNodes);
+      }
+    },
+    []
+  );
 
   return moveSelectedNodes;
 }

--- a/packages/react/src/store/initialState.ts
+++ b/packages/react/src/store/initialState.ts
@@ -169,6 +169,7 @@ const getInitialState = ({
     onNodeDragStart: undefined,
     onNodeDrag: undefined,
     onNodeDragStop: undefined,
+    onNodeMove: undefined,
 
     onSelectionDragStart: undefined,
     onSelectionDrag: undefined,

--- a/packages/react/src/types/component-props.ts
+++ b/packages/react/src/types/component-props.ts
@@ -44,6 +44,7 @@ import type {
   SelectionDragHandler,
   EdgeMouseHandler,
   OnNodeDrag,
+  OnNodeMove,
   OnBeforeDelete,
   IsValidConnection,
   ProOptions,
@@ -116,6 +117,8 @@ export interface ReactFlowProps<NodeType extends Node = Node, EdgeType extends E
   onNodeDrag?: OnNodeDrag<NodeType>;
   /** This event handler is called when a user stops dragging a node. */
   onNodeDragStop?: OnNodeDrag<NodeType>;
+  /** This event handler is called when a user moves one or more selected nodes with the keyboard. */
+  onNodeMove?: OnNodeMove<NodeType>;
   /** This event handler is called when a user clicks on an edge. */
   onEdgeClick?: (event: ReactMouseEvent, edge: EdgeType) => void;
   /** This event handler is called when a user right-clicks on an edge. */

--- a/packages/react/src/types/nodes.ts
+++ b/packages/react/src/types/nodes.ts
@@ -57,6 +57,11 @@ export type OnNodeDrag<NodeType extends Node = Node> = (
   node: NodeType,
   nodes: NodeType[]
 ) => void;
+export type OnNodeMove<NodeType extends Node = Node> = (
+  event: KeyboardEvent,
+  node: NodeType,
+  nodes: NodeType[]
+) => void;
 
 export type NodeWrapperProps<NodeType extends Node> = {
   id: string;

--- a/packages/react/src/types/store.ts
+++ b/packages/react/src/types/store.ts
@@ -46,6 +46,7 @@ import type {
   UnselectNodesAndEdgesParams,
   OnDelete,
   OnNodeDrag,
+  OnNodeMove,
   OnBeforeDelete,
   IsValidConnection,
   InternalNode,
@@ -106,6 +107,7 @@ export type ReactFlowStore<NodeType extends Node = Node, EdgeType extends Edge =
   onNodeDragStart: OnNodeDrag<NodeType> | undefined;
   onNodeDrag: OnNodeDrag<NodeType> | undefined;
   onNodeDragStop: OnNodeDrag<NodeType> | undefined;
+  onNodeMove: OnNodeMove<NodeType> | undefined;
 
   onSelectionDragStart: OnSelectionDrag | undefined;
   onSelectionDrag: OnSelectionDrag | undefined;

--- a/tests/playwright/e2e/nodes.spec.ts
+++ b/tests/playwright/e2e/nodes.spec.ts
@@ -92,6 +92,71 @@ test.describe('Nodes', () => {
   });
 
   test.describe('dragging', () => {
+    test('moving a node with the keyboard fires onNodeMove', async ({ page }) => {
+      test.skip(FRAMEWORK !== 'react', 'onNodeMove is a React Flow callback');
+
+      const node = page.locator('.react-flow__node').and(page.locator('[data-id="Node-1"]'));
+
+      await expect(node).toHaveCSS('visibility', 'visible');
+      await node.click();
+      await node.press('ArrowRight');
+
+      const event = JSON.parse((await page.locator('body').getAttribute('data-node-move-event'))!);
+
+      expect(event).toEqual({
+        key: 'ArrowRight',
+        node: { id: 'Node-1', position: { x: 5, y: 0 } },
+        nodes: [{ id: 'Node-1', position: { x: 5, y: 0 } }],
+      });
+    });
+
+    test('keyboard movement with Shift reports the larger step', async ({ page }) => {
+      test.skip(FRAMEWORK !== 'react', 'onNodeMove is a React Flow callback');
+      const node = page.locator('.react-flow__node[data-id="Node-1"]');
+      await node.click();
+      await node.press('Shift+ArrowDown');
+      await expect(page.locator('body')).toHaveAttribute(
+        'data-node-move-event',
+        JSON.stringify({
+          key: 'ArrowDown',
+          node: { id: 'Node-1', position: { x: 0, y: 20 } },
+          nodes: [{ id: 'Node-1', position: { x: 0, y: 20 } }],
+        })
+      );
+    });
+
+    test('keyboard movement reports all selected nodes', async ({ page }) => {
+      test.skip(FRAMEWORK !== 'react', 'onNodeMove is a React Flow callback');
+      const first = page.locator('.react-flow__node[data-id="Node-1"]');
+      const second = page.locator('.react-flow__node[data-id="Node-2"]');
+      await first.click();
+      await page.keyboard.down('s');
+      await second.click();
+      await page.keyboard.up('s');
+      await expect(first).toHaveClass(/selected/);
+      await expect(second).toHaveClass(/selected/);
+      await second.press('ArrowLeft');
+      await expect(page.locator('body')).toHaveAttribute(
+        'data-node-move-event',
+        JSON.stringify({
+          key: 'ArrowLeft',
+          node: { id: 'Node-2', position: { x: -105, y: 100 } },
+          nodes: [
+            { id: 'Node-1', position: { x: -5, y: 0 } },
+            { id: 'Node-2', position: { x: -105, y: 100 } },
+          ],
+        })
+      );
+    });
+
+    test('keyboard movement does not fire for a non-draggable node', async ({ page }) => {
+      test.skip(FRAMEWORK !== 'react', 'onNodeMove is a React Flow callback');
+      const node = page.locator('.react-flow__node[data-id="notDraggable"]');
+      await node.click();
+      await node.press('ArrowRight');
+      await expect(page.locator('body')).not.toHaveAttribute('data-node-move-event');
+    });
+
     test('dragging a node', async ({ page }) => {
       const node = page.locator(`.${FRAMEWORK}-flow__node`).first();
 


### PR DESCRIPTION
Summary

- Add an "onNodeMove" callback for keyboard-driven node movement.
- Provide the original "KeyboardEvent", the actively moved node, and all moved selected nodes.
- Expose the callback through React Flow props, store state, and public node types.
- Avoid firing the callback when no position change occurs or the node is not draggable.
- Add Playwright coverage for normal, Shift-modified, multi-selection, and non-draggable keyboard movement.
- Add a minor changeset for "@xyflow/react".

Why

Keyboard movement currently updates node positions without providing consumers an equivalent event hook for observing the movement. This makes it difficult to persist, audit, or react to accessible keyboard interactions.

"onNodeMove" makes keyboard-driven movement observable while leaving the existing pointer-drag callbacks unchanged.

Verification

- Added Playwright regression coverage for four keyboard-movement scenarios.
- Propagated TypeScript types through the public React Flow API.
- Included a changeset for the new callback.